### PR TITLE
[codex] Add local folder import

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Drop a PDF in and a converter generates a readable, indexable HTML companion (`p
 
 ### Space-level import
 
-Drag a folder, or paste a public GitHub URL into the Welcome screen — StashBase clones / copies it as a new space. If the import bundle includes a `snapshot.parquet`, embeddings are bulk-loaded (skipping re-embed, saving tokens).
+Use **Import folder** or paste a public GitHub URL into the Welcome screen — StashBase copies the folder or clones the repo as a new space under your KB root. Folder import copies by default, with an explicit move option. If the imported bundle includes `.stashbase/snapshot.parquet`, embeddings are bulk-loaded when the space opens, skipping re-embed when compatible.
 
 ### MCP exposure with one-click connector
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -482,10 +482,12 @@ async function createWindow(initialSpace) {
 // `defaultPath` opens the panel at a sensible starting location; the
 // caller still validates the result is under kbRoot before using it.
 ipcMain.handle('dialog:openFolder', async (_e, opts = {}) => {
+  const properties = ['openDirectory'];
+  if (opts.allowCreateDirectory !== false) properties.push('createDirectory');
   const dialogOpts = {
     title: opts.title || 'Choose a folder',
     buttonLabel: opts.buttonLabel || 'Choose',
-    properties: ['openDirectory', 'createDirectory'],
+    properties,
   };
   if (typeof opts.defaultPath === 'string' && opts.defaultPath) {
     dialogOpts.defaultPath = opts.defaultPath;

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -15,9 +15,9 @@ window.addEventListener('DOMContentLoaded', () => {
 
 contextBridge.exposeInMainWorld('electron', {
   /** Show the OS folder picker. Returns the picked absolute path or
-   *  null if the user cancelled. Accepts an optional `defaultPath` so
-   *  the dialog opens at a meaningful location (kbRoot for the clone
-   *  flow). The OS-native "New Folder" affordance is always enabled. */
+   *  null if the user cancelled. Accepts `defaultPath` and
+   *  `allowCreateDirectory`; import-folder passes false so the dialog
+   *  only selects existing directories. */
   openFolderDialog: (opts) => ipcRenderer.invoke('dialog:openFolder', opts),
   /** Hand an http(s) URL to the OS default browser. Replaces an earlier
    *  in-app webview overlay; too many sites block iframing for it to

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build:server": "node scripts/build-server.mjs",
     "build:mcp": "node scripts/build-mcp.mjs",
     "build:python-sidecar": "node scripts/build-python-sidecar.mjs",
+    "test:import-folder": "node --import tsx --test server/import-folder.test.ts",
     "postinstall": "node scripts/fix-pty-helper.mjs",
     "build": "pnpm build:web && pnpm build:server && pnpm build:mcp",
     "build:desktop": "pnpm build && pnpm build:python-sidecar",

--- a/server/import-folder.test.ts
+++ b/server/import-folder.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  importFolderAsSpace,
+  previewFolderImport,
+} from './import-folder.ts';
+
+function tmpDir(label: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `stashbase-${label}-`));
+}
+
+test('preview derives the destination name and requires confirmation for non-empty sources', () => {
+  const kbRoot = tmpDir('kb');
+  const source = tmpDir('source');
+  fs.writeFileSync(path.join(source, 'note.md'), '# hello\n');
+
+  const preview = previewFolderImport({ source, kbRoot });
+
+  assert.equal(preview.name, path.basename(source));
+  assert.equal(preview.destination, path.join(kbRoot, path.basename(source)));
+  assert.equal(preview.exists, true);
+  assert.equal(preview.requiresConfirmation, true);
+  assert.equal(preview.entryCount, 1);
+  assert.equal(preview.hasSnapshot, false);
+});
+
+test('copy imports into a new space, dereferences symlinks, and leaves the source intact', () => {
+  const kbRoot = tmpDir('kb');
+  const source = tmpDir('source');
+  const external = tmpDir('external');
+  fs.writeFileSync(path.join(external, 'outside.md'), '# outside\n');
+  fs.symlinkSync(path.join(external, 'outside.md'), path.join(source, 'linked.md'));
+  fs.mkdirSync(path.join(source, '.stashbase'), { recursive: true });
+  fs.writeFileSync(path.join(source, '.stashbase', 'snapshot.parquet'), 'snapshot');
+  fs.writeFileSync(path.join(source, '.stashbase', 'config.json'), '{}');
+
+  const result = importFolderAsSpace({
+    source,
+    kbRoot,
+    name: 'imported',
+    mode: 'copy',
+    confirmExisting: true,
+  });
+
+  assert.equal(result.name, 'imported');
+  assert.equal(result.path, path.join(kbRoot, 'imported'));
+  assert.equal(fs.readFileSync(path.join(result.path, 'linked.md'), 'utf8'), '# outside\n');
+  assert.equal(fs.lstatSync(path.join(result.path, 'linked.md')).isSymbolicLink(), false);
+  assert.equal(fs.existsSync(path.join(result.path, '.stashbase', 'snapshot.parquet')), true);
+  assert.equal(fs.existsSync(path.join(result.path, '.stashbase', 'config.json')), false);
+  assert.equal(fs.existsSync(source), true);
+});
+
+test('preview counts a symlinked directory once', () => {
+  const kbRoot = tmpDir('kb');
+  const source = tmpDir('source');
+  const linkedDir = tmpDir('linked');
+  fs.writeFileSync(path.join(linkedDir, 'linked.md'), '# linked\n');
+  fs.symlinkSync(linkedDir, path.join(source, 'linked'));
+
+  const preview = previewFolderImport({ source, kbRoot });
+
+  assert.equal(preview.entryCount, 2);
+  assert.equal(preview.totalBytes, Buffer.byteLength('# linked\n'));
+});
+
+test('move imports by copy-then-delete, preserving dereferenced content in the space', () => {
+  const kbRoot = tmpDir('kb');
+  const source = tmpDir('source');
+  fs.writeFileSync(path.join(source, 'note.md'), '# moved\n');
+
+  const result = importFolderAsSpace({
+    source,
+    kbRoot,
+    name: 'moved-space',
+    mode: 'move',
+    confirmExisting: true,
+  });
+
+  assert.equal(fs.readFileSync(path.join(result.path, 'note.md'), 'utf8'), '# moved\n');
+  assert.equal(fs.existsSync(source), false);
+});
+
+test('import refuses to merge into an existing space', () => {
+  const kbRoot = tmpDir('kb');
+  const source = tmpDir('source');
+  fs.writeFileSync(path.join(source, 'note.md'), '# hello\n');
+  fs.mkdirSync(path.join(kbRoot, 'existing'));
+
+  assert.throws(
+    () => importFolderAsSpace({
+      source,
+      kbRoot,
+      name: 'existing',
+      mode: 'copy',
+      confirmExisting: true,
+    }),
+    /already exists/,
+  );
+});
+
+test('import refuses non-empty source without confirmation', () => {
+  const kbRoot = tmpDir('kb');
+  const source = tmpDir('source');
+  fs.writeFileSync(path.join(source, 'note.md'), '# hello\n');
+
+  assert.throws(
+    () => importFolderAsSpace({ source, kbRoot, mode: 'copy', confirmExisting: false }),
+    /confirmation required/,
+  );
+});
+
+test('import refuses unknown modes', () => {
+  const kbRoot = tmpDir('kb');
+  const source = tmpDir('source');
+
+  assert.throws(
+    () => importFolderAsSpace({
+      source,
+      kbRoot,
+      mode: 'link' as any,
+      confirmExisting: true,
+    }),
+    /mode must be "copy" or "move"/,
+  );
+});
+
+test('import refuses cyclic directory symlinks and rolls back the destination', () => {
+  const kbRoot = tmpDir('kb');
+  const source = tmpDir('source');
+  fs.writeFileSync(path.join(source, 'note.md'), '# hello\n');
+  fs.symlinkSync(source, path.join(source, 'cycle'));
+
+  assert.throws(
+    () => importFolderAsSpace({
+      source,
+      kbRoot,
+      name: 'cyclic',
+      mode: 'copy',
+      confirmExisting: true,
+    }),
+    /cyclic symlink/,
+  );
+  assert.equal(fs.existsSync(path.join(kbRoot, 'cyclic')), false);
+});
+
+test('import refuses sources that contain the library root', () => {
+  const parent = tmpDir('parent');
+  const kbRoot = path.join(parent, 'StashBase');
+  fs.mkdirSync(kbRoot);
+  fs.writeFileSync(path.join(parent, 'note.md'), '# hello\n');
+
+  assert.throws(
+    () => previewFolderImport({ source: parent, kbRoot }),
+    /contains the library root/,
+  );
+});
+
+test('import refuses home, filesystem root, kb root, and sources already inside kb root', () => {
+  const kbRoot = tmpDir('kb');
+  const inside = path.join(kbRoot, 'space');
+  fs.mkdirSync(inside);
+
+  for (const source of [os.homedir(), path.parse(kbRoot).root, kbRoot, inside]) {
+    assert.throws(
+      () => previewFolderImport({ source, kbRoot }),
+      /refusing|already inside the library/,
+    );
+  }
+});

--- a/server/import-folder.ts
+++ b/server/import-folder.ts
@@ -1,0 +1,215 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { validateSpaceName } from './space.ts';
+
+export type ImportFolderMode = 'copy' | 'move';
+
+export interface FolderImportPreview {
+  source: string;
+  name: string;
+  destination: string;
+  exists: boolean;
+  entryCount: number;
+  totalBytes: number;
+  requiresConfirmation: boolean;
+  warnings: string[];
+  hasSnapshot: boolean;
+}
+
+export interface ImportFolderOptions {
+  source: string;
+  kbRoot: string;
+  name?: string;
+  mode?: ImportFolderMode;
+  confirmExisting?: boolean;
+}
+
+export interface ImportFolderResult {
+  path: string;
+  name: string;
+  mode: ImportFolderMode;
+}
+
+const STASHBASE_PER_MACHINE_ENTRIES = ['config.json', 'mfs', 'cache'];
+const CONFIRM_ENTRY_LIMIT = 0;
+
+export function previewFolderImport(
+  opts: Pick<ImportFolderOptions, 'source' | 'kbRoot' | 'name'>,
+): FolderImportPreview {
+  const source = normalizeSource(opts.source);
+  const kbRoot = path.resolve(opts.kbRoot);
+  assertImportableSource(source, kbRoot);
+
+  const name = (opts.name?.trim() || path.basename(source)).trim();
+  const badName = validateSpaceName(name);
+  if (badName) throw new Error(badName);
+
+  const destination = path.join(kbRoot, name);
+  const stats = scanFolder(source);
+  const warnings = buildWarnings(source, kbRoot, name, stats.entryCount);
+
+  return {
+    source,
+    name,
+    destination,
+    exists: stats.entryCount > 0,
+    entryCount: stats.entryCount,
+    totalBytes: stats.totalBytes,
+    requiresConfirmation: stats.entryCount > CONFIRM_ENTRY_LIMIT,
+    warnings,
+    hasSnapshot: fileExists(path.join(source, '.stashbase', 'snapshot.parquet')),
+  };
+}
+
+export function importFolderAsSpace(opts: ImportFolderOptions): ImportFolderResult {
+  const mode = opts.mode ?? 'copy';
+  if (mode !== 'copy' && mode !== 'move') throw new Error('mode must be "copy" or "move"');
+  const preview = previewFolderImport(opts);
+  if (preview.requiresConfirmation && opts.confirmExisting !== true) {
+    const err = new Error('confirmation required before importing this folder');
+    (err as any).code = 'CONFIRM_EXISTING';
+    throw err;
+  }
+
+  fs.mkdirSync(path.dirname(preview.destination), { recursive: true });
+  if (!dirExists(path.dirname(preview.destination))) throw new Error('library root is not a directory');
+  if (fs.existsSync(preview.destination)) {
+    const err = new Error(`space "${preview.name}" already exists`);
+    (err as any).code = 'SPACE_EXISTS';
+    throw err;
+  }
+
+  try {
+    copyDirectoryDereferenced(preview.source, preview.destination);
+    pruneImportedStashbase(path.join(preview.destination, '.stashbase'));
+    if (mode === 'move') {
+      fs.rmSync(preview.source, { recursive: true, force: false });
+    }
+    return { path: preview.destination, name: preview.name, mode };
+  } catch (err) {
+    try { fs.rmSync(preview.destination, { recursive: true, force: true }); } catch { /* best-effort rollback */ }
+    throw err;
+  }
+}
+
+function normalizeSource(raw: string): string {
+  if (typeof raw !== 'string' || !raw.trim()) throw new Error('source required');
+  let expanded = raw.trim();
+  if (expanded === '~' || expanded.startsWith('~/')) expanded = path.join(os.homedir(), expanded.slice(1));
+  const source = path.resolve(expanded);
+  if (!dirExists(source)) throw new Error(fs.existsSync(source) ? 'source is not a directory' : 'source not found');
+  return source;
+}
+
+function assertImportableSource(source: string, kbRoot: string): void {
+  const home = os.homedir();
+  if (source === home || source === path.parse(source).root) {
+    throw new Error('refusing to import home or filesystem root');
+  }
+  const relFromRoot = path.relative(kbRoot, source);
+  const isInsideKb = source === kbRoot
+    || (relFromRoot !== '' && !relFromRoot.startsWith('..') && !path.isAbsolute(relFromRoot));
+  if (isInsideKb) {
+    throw new Error('source is already inside the library; use Open space');
+  }
+  const relRootFromSource = path.relative(source, kbRoot);
+  const containsKbRoot = relRootFromSource !== ''
+    && !relRootFromSource.startsWith('..')
+    && !path.isAbsolute(relRootFromSource);
+  if (containsKbRoot) {
+    throw new Error('source contains the library root; choose a more specific folder');
+  }
+}
+
+function scanFolder(source: string): { entryCount: number; totalBytes: number } {
+  let entryCount = 0;
+  let totalBytes = 0;
+  const seenDirectories = new Set<string>();
+  try { seenDirectories.add(fs.realpathSync(source)); } catch { /* source was already stat-checked */ }
+  const stack = [source];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const entry of entries) {
+      entryCount += 1;
+      const full = path.join(dir, entry.name);
+      try {
+        const stat = fs.statSync(full);
+        if (stat.isFile()) totalBytes += stat.size;
+        if (stat.isDirectory()) {
+          const real = fs.realpathSync(full);
+          if (!seenDirectories.has(real)) {
+            seenDirectories.add(real);
+            stack.push(full);
+          }
+        }
+      } catch {
+        /* Unreadable entries are surfaced by copy during import. */
+      }
+    }
+  }
+  return { entryCount, totalBytes };
+}
+
+function copyDirectoryDereferenced(source: string, destination: string): void {
+  if (fs.existsSync(destination)) throw new Error(`destination already exists: ${destination}`);
+  fs.mkdirSync(destination, { recursive: false });
+  const seen = new Set([fs.realpathSync(source)]);
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    const src = path.join(source, entry.name);
+    const dest = path.join(destination, entry.name);
+    copyEntryDereferenced(src, dest, seen);
+  }
+}
+
+function copyEntryDereferenced(source: string, destination: string, seenDirectories: Set<string>): void {
+  const stat = fs.statSync(source);
+  if (stat.isDirectory()) {
+    const real = fs.realpathSync(source);
+    if (seenDirectories.has(real)) throw new Error(`cyclic symlink detected: ${source}`);
+    seenDirectories.add(real);
+    fs.mkdirSync(destination, { mode: stat.mode });
+    for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+      copyEntryDereferenced(path.join(source, entry.name), path.join(destination, entry.name), seenDirectories);
+    }
+    seenDirectories.delete(real);
+    return;
+  }
+  if (stat.isFile()) {
+    fs.copyFileSync(source, destination, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(destination, stat.mode);
+    return;
+  }
+  throw new Error(`unsupported filesystem entry: ${source}`);
+}
+
+function buildWarnings(source: string, kbRoot: string, name: string, entryCount: number): string[] {
+  const warnings: string[] = [];
+  const home = os.homedir();
+  const sensitiveNames = new Set(['Desktop', 'Documents', 'Downloads']);
+  if (path.dirname(source) === home && sensitiveNames.has(path.basename(source))) {
+    warnings.push(`This looks like your ${path.basename(source)} folder.`);
+  }
+  if (entryCount > 0) {
+    warnings.push('Importing copies this existing folder into your StashBase library.');
+  }
+  warnings.push(`Destination will be ${path.join(kbRoot, name)}.`);
+  return warnings;
+}
+
+function pruneImportedStashbase(stashbaseDir: string): void {
+  if (!fs.existsSync(stashbaseDir)) return;
+  for (const entry of STASHBASE_PER_MACHINE_ENTRIES) {
+    fs.rmSync(path.join(stashbaseDir, entry), { recursive: true, force: true });
+  }
+}
+
+function dirExists(p: string): boolean {
+  try { return fs.statSync(p).isDirectory(); } catch { return false; }
+}
+
+function fileExists(p: string): boolean {
+  try { return fs.statSync(p).isFile(); } catch { return false; }
+}

--- a/server/routes/space.ts
+++ b/server/routes/space.ts
@@ -35,6 +35,11 @@ import { errorMessage } from '../log.ts';
 import { sendError } from '../http.ts';
 import { indexer } from '../state.ts';
 import { switchSpaceMcpServers } from '../mcp-host.ts';
+import {
+  importFolderAsSpace,
+  previewFolderImport,
+  type ImportFolderMode,
+} from '../import-folder.ts';
 
 export function mount(app: express.Express): void {
   // List the open + recent spaces. Powers the Welcome screen. Includes
@@ -186,57 +191,46 @@ export function mount(app: express.Express): void {
     }
   });
 
-  // Import an existing local folder as a new space by copying its
-  // contents into <kbRoot>/<name>. Source can be anywhere on disk; the
-  // copy is one-way (we never write back). Refuses if the source is
-  // already under kbRoot (the user can just "Open space" instead), if
-  // the destination already exists, or if the source is a sensitive
-  // parent (home / kbRoot / root). UI follows up with POST /api/space.
-  app.post('/api/space/import-folder', async (req, res) => {
-    const rawSrc = typeof req.body?.source === 'string' ? req.body.source.trim() : '';
-    const rawName = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
-    if (!rawSrc) return res.status(400).json({ error: 'source required' });
-    const src = path.resolve(rawSrc.replace(/^~/, os.homedir()));
-    if (!fs.existsSync(src)) return res.status(404).json({ error: 'source not found' });
-    if (!fs.statSync(src).isDirectory()) return res.status(400).json({ error: 'source is not a directory' });
-    const home = os.homedir();
-    const root = getKbRoot();
-    // Refuse cases where copying would either be a no-op (already
-    // under kbRoot) or a catastrophe (copying $HOME or `/` somewhere).
-    if (src === home || src === path.parse(src).root) {
-      return res.status(400).json({ error: 'refusing to import home or filesystem root' });
-    }
-    const relFromRoot = path.relative(root, src);
-    const isUnderKb = src === root
-      || (relFromRoot !== '' && !relFromRoot.startsWith('..') && !path.isAbsolute(relFromRoot));
-    if (isUnderKb) {
-      return res.status(400).json({ error: 'source is already inside the library; use Open space' });
-    }
-    const name = rawName || path.basename(src);
-    const nameErr = validateSpaceName(name);
-    if (nameErr) return res.status(400).json({ error: nameErr });
-    try { fs.mkdirSync(root, { recursive: true }); } catch { /* fall through */ }
-    if (!fs.existsSync(root) || !fs.statSync(root).isDirectory()) {
-      return res.status(400).json({ error: 'library root is not a directory' });
-    }
-    const dest = path.join(root, name);
-    if (fs.existsSync(dest)) {
-      return res.status(409).json({ error: `space "${name}" already exists` });
-    }
+  // Preview + import an existing local folder as a new space under
+  // <kbRoot>/<name>. The import helper handles the safety rules:
+  // no in-library sources, no merge into existing spaces, copy by
+  // default, optional copy-then-delete move, and symlink dereference.
+  app.post('/api/space/import-folder/preview', (req, res) => {
     try {
-      // Node's `fs.cp` (recursive copy) is sync-API stable since v16
-      // and follows symlinks by default; we keep that behavior to
-      // surface the user's content as plain files in the new space.
-      // `dereference: true` here would inflate snapshot bundles —
-      // leave default off; cps default behaviour preserves links.
-      fs.cpSync(src, dest, { recursive: true });
-      // Strip any per-machine .stashbase state that came along — same
-      // reasoning as a clone (the new copy shouldn't inherit the old
-      // host's embedder routing / Milvus DB).
-      pruneClonedStashbase(path.join(dest, '.stashbase'));
-      res.json({ path: dest });
+      const source = typeof req.body?.source === 'string' ? req.body.source : '';
+      const name = typeof req.body?.name === 'string' ? req.body.name : '';
+      res.json(previewFolderImport({ source, name, kbRoot: getKbRoot() }));
     } catch (err: unknown) {
-      sendError(res, err);
+      res.status(400).json({ error: errorMessage(err) });
+    }
+  });
+
+  app.post('/api/space/import-folder', (req, res) => {
+    try {
+      const source = typeof req.body?.source === 'string' ? req.body.source : '';
+      const name = typeof req.body?.name === 'string' ? req.body.name : '';
+      const rawMode = req.body?.mode;
+      if (rawMode !== undefined && rawMode !== 'copy' && rawMode !== 'move') {
+        return res.status(400).json({ error: 'mode must be "copy" or "move"' });
+      }
+      const mode: ImportFolderMode = rawMode === 'move' ? 'move' : 'copy';
+      const confirmExisting = req.body?.confirmExisting === true;
+      const result = importFolderAsSpace({
+        source,
+        name,
+        mode,
+        confirmExisting,
+        kbRoot: getKbRoot(),
+      });
+      res.json(result);
+    } catch (err: unknown) {
+      if ((err as any)?.code === 'CONFIRM_EXISTING') {
+        return res.status(409).json({ error: errorMessage(err), code: 'CONFIRM_EXISTING' });
+      }
+      if ((err as any)?.code === 'SPACE_EXISTS') {
+        return res.status(409).json({ error: errorMessage(err), code: 'SPACE_EXISTS' });
+      }
+      res.status(400).json({ error: errorMessage(err) });
     }
   });
 

--- a/web-src/src/api.ts
+++ b/web-src/src/api.ts
@@ -45,6 +45,26 @@ export interface SpaceConfig {
   skillsDirs?: string[];
 }
 
+export type ImportFolderMode = 'copy' | 'move';
+
+export interface FolderImportPreview {
+  source: string;
+  name: string;
+  destination: string;
+  exists: boolean;
+  entryCount: number;
+  totalBytes: number;
+  requiresConfirmation: boolean;
+  warnings: string[];
+  hasSnapshot: boolean;
+}
+
+export interface FolderImportResult {
+  path: string;
+  name: string;
+  mode: ImportFolderMode;
+}
+
 export interface FilesPayload {
   files: FileMeta[];
   folders: FolderMeta[];
@@ -330,10 +350,20 @@ export const api = {
     send<{ path: string }>('POST', '/api/git/clone', { url, name }),
   /** Copy a local folder into kbRoot as a new space. `source` is an
    *  absolute path; the renderer obtains it from
-   *  `window.stashbase.openFolderDialog` (Electron-only). `name`
+   *  `window.electron.openFolderDialog` (Electron-only). `name`
    *  defaults to the basename of `source` server-side. */
-  importFolder: (source: string, name = '') =>
-    send<{ path: string }>('POST', '/api/space/import-folder', { source, name }),
+  previewImportFolder: (source: string, name = '') =>
+    send<FolderImportPreview>('POST', '/api/space/import-folder/preview', { source, name }),
+  importFolder: (
+    source: string,
+    opts: { name?: string; mode?: ImportFolderMode; confirmExisting?: boolean } = {},
+  ) =>
+    send<FolderImportResult>('POST', '/api/space/import-folder', {
+      source,
+      name: opts.name ?? '',
+      mode: opts.mode ?? 'copy',
+      confirmExisting: opts.confirmExisting === true,
+    }),
   /** Mirror this space's `skills/<name>/SKILL.md` into the active
    *  CLI's per-project prompt dir (`.claude/commands` / `.codex/prompts`).
    *  Renderer fires this on terminal panel open / CLI switch. */

--- a/web-src/src/components/Welcome.tsx
+++ b/web-src/src/components/Welcome.tsx
@@ -1,5 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
-import { api, ApiError, errorMessage } from '../api';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  api,
+  ApiError,
+  errorMessage,
+  type FolderImportPreview,
+  type ImportFolderMode,
+} from '../api';
 import { CubeLogoIcon, FolderIcon, GitCloneIcon, NewFolderIcon } from '../icons';
 import { useApp } from '../store/AppContext';
 import { CloneRepoModal } from './CloneRepoModal';
@@ -7,7 +13,12 @@ import { ModalShell } from './ModalShell';
 import { openSettings } from './SettingsModal';
 
 interface ElectronBridge {
-  openFolderDialog?: (opts?: unknown) => Promise<string | null>;
+  openFolderDialog?: (opts?: {
+    title?: string;
+    buttonLabel?: string;
+    defaultPath?: string;
+    allowCreateDirectory?: boolean;
+  }) => Promise<string | null>;
 }
 
 /** Shorten an absolute path for display: `/Users/foo/Notes` → `~/Notes`
@@ -39,6 +50,7 @@ export function Welcome() {
   const [cloneOpen, setCloneOpen] = useState(false);
   const [newOpen, setNewOpen] = useState(false);
   const [openOpen, setOpenOpen] = useState(false);
+  const [importSource, setImportSource] = useState<string | null>(null);
   const [kbRoot, setKbRoot] = useState('');
   const [rootPickerOpen, setRootPickerOpen] = useState(false);
   const [showAllRecent, setShowAllRecent] = useState(false);
@@ -107,7 +119,7 @@ export function Welcome() {
             </span>
             <span className="welcome-action-label">Clone repo</span>
           </button>
-          <ImportFolderButton />
+          <ImportFolderButton onPicked={setImportSource} />
         </div>
 
         <div className="welcome-mcp">
@@ -164,6 +176,13 @@ export function Welcome() {
         )}
       </div>
       {cloneOpen && <CloneRepoModal onClose={() => setCloneOpen(false)} />}
+      {importSource && (
+        <ImportFolderModal
+          source={importSource}
+          homeDir={state.homeDir ?? ''}
+          onClose={() => setImportSource(null)}
+        />
+      )}
       {rootPickerOpen && (
         <KbRootPickerModal
           initialPath={kbRoot}
@@ -190,10 +209,6 @@ export function Welcome() {
       )}
     </div>
   );
-}
-
-interface ElectronBridge {
-  openFolderDialog?: (opts?: unknown) => Promise<string | null>;
 }
 
 function KbRootPickerModal({
@@ -280,8 +295,8 @@ function KbRootPickerModal({
  *  a brand-new space. Browser fallback (no Electron bridge) hides the
  *  button entirely: there's no portable file-picker we'd trust to
  *  return an absolute path the server can act on. */
-function ImportFolderButton() {
-  const { actions, dispatch } = useApp();
+function ImportFolderButton({ onPicked }: { onPicked: (path: string) => void }) {
+  const { dispatch } = useApp();
   const [busy, setBusy] = useState(false);
   const bridge = useMemo<ElectronBridge | undefined>(
     () => (window as { electron?: ElectronBridge }).electron,
@@ -294,13 +309,10 @@ function ImportFolderButton() {
     try {
       const picked = await bridge!.openFolderDialog!({
         title: 'Import folder as space',
-        buttonLabel: 'Import',
+        buttonLabel: 'Choose Folder',
+        allowCreateDirectory: false,
       });
-      if (!picked) return;
-      const result = await api.importFolder(picked);
-      // Server returns the destination path; flip into it like
-      // CloneRepoModal does so the user lands in the new space.
-      await actions.openSpace(result.path);
+      if (picked) onPicked(picked);
     } catch (err) {
       dispatch({ type: 'WELCOME_ERROR', error: errorMessage(err) });
     } finally {
@@ -318,8 +330,162 @@ function ImportFolderButton() {
       <span className="welcome-action-icon">
         <FolderIcon />
       </span>
-      <span className="welcome-action-label">{busy ? 'Importing…' : 'Import folder'}</span>
+      <span className="welcome-action-label">{busy ? 'Choosing…' : 'Import folder'}</span>
     </button>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value >= 10 || unit === 0 ? value.toFixed(0) : value.toFixed(1)} ${units[unit]}`;
+}
+
+function ImportFolderModal({
+  source,
+  homeDir,
+  onClose,
+}: {
+  source: string;
+  homeDir: string;
+  onClose: () => void;
+}) {
+  const { actions } = useApp();
+  const [preview, setPreview] = useState<FolderImportPreview | null>(null);
+  const [name, setName] = useState('');
+  const [mode, setMode] = useState<ImportFolderMode>('copy');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const previewSeq = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const seq = ++previewSeq.current;
+    setPreview(null);
+    setError(null);
+    void (async () => {
+      try {
+        const p = await api.previewImportFolder(source);
+        if (cancelled || seq !== previewSeq.current) return;
+        setPreview(p);
+        setName(p.name);
+      } catch (err) {
+        if (!cancelled && seq === previewSeq.current) setError(errorMessage(err));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [source]);
+
+  async function refreshName(nextName: string) {
+    setName(nextName);
+    const seq = ++previewSeq.current;
+    if (!nextName.trim()) {
+      setPreview(null);
+      setError(null);
+      return;
+    }
+    try {
+      const p = await api.previewImportFolder(source, nextName);
+      if (seq !== previewSeq.current) return;
+      setPreview(p);
+      setError(null);
+    } catch (err) {
+      if (seq !== previewSeq.current) return;
+      setError(errorMessage(err));
+    }
+  }
+
+  async function submit() {
+    const n = name.trim();
+    if (!n) { setError('Name required'); return; }
+    if (n.includes('/') || n.includes('\\') || n.startsWith('.')) {
+      setError('Name cannot contain slashes or start with "."');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await api.importFolder(source, {
+        name: n,
+        mode,
+        confirmExisting: true,
+      });
+      onClose();
+      await actions.openSpaceByName(result.name);
+    } catch (err) {
+      setError(errorMessage(err));
+      setBusy(false);
+    }
+  }
+
+  const sourceDisplay = prettifyHome(source, homeDir);
+  const destinationDisplay = preview ? prettifyHome(preview.destination, homeDir) : '';
+  const importActionMessage = mode === 'move'
+    ? 'Importing moves this existing folder into your StashBase library and removes the original.'
+    : 'Importing copies this existing folder into your StashBase library.';
+  const serverWarnings = (preview?.warnings ?? []).filter((w) =>
+    w !== 'Importing copies this existing folder into your StashBase library.',
+  );
+
+  return (
+    <ModalShell onCancel={busy ? () => { /* swallow during import */ } : onClose}>
+      <h3>Import folder</h3>
+      <p className="modal-hint">
+        Imports <code>{sourceDisplay}</code> as a new space.
+      </p>
+      <input
+        type="text"
+        className="modal-input"
+        placeholder="Space name"
+        autoComplete="off"
+        spellCheck={false}
+        value={name}
+        onChange={(e) => { void refreshName(e.target.value); }}
+        disabled={busy}
+        autoFocus
+        onKeyDown={(e) => {
+          if (e.nativeEvent.isComposing) return;
+          if (e.key === 'Enter') { e.preventDefault(); void submit(); }
+          else if (e.key === 'Escape' && !busy) { e.preventDefault(); onClose(); }
+        }}
+      />
+      <label className="modal-check">
+        <input
+          type="checkbox"
+          checked={mode === 'move'}
+          disabled={busy}
+          onChange={(e) => setMode(e.target.checked ? 'move' : 'copy')}
+        />
+        <span>Move folder into StashBase instead of copying</span>
+      </label>
+      {preview && (
+        <div className="modal-hint">
+          <div>Destination: <code>{destinationDisplay}</code></div>
+          <div>{preview.entryCount} item{preview.entryCount === 1 ? '' : 's'} · {formatBytes(preview.totalBytes)}</div>
+          {preview.exists && <div>{importActionMessage}</div>}
+          {preview.hasSnapshot && <div>Snapshot found; StashBase will import it when the space opens.</div>}
+          {serverWarnings.map((w) => <div key={w}>{w}</div>)}
+        </div>
+      )}
+      {error && <div className="modal-error">{error}</div>}
+      <div className="modal-actions">
+        <button type="button" className="modal-btn" onClick={onClose} disabled={busy}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="modal-btn primary"
+          onClick={() => { void submit(); }}
+          disabled={busy || !preview || !name.trim()}
+        >{busy ? 'Importing…' : mode === 'move' ? 'Move into StashBase' : 'Copy into StashBase'}</button>
+      </div>
+    </ModalShell>
   );
 }
 

--- a/web-src/src/styles/sidebar.css
+++ b/web-src/src/styles/sidebar.css
@@ -268,6 +268,20 @@
       outline-offset: -1px;
     }
 
+    .modal-check {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 10px;
+      margin-bottom: 14px;
+      color: var(--fg);
+      font-size: 13px;
+    }
+
+    .modal-check input {
+      margin: 0;
+    }
+
     .modal-error {
       margin-top: 10px;
       padding: 8px 10px;
@@ -1205,4 +1219,3 @@
       color: var(--muted);
       font-style: italic;
     }
-


### PR DESCRIPTION
## Summary
- Add a GUI local folder import flow with native directory picker, confirmation modal, copy-by-default behavior, and optional copy-then-delete move mode.
- Move import safety logic into a tested server helper that refuses dangerous sources, duplicate spaces, cyclic symlinks, and sources that would violate the KB-root invariant.
- Preserve portable `.stashbase/snapshot.parquet` while pruning per-machine `.stashbase` state, then open imported spaces by name so existing bind/snapshot import behavior runs.

## Test Plan
- `pnpm test:import-folder`
- `pnpm build`
- Browser smoke on `http://127.0.0.1:8190` loaded the Welcome UI
