### PR TITLE
fix(space): folder-import move safety, prune dedup, large-folder guard

### DIFF
--- a/server/import-folder.test.ts
+++ b/server/import-folder.test.ts
@@ -84,6 +84,34 @@ test('move imports by copy-then-delete, preserving dereferenced content in the s
   assert.equal(fs.existsSync(source), false);
 });
 
+test('move keeps the imported space and warns when the original cannot be removed', () => {
+  const kbRoot = tmpDir('kb');
+  const parent = tmpDir('parent');
+  const source = path.join(parent, 'src');
+  fs.mkdirSync(source);
+  fs.writeFileSync(path.join(source, 'note.md'), '# moved\n');
+  // Strip write permission on the parent so the source entry cannot be
+  // unlinked — simulates a copy-succeeds-but-delete-fails move (a lock or
+  // permission issue). The copy is already committed at that point.
+  fs.chmodSync(parent, 0o500);
+  try {
+    const result = importFolderAsSpace({
+      source,
+      kbRoot,
+      name: 'kept',
+      mode: 'move',
+      confirmExisting: true,
+    });
+    // The new space must survive — tearing it down would lose data on
+    // both sides, since the original is also partially gone.
+    assert.equal(fs.readFileSync(path.join(result.path, 'note.md'), 'utf8'), '# moved\n');
+    assert.equal(fs.existsSync(source), true);
+    assert.match(result.warning ?? '', /could not be fully removed/);
+  } finally {
+    fs.chmodSync(parent, 0o700);
+  }
+});
+
 test('import refuses to merge into an existing space', () => {
   const kbRoot = tmpDir('kb');
   const source = tmpDir('source');

--- a/server/import-folder.ts
+++ b/server/import-folder.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { validateSpaceName } from './space.ts';
+import { validateSpaceName, pruneStashbasePerMachineState } from './space.ts';
 
 export type ImportFolderMode = 'copy' | 'move';
 
@@ -29,10 +29,21 @@ export interface ImportFolderResult {
   path: string;
   name: string;
   mode: ImportFolderMode;
+  /** Set only on a `move` where the copy succeeded but deleting the
+   *  original folder failed (permissions / file in use). The new space
+   *  is intact and usable; this tells the caller the source still needs
+   *  manual cleanup. */
+  warning?: string;
 }
 
-const STASHBASE_PER_MACHINE_ENTRIES = ['config.json', 'store', 'mfs', 'cache', 'state.db'];
 const CONFIRM_ENTRY_LIMIT = 0;
+/** Cap on how deep `scanFolder` walks before it stops counting. A
+ *  preview is informational, not a manifest — without a bound, pointing
+ *  the picker at a tens-of-GB tree would block the server on a full
+ *  recursive stat. Past the cap we report an approximate count and warn.
+ *  The real copy still walks everything, but that's a deliberate,
+ *  user-confirmed action rather than an incidental preview. */
+const SCAN_ENTRY_CAP = 50_000;
 
 export function previewFolderImport(
   opts: Pick<ImportFolderOptions, 'source' | 'kbRoot' | 'name'>,
@@ -47,7 +58,7 @@ export function previewFolderImport(
 
   const destination = path.join(kbRoot, name);
   const stats = scanFolder(source);
-  const warnings = buildWarnings(source, kbRoot, name, stats.entryCount);
+  const warnings = buildWarnings(source, kbRoot, name, stats.entryCount, stats.truncated);
 
   return {
     source,
@@ -80,17 +91,36 @@ export function importFolderAsSpace(opts: ImportFolderOptions): ImportFolderResu
     throw err;
   }
 
+  // Phase 1 — build the new space. Anything that throws here leaves a
+  // partial destination behind, so we roll it back. The source is still
+  // untouched, so rolling back the destination is safe and complete.
   try {
     copyDirectoryDereferenced(preview.source, preview.destination);
-    pruneImportedStashbase(path.join(preview.destination, '.stashbase'));
-    if (mode === 'move') {
-      fs.rmSync(preview.source, { recursive: true, force: false });
-    }
-    return { path: preview.destination, name: preview.name, mode };
+    pruneStashbasePerMachineState(path.join(preview.destination, '.stashbase'));
   } catch (err) {
     try { fs.rmSync(preview.destination, { recursive: true, force: true }); } catch { /* best-effort rollback */ }
     throw err;
   }
+
+  // Phase 2 — for a move, delete the original now that the copy is
+  // committed. This is deliberately *outside* the rollback above: if
+  // deleting the source fails partway (permissions / file in use), the
+  // new space is already complete and must be kept. Tearing it down here
+  // would lose data on both sides. Surface a warning instead so the user
+  // can clean up the leftover original by hand.
+  if (mode === 'move') {
+    try {
+      fs.rmSync(preview.source, { recursive: true, force: false });
+    } catch {
+      return {
+        path: preview.destination,
+        name: preview.name,
+        mode,
+        warning: `Imported into "${preview.name}", but the original folder at ${preview.source} could not be fully removed. Please delete it manually.`,
+      };
+    }
+  }
+  return { path: preview.destination, name: preview.name, mode };
 }
 
 function normalizeSource(raw: string): string {
@@ -122,13 +152,14 @@ function assertImportableSource(source: string, kbRoot: string): void {
   }
 }
 
-function scanFolder(source: string): { entryCount: number; totalBytes: number } {
+function scanFolder(source: string): { entryCount: number; totalBytes: number; truncated: boolean } {
   let entryCount = 0;
   let totalBytes = 0;
   const seenDirectories = new Set<string>();
   try { seenDirectories.add(fs.realpathSync(source)); } catch { /* source was already stat-checked */ }
   const stack = [source];
   while (stack.length) {
+    if (entryCount >= SCAN_ENTRY_CAP) return { entryCount, totalBytes, truncated: true };
     const dir = stack.pop()!;
     let entries: fs.Dirent[];
     try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
@@ -150,7 +181,7 @@ function scanFolder(source: string): { entryCount: number; totalBytes: number } 
       }
     }
   }
-  return { entryCount, totalBytes };
+  return { entryCount, totalBytes, truncated: false };
 }
 
 function copyDirectoryDereferenced(source: string, destination: string): void {
@@ -185,25 +216,27 @@ function copyEntryDereferenced(source: string, destination: string, seenDirector
   throw new Error(`unsupported filesystem entry: ${source}`);
 }
 
-function buildWarnings(source: string, kbRoot: string, name: string, entryCount: number): string[] {
+function buildWarnings(
+  source: string,
+  kbRoot: string,
+  name: string,
+  entryCount: number,
+  truncated: boolean,
+): string[] {
   const warnings: string[] = [];
   const home = os.homedir();
   const sensitiveNames = new Set(['Desktop', 'Documents', 'Downloads']);
   if (path.dirname(source) === home && sensitiveNames.has(path.basename(source))) {
     warnings.push(`This looks like your ${path.basename(source)} folder.`);
   }
+  if (truncated) {
+    warnings.push(`Large folder (${SCAN_ENTRY_CAP.toLocaleString()}+ items); the count below is approximate and importing may take a while.`);
+  }
   if (entryCount > 0) {
     warnings.push('Importing copies this existing folder into your StashBase library.');
   }
   warnings.push(`Destination will be ${path.join(kbRoot, name)}.`);
   return warnings;
-}
-
-function pruneImportedStashbase(stashbaseDir: string): void {
-  if (!fs.existsSync(stashbaseDir)) return;
-  for (const entry of STASHBASE_PER_MACHINE_ENTRIES) {
-    fs.rmSync(path.join(stashbaseDir, entry), { recursive: true, force: true });
-  }
 }
 
 function dirExists(p: string): boolean {

--- a/server/routes/space.ts
+++ b/server/routes/space.ts
@@ -30,6 +30,7 @@ import {
   setKbRoot,
   validateSpaceName,
   writeSpaceConfig,
+  pruneStashbasePerMachineState,
 } from '../space.ts';
 import { errorMessage } from '../log.ts';
 import { sendError } from '../http.ts';
@@ -272,7 +273,7 @@ export function mount(app: express.Express): void {
       //     the new user skip re-embedding (auto-imported on bind)
       //   - any future portable artefacts the maintainer ships
       // `.git/` and other dotdirs are user content and stay.
-      pruneClonedStashbase(path.join(dest, '.stashbase'));
+      pruneStashbasePerMachineState(path.join(dest, '.stashbase'));
       res.json({ path: dest });
     } catch (err: unknown) {
       sendError(res, err);
@@ -316,22 +317,6 @@ function walkSpace(
     const full = path.join(dir, e.name);
     fn(rel, full, e);
     if (e.isDirectory()) walkSpace(full, rel, fn);
-  }
-}
-
-/** Internal entries under `.stashbase/` that **must** be wiped after a
- *  clone — per-machine state, never portable. Everything else in the
- *  directory stays; the snapshot file lives here intentionally. */
-const STASHBASE_PER_MACHINE_ENTRIES = ['config.json', 'store', 'mfs', 'cache', 'state.db'];
-
-/** Selectively delete per-machine internal state out of a freshly-
- *  cloned space's `.stashbase/` directory, leaving portable artefacts
- *  (notably `snapshot.parquet`) intact. No-op if the directory doesn't
- *  exist. */
-function pruneClonedStashbase(stashbaseDir: string): void {
-  if (!fs.existsSync(stashbaseDir)) return;
-  for (const entry of STASHBASE_PER_MACHINE_ENTRIES) {
-    fs.rmSync(path.join(stashbaseDir, entry), { recursive: true, force: true });
   }
 }
 

--- a/server/space.ts
+++ b/server/space.ts
@@ -200,6 +200,26 @@ export function validateSpaceName(name: string): string | null {
   return null;
 }
 
+/** Internal entries under `.stashbase/` that **must** be wiped when a
+ *  space arrives from elsewhere — a git clone or a folder import.
+ *  These are per-machine state (embedder routing, the local vector store,
+ *  the storage-state DB, the cache) and never portable. Everything else
+ *  stays; `snapshot.parquet` lives here intentionally and is preserved.
+ *  Shared by the clone and import-folder flows so a rename here only
+ *  happens once. (`mfs` is the pre-rename store dir, kept until legacy
+ *  spaces age out.) */
+export const STASHBASE_PER_MACHINE_ENTRIES = ['config.json', 'store', 'mfs', 'cache', 'state.db'];
+
+/** Selectively delete per-machine internal state out of a space's
+ *  `.stashbase/` directory, leaving portable artefacts (notably
+ *  `snapshot.parquet`) intact. No-op if the directory doesn't exist. */
+export function pruneStashbasePerMachineState(stashbaseDir: string): void {
+  if (!fs.existsSync(stashbaseDir)) return;
+  for (const entry of STASHBASE_PER_MACHINE_ENTRIES) {
+    fs.rmSync(path.join(stashbaseDir, entry), { recursive: true, force: true });
+  }
+}
+
 /** Direct child directories of the KB root, sorted alphabetically.
  *  Powers the "Open space" dropdown — every entry is a candidate the
  *  server will accept as a space name. Dot-dirs are skipped (`.git`,

--- a/web-src/src/api.ts
+++ b/web-src/src/api.ts
@@ -63,6 +63,10 @@ export interface FolderImportResult {
   path: string;
   name: string;
   mode: ImportFolderMode;
+  /** Present only when a `move` import copied successfully but the
+   *  original folder could not be fully deleted; the new space is intact
+   *  and the original needs manual cleanup. */
+  warning?: string;
 }
 
 export interface FilesPayload {

--- a/web-src/src/components/Welcome.tsx
+++ b/web-src/src/components/Welcome.tsx
@@ -362,6 +362,10 @@ function ImportFolderModal({
   const [mode, setMode] = useState<ImportFolderMode>('copy');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Set once a move import finished but left the original behind (see
+  // FolderImportResult.warning). The space exists; we keep the modal up
+  // to show the cleanup notice and let the user open it deliberately.
+  const [doneName, setDoneName] = useState<string | null>(null);
   const previewSeq = useRef(0);
 
   useEffect(() => {
@@ -416,6 +420,15 @@ function ImportFolderModal({
         mode,
         confirmExisting: true,
       });
+      if (result.warning) {
+        // Import succeeded but the original couldn't be removed. Keep the
+        // modal open so the notice survives; the user opens the space
+        // (which unmounts Welcome) only after acknowledging it.
+        setDoneName(result.name);
+        setError(result.warning);
+        setBusy(false);
+        return;
+      }
       onClose();
       await actions.openSpaceByName(result.name);
     } catch (err) {
@@ -473,17 +486,25 @@ function ImportFolderModal({
           {serverWarnings.map((w) => <div key={w}>{w}</div>)}
         </div>
       )}
-      {error && <div className="modal-error">{error}</div>}
+      {error && <div className={doneName ? 'modal-warning' : 'modal-error'}>{error}</div>}
       <div className="modal-actions">
         <button type="button" className="modal-btn" onClick={onClose} disabled={busy}>
-          Cancel
+          {doneName ? 'Close' : 'Cancel'}
         </button>
-        <button
-          type="button"
-          className="modal-btn primary"
-          onClick={() => { void submit(); }}
-          disabled={busy || !preview || !name.trim()}
-        >{busy ? 'Importing…' : mode === 'move' ? 'Move into StashBase' : 'Copy into StashBase'}</button>
+        {doneName ? (
+          <button
+            type="button"
+            className="modal-btn primary"
+            onClick={() => { onClose(); void actions.openSpaceByName(doneName); }}
+          >Open space</button>
+        ) : (
+          <button
+            type="button"
+            className="modal-btn primary"
+            onClick={() => { void submit(); }}
+            disabled={busy || !preview || !name.trim()}
+          >{busy ? 'Importing…' : mode === 'move' ? 'Move into StashBase' : 'Copy into StashBase'}</button>
+        )}
       </div>
     </ModalShell>
   );

--- a/web-src/src/styles/sidebar.css
+++ b/web-src/src/styles/sidebar.css
@@ -292,6 +292,16 @@
       line-height: 1.45;
     }
 
+    .modal-warning {
+      margin-top: 10px;
+      padding: 8px 10px;
+      background: rgba(217, 119, 6, 0.1);
+      color: #b45309;
+      border-radius: 6px;
+      font-size: 12px;
+      line-height: 1.45;
+    }
+
     .mcp-client-list {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
Addresses three review findings on the local folder import merged in #1.

## 🔴 move mode rollback could lose data on both sides
`importFolderAsSpace` ran `copy → prune → rmSync(source)` in one `try`, with the `catch` doing `rmSync(destination)`. If the copy succeeded but deleting the source failed midway (permissions / file in use), the catch deleted the freshly-copied space *too* — leaving partial remnants on both sides.

Now split into two phases:
1. **Build** the new space (copy + prune). Failure here rolls back the destination — safe, because the source is still untouched.
2. **Delete the source** (move only), *outside* that rollback. If it fails, the new space is complete and is **kept**; the result carries a `warning` ("original folder could not be fully removed; please delete it manually"). The Welcome modal shows the warning and switches the primary button to **Open space** instead of silently navigating away.

New regression test: `move keeps the imported space and warns when the original cannot be removed`.

## 🟡 prune logic duplicated
`pruneImportedStashbase` and clone's `pruneClonedStashbase` were two copies of `['config.json','mfs','cache']`. Hoisted `STASHBASE_PER_MACHINE_ENTRIES` + `pruneStashbasePerMachineState` into `server/space.ts`; both flows import it, so the upcoming `mfs→store` rename only touches one place.

## 🟡 large-folder preview could block the server
`previewFolderImport` did a full recursive sync walk; pointing the picker at a tens-of-GB tree would stall the event loop. `scanFolder` now caps at 50k entries, returns an approximate count, and surfaces a "large folder; import may take a while" warning. (The real copy still walks everything — that's a user-confirmed action.)

## Test plan
- `node --import tsx --test server/import-folder.test.ts` → 11/11 pass
- `tsc --noEmit` on root + web-src → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)