### PR TITLE
feat(agent-composer): add keyboard navigation to file mentions

### DIFF
--- a/web-src/src/components/agent/AgentComposer.tsx
+++ b/web-src/src/components/agent/AgentComposer.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import {
   ArrowUpIcon, BoltIcon, CheckIcon, ChevronDownIcon, ClipboardListIcon, CodeIcon, DumbbellIcon,
   FileGenericIcon, HandIcon, PlusIcon,
 } from '../../icons';
 import { useApp } from '../../store/AppContext';
 import { baseName } from './attachments';
+import { MentionComposer, type MentionComposerHandle, type MentionQuery } from './MentionComposer';
 import type { Attachment, EffortLevel, PermMode } from './types';
 
 const MODES: { id: PermMode; label: string; desc: string; Icon: typeof HandIcon }[] = [
@@ -171,16 +172,19 @@ export function AgentComposer({
   onStop: () => void;
 }) {
   const [text, setText] = useState('');
-  const taRef = useRef<HTMLTextAreaElement>(null);
+  const composerRef = useRef<MentionComposerHandle>(null);
+  const mentionListboxId = useId();
   const { state } = useApp();
-  const [mention, setMention] = useState<{ q: string; from: number } | null>(null);
+  const [mention, setMention] = useState<MentionQuery>(null);
+  const [activeMentionIndex, setActiveMentionIndex] = useState(0);
   const [modeOpen, setModeOpen] = useState(false);
   const [effortOpen, setEffortOpen] = useState(false);
   const modeWrapRef = useRef<HTMLDivElement>(null);
   const effortWrapRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const activeMentionRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => { if (active) taRef.current?.focus(); }, [active]);
+  useEffect(() => { if (active) composerRef.current?.focus(); }, [active]);
 
   useEffect(() => {
     if (!modeOpen) return;
@@ -217,6 +221,12 @@ export function AgentComposer({
       .slice(0, 8);
   }, [mention, state.files]);
 
+  const activeSuggestionIndex = Math.min(activeMentionIndex, Math.max(suggestions.length - 1, 0));
+
+  useEffect(() => {
+    activeMentionRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [activeSuggestionIndex]);
+
   const placeholder = phase === 'connecting'
     ? 'Connecting…'
     : phase === 'closed'
@@ -225,65 +235,51 @@ export function AgentComposer({
         ? 'Ask for follow-up changes'
         : `Message ${agentShortName}…`;
 
-  function onChange(v: string, caret: number) {
-    setText(v);
-    const upto = v.slice(0, caret);
-    const m = /(^|\s)@([^\s@]*)$/.exec(upto);
-    if (m) setMention({ q: m[2], from: caret - m[2].length });
-    else setMention(null);
-  }
-
   function pickMention(path: string) {
-    const ta = taRef.current;
-    if (!ta || !mention) return;
-    const before = text.slice(0, mention.from);
-    const after = text.slice(ta.selectionStart);
-    const next = before + path + ' ' + after;
-    setText(next);
-    setMention(null);
-    requestAnimationFrame(() => {
-      ta.focus();
-      const c = (before + path + ' ').length;
-      ta.setSelectionRange(c, c);
-    });
-  }
-
-  function submit() {
-    const t = text.trim();
-    if ((!t && attachments.length === 0) || disabled || uploading) return;
-    onSend(t);
-    setText('');
+    if (!mention) return;
+    composerRef.current?.insertMention(path, mention);
     setMention(null);
   }
 
-  function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (mention && suggestions.length && (e.key === 'Enter' || e.key === 'Tab')) {
-      e.preventDefault();
-      pickMention(suggestions[0].name);
-      return;
-    }
-    if (showModeMenu && e.key === 'Tab' && e.shiftKey && !disabled) {
-      e.preventDefault();
-      cycleMode();
-      return;
-    }
-    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-      e.preventDefault();
-      submit();
-    }
-    if (e.key === 'Escape' && mention) setMention(null);
+  function submit(t: string) {
+    const trimmed = t.trim();
+    if ((!trimmed && attachments.length === 0) || disabled || uploading) return false;
+    onSend(trimmed);
+    setMention(null);
+    return true;
+  }
+
+  function moveMention(direction: 1 | -1) {
+    if (!suggestions.length) return;
+    setActiveMentionIndex((index) => (index + direction + suggestions.length) % suggestions.length);
   }
 
   return (
     <div className="agent-composer">
       {mention && suggestions.length > 0 && (
         <div className="agent-mention">
-          {suggestions.map((f) => (
-            <button key={f.name} type="button" className="agent-mention-item" onClick={() => pickMention(f.name)}>
-              <span className="agent-mention-name">{baseName(f.name)}</span>
-              <span className="agent-mention-path">{f.name}</span>
-            </button>
-          ))}
+          <div id={mentionListboxId} className="agent-mention-list" role="listbox" aria-label="Matching library files">
+            {suggestions.map((f, index) => (
+              <button
+                key={f.name}
+                ref={index === activeSuggestionIndex ? activeMentionRef : null}
+                id={`${mentionListboxId}-option-${index}`}
+                type="button"
+                role="option"
+                aria-selected={index === activeSuggestionIndex}
+                tabIndex={-1}
+                className={'agent-mention-item' + (index === activeSuggestionIndex ? ' active' : '')}
+                onMouseEnter={() => setActiveMentionIndex(index)}
+                onClick={() => pickMention(f.name)}
+              >
+                <FileGenericIcon className="agent-mention-icon" />
+                <span className="agent-mention-text">
+                  <span className="agent-mention-name">{baseName(f.name)}</span>
+                  <span className="agent-mention-path">{f.name}</span>
+                </span>
+              </button>
+            ))}
+          </div>
         </div>
       )}
       <div className="agent-composer-box">
@@ -305,15 +301,31 @@ export function AgentComposer({
             {uploading && <span className="agent-attach-loading">Uploading…</span>}
           </div>
         )}
-        <textarea
-          ref={taRef}
-          className="agent-input"
-          rows={1}
+        <MentionComposer
+          ref={composerRef}
           placeholder={placeholder}
-          value={text}
           disabled={disabled}
-          onChange={(e) => onChange(e.target.value, e.target.selectionStart)}
-          onKeyDown={onKeyDown}
+          onChange={setText}
+          onMentionChange={(next) => {
+            setMention(next);
+            setActiveMentionIndex(0);
+          }}
+          onMentionNavigate={moveMention}
+          onMentionAccept={() => {
+            if (!suggestions.length) return false;
+            pickMention(suggestions[activeSuggestionIndex].name);
+            return true;
+          }}
+          onMentionDismiss={() => setMention(null)}
+          onShiftTab={() => {
+            if (!showModeMenu || disabled) return false;
+            cycleMode();
+            return true;
+          }}
+          onSubmit={submit}
+          mentionOpen={Boolean(mention && suggestions.length)}
+          mentionListboxId={mention && suggestions.length ? mentionListboxId : undefined}
+          activeMentionOptionId={mention && suggestions.length ? `${mentionListboxId}-option-${activeSuggestionIndex}` : undefined}
         />
         <input
           ref={fileInputRef}
@@ -369,7 +381,7 @@ export function AgentComposer({
               className="agent-send"
               title="Send"
               disabled={disabled || uploading || (!text.trim() && attachments.length === 0)}
-              onClick={submit}
+              onClick={() => composerRef.current?.submit()}
             >
               <ArrowUpIcon />
             </button>

--- a/web-src/src/components/agent/MentionComposer.tsx
+++ b/web-src/src/components/agent/MentionComposer.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useImperativeHandle, useRef } from 'react';
+import { Compartment, EditorState, RangeSet, RangeValue, StateEffect, StateField } from '@codemirror/state';
+import { defaultKeymap, history, historyKeymap, invertedEffects } from '@codemirror/commands';
+import { Decoration, type DecorationSet, EditorView, keymap, placeholder, WidgetType } from '@codemirror/view';
+
+const MENTION = '\uFFFC';
+
+export type MentionQuery = { q: string; from: number } | null;
+
+export type MentionComposerHandle = {
+  focus: () => void;
+  insertMention: (path: string, query: Exclude<MentionQuery, null>) => void;
+  submit: () => void;
+};
+
+class Mention extends RangeValue {
+  // Keep text inserted at the token's right boundary outside the marker range.
+  // Otherwise RangeSet mapping expands the range and keepMentionMarkers removes it.
+  endSide = -1;
+
+  constructor(readonly path: string) { super(); }
+
+  eq(other: Mention) {
+    return this.path === other.path;
+  }
+}
+
+class MentionWidget extends WidgetType {
+  constructor(private readonly path: string) { super(); }
+
+  eq(other: MentionWidget) {
+    return this.path === other.path;
+  }
+
+  toDOM() {
+    const token = document.createElement('span');
+    token.className = 'agent-file-mention';
+    token.textContent = this.path.split('/').pop() ?? this.path;
+    token.title = this.path;
+    token.setAttribute('aria-label', `File mention: ${this.path}`);
+    return token;
+  }
+}
+
+type MentionState = { mentions: RangeSet<Mention>; decorations: DecorationSet };
+
+const addMention = StateEffect.define<{ from: number; path: string }>({
+  map: (value, changes) => ({ ...value, from: changes.mapPos(value.from, -1) }),
+});
+
+const removeMention = StateEffect.define<{ from: number; path: string }>({
+  map: (value, changes) => ({ ...value, from: changes.mapPos(value.from, -1) }),
+});
+
+const mentionField = StateField.define<MentionState>({
+  create: () => buildMentionState(RangeSet.empty),
+  update: (value, transaction) => {
+    let mentions = keepMentionMarkers(value.mentions.map(transaction.changes), transaction.state.doc);
+    for (const effect of transaction.effects) {
+      if (effect.is(addMention)) {
+        mentions = mentions.update({
+          add: [new Mention(effect.value.path).range(effect.value.from, effect.value.from + MENTION.length)],
+          sort: true,
+        });
+      } else if (effect.is(removeMention)) {
+        mentions = mentions.update({
+          filter: (from, _to, mention) => from !== effect.value.from || mention.path !== effect.value.path,
+        });
+      }
+    }
+    return buildMentionState(mentions);
+  },
+  provide: (field) => [
+    EditorView.decorations.from(field, (value) => value.decorations),
+    EditorView.atomicRanges.of((view) => view.state.field(field).mentions),
+  ],
+});
+
+function buildMentionState(mentions: RangeSet<Mention>): MentionState {
+  const decorations: ReturnType<Decoration['range']>[] = [];
+  mentions.between(0, Infinity, (from, to, mention) => {
+    decorations.push(Decoration.replace({ widget: new MentionWidget(mention.path) }).range(from, to));
+  });
+  return { mentions, decorations: Decoration.set(decorations, true) };
+}
+
+function keepMentionMarkers(mentions: RangeSet<Mention>, doc: EditorState['doc']) {
+  const kept: ReturnType<Mention['range']>[] = [];
+  mentions.between(0, doc.length, (from, to, mention) => {
+    if (doc.sliceString(from, to) === MENTION) kept.push(mention.range(from, to));
+  });
+  return RangeSet.of(kept, true);
+}
+
+function serialize(state: EditorState) {
+  const { mentions } = state.field(mentionField);
+  let cursor = 0;
+  let text = '';
+  mentions.between(0, state.doc.length, (from, to, mention) => {
+    text += state.doc.sliceString(cursor, from) + `@${mention.path}`;
+    cursor = to;
+  });
+  return text + state.doc.sliceString(cursor);
+}
+
+function mentionQuery(state: EditorState): MentionQuery {
+  const selection = state.selection.main;
+  if (!selection.empty) return null;
+  const before = state.doc.sliceString(0, selection.head);
+  const match = /(^|\s)@([^\s@]*)$/.exec(before);
+  return match ? { q: match[2], from: selection.head - match[2].length } : null;
+}
+
+function deleteMentionSelection(view: EditorView, backward: boolean) {
+  const selection = view.state.selection.main;
+  const { mentions } = view.state.field(mentionField);
+  let from = selection.from;
+  let to = selection.to;
+  if (selection.empty) {
+    const targets: { from: number; to: number }[] = [];
+    mentions.between(0, view.state.doc.length, (mentionFrom, mentionTo) => {
+      if ((backward && mentionTo === selection.head) || (!backward && mentionFrom === selection.head)) {
+        targets.push({ from: mentionFrom, to: mentionTo });
+      }
+    });
+    const target = targets[0];
+    if (!target) return false;
+    from = target.from;
+    to = target.to;
+  }
+
+  const removed: StateEffect<{ from: number; path: string }>[] = [];
+  mentions.between(from, to, (mentionFrom, mentionTo, mention) => {
+    if (mentionFrom < to && mentionTo > from) removed.push(removeMention.of({ from: mentionFrom, path: mention.path }));
+  });
+  if (!removed.length) return false;
+  view.dispatch({ changes: { from, to }, effects: removed });
+  return true;
+}
+
+export function MentionComposer({
+  disabled,
+  placeholder: placeholderText,
+  onChange,
+  onMentionChange,
+  onMentionNavigate,
+  onMentionAccept,
+  onMentionDismiss,
+  onShiftTab,
+  onSubmit,
+  mentionListboxId,
+  activeMentionOptionId,
+  mentionOpen,
+  ref,
+}: {
+  disabled: boolean;
+  placeholder: string;
+  onChange: (text: string) => void;
+  onMentionChange: (mention: MentionQuery) => void;
+  onMentionNavigate: (direction: 1 | -1) => void;
+  onMentionAccept: () => boolean;
+  onMentionDismiss: () => void;
+  onShiftTab: () => boolean;
+  onSubmit: (text: string) => boolean;
+  mentionListboxId?: string;
+  activeMentionOptionId?: string;
+  mentionOpen: boolean;
+  ref: React.Ref<MentionComposerHandle>;
+}) {
+  const hostRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView>(null);
+  const disabledRef = useRef(disabled);
+  const onChangeRef = useRef(onChange);
+  const onMentionChangeRef = useRef(onMentionChange);
+  const onMentionNavigateRef = useRef(onMentionNavigate);
+  const onMentionAcceptRef = useRef(onMentionAccept);
+  const onMentionDismissRef = useRef(onMentionDismiss);
+  const onShiftTabRef = useRef(onShiftTab);
+  const onSubmitRef = useRef(onSubmit);
+  const mentionOpenRef = useRef(mentionOpen);
+  const mentionDismissedRef = useRef(false);
+  const editableCompartmentRef = useRef(new Compartment());
+  const placeholderCompartmentRef = useRef(new Compartment());
+
+  disabledRef.current = disabled;
+  onChangeRef.current = onChange;
+  onMentionChangeRef.current = onMentionChange;
+  onMentionNavigateRef.current = onMentionNavigate;
+  onMentionAcceptRef.current = onMentionAccept;
+  onMentionDismissRef.current = onMentionDismiss;
+  onShiftTabRef.current = onShiftTab;
+  onSubmitRef.current = onSubmit;
+  mentionOpenRef.current = mentionOpen;
+
+  function submit() {
+    const view = viewRef.current;
+    if (!view || !onSubmitRef.current(serialize(view.state))) return;
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length } });
+  }
+
+  useImperativeHandle(ref, () => ({
+    focus: () => viewRef.current?.focus(),
+    insertMention: (path, query) => {
+      const view = viewRef.current;
+      if (!view) return;
+      const from = query.from - 1;
+      view.dispatch({
+        changes: { from, to: view.state.selection.main.head, insert: MENTION + ' ' },
+        effects: addMention.of({ from, path }),
+        selection: { anchor: from + MENTION.length + 1 },
+      });
+      view.focus();
+    },
+    submit,
+  }));
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const currentMentionQuery = () => {
+      const view = viewRef.current;
+      return view && mentionOpenRef.current ? mentionQuery(view.state) : null;
+    };
+    const view = new EditorView({
+      state: EditorState.create({
+        extensions: [
+          history(),
+          invertedEffects.of((transaction) => transaction.effects.flatMap((effect) => {
+            if (effect.is(addMention)) return [removeMention.of(effect.value)];
+            if (effect.is(removeMention)) return [addMention.of(effect.value)];
+            return [];
+          })),
+          mentionField,
+          EditorView.lineWrapping,
+          placeholderCompartmentRef.current.of(placeholder(placeholderText)),
+          editableCompartmentRef.current.of(EditorView.editable.of(!disabledRef.current)),
+          keymap.of([
+            {
+              key: 'ArrowDown',
+              run: () => {
+                if (!currentMentionQuery()) return false;
+                onMentionNavigateRef.current(1);
+                return true;
+              },
+            },
+            {
+              key: 'ArrowUp',
+              run: () => {
+                if (!currentMentionQuery()) return false;
+                onMentionNavigateRef.current(-1);
+                return true;
+              },
+            },
+            {
+              key: 'Enter',
+              run: () => {
+                if (currentMentionQuery() && onMentionAcceptRef.current()) return true;
+                if (disabledRef.current) return true;
+                submit();
+                return true;
+              },
+            },
+            {
+              key: 'Tab',
+              run: () => currentMentionQuery() ? onMentionAcceptRef.current() : false,
+            },
+            { key: 'Shift-Tab', run: () => onShiftTabRef.current() },
+            {
+              key: 'Escape',
+              run: () => {
+                if (!currentMentionQuery()) return false;
+                mentionDismissedRef.current = true;
+                onMentionDismissRef.current();
+                return true;
+              },
+            },
+            { key: 'Backspace', run: (view) => deleteMentionSelection(view, true) },
+            { key: 'Delete', run: (view) => deleteMentionSelection(view, false) },
+            ...defaultKeymap,
+            ...historyKeymap,
+          ]),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) {
+              mentionDismissedRef.current = false;
+              onChangeRef.current(serialize(update.state));
+            }
+            if (update.docChanged || update.selectionSet) {
+              onMentionChangeRef.current(mentionDismissedRef.current ? null : mentionQuery(update.state));
+            }
+          }),
+          EditorView.theme({
+            '&': { minHeight: '36px', maxHeight: '160px', font: 'inherit', fontSize: '13px' },
+            '&.cm-focused': { outline: 'none' },
+            '.cm-scroller': { overflow: 'auto', fontFamily: 'inherit', lineHeight: '1.5' },
+            '.cm-content': { minHeight: '30px', padding: '6px 2px 0', caretColor: 'var(--fg)' },
+            '.cm-placeholder': { color: 'var(--muted)' },
+          }),
+          EditorView.contentAttributes.of({ 'aria-label': 'Message agent' }),
+        ],
+      }),
+      parent: host,
+    });
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+  // The editor owns its document; callbacks are kept current in refs.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    viewRef.current?.dispatch({ effects: editableCompartmentRef.current.reconfigure(EditorView.editable.of(!disabled)) });
+  }, [disabled]);
+
+  useEffect(() => {
+    viewRef.current?.dispatch({ effects: placeholderCompartmentRef.current.reconfigure(placeholder(placeholderText)) });
+  }, [placeholderText]);
+
+  useEffect(() => {
+    const input = viewRef.current?.contentDOM;
+    if (!input) return;
+    if (!mentionOpen) {
+      input.removeAttribute('role');
+      input.removeAttribute('aria-autocomplete');
+      input.removeAttribute('aria-haspopup');
+      input.removeAttribute('aria-controls');
+      input.removeAttribute('aria-expanded');
+      input.removeAttribute('aria-activedescendant');
+      return;
+    }
+    input.setAttribute('role', 'combobox');
+    input.setAttribute('aria-autocomplete', 'list');
+    input.setAttribute('aria-haspopup', 'listbox');
+    input.setAttribute('aria-expanded', String(Boolean(mentionListboxId)));
+    if (mentionListboxId) input.setAttribute('aria-controls', mentionListboxId);
+    if (activeMentionOptionId) input.setAttribute('aria-activedescendant', activeMentionOptionId);
+  }, [activeMentionOptionId, mentionListboxId, mentionOpen]);
+
+  return <div ref={hostRef} className="agent-input" />;
+}

--- a/web-src/src/styles/chat.css
+++ b/web-src/src/styles/chat.css
@@ -953,21 +953,18 @@
     .agent-input {
       border: 0;
       background: transparent;
-      resize: none;
       outline: none;
-      font: inherit;
-      font-size: 13px;
-      line-height: 1.5;
       color: var(--fg);
-      /* Grow with content natively (Chromium 123+, Electron 30+): taller
-       * only when the text wraps, up to the max. `rows={1}` is the fallback
-       * height if field-sizing is ever unavailable. The min-height floors
-       * the empty input a touch taller than the button row below it (the
-       * 28px send button) so the composer isn't top-light. */
-      field-sizing: content;
-      min-height: 36px;
-      max-height: 160px;
-      padding: 6px 2px 0;
+    }
+    .agent-file-mention {
+      display: inline-block;
+      padding: 0 4px;
+      border-radius: 4px;
+      background: var(--active);
+      color: var(--fg);
+      line-height: inherit;
+      vertical-align: baseline;
+      white-space: nowrap;
     }
     /* Action bar under the textarea: + … mode / send.
      * A full-width rule separates it from the input — the negative side
@@ -1156,7 +1153,8 @@
       right: 8px;
       bottom: calc(100% - 4px);
       max-height: 220px;
-      overflow-y: auto;
+      overflow: hidden;
+      box-sizing: border-box;
       background: var(--bg);
       border: 1px solid var(--border);
       border-radius: 8px;
@@ -1164,9 +1162,11 @@
       padding: 4px;
       z-index: 30;
     }
+    .agent-mention-list { max-height: 210px; overflow-y: auto; }
     .agent-mention-item {
       display: flex;
-      flex-direction: column;
+      align-items: flex-start;
+      gap: 7px;
       width: 100%;
       border: 0;
       background: transparent;
@@ -1175,6 +1175,9 @@
       border-radius: 5px;
       cursor: pointer;
     }
-    .agent-mention-item:hover { background: var(--hover); }
+    .agent-mention-item:hover,
+    .agent-mention-item.active { background: var(--hover); }
+    .agent-mention-icon { flex: 0 0 auto; width: 14px; height: 14px; margin-top: 2px; color: var(--muted); }
+    .agent-mention-text { display: flex; flex: 1; min-width: 0; flex-direction: column; }
     .agent-mention-name { font-size: 12.5px; color: var(--fg); }
     .agent-mention-path { font-size: 11px; color: var(--muted); }


### PR DESCRIPTION
## Summary

- Add a CodeMirror-backed mention composer with atomic file tokens.
- Add Arrow Up/Down navigation with wrapping, Enter/Tab acceptance, Escape dismissal, pointer sync, and listbox/combobox semantics.
- Keep selected mentions intact when typing after them and insert a separating space automatically.
- Refine the compact picker styling with file icons, active-row state, and scrollable results.

## Screen Recording


https://github.com/user-attachments/assets/e17a8851-6529-4e75-ad79-991821160b64



## Root cause fixed

Mention markers were represented by a one-character document token. CodeMirror's default range mapping expanded the token when text was inserted immediately after it, causing marker validation to remove the mention. The marker now uses a left-biased end boundary.

## Validation

- `npx tsc --noEmit`
- `npx vite build --config web-src/vite.config.ts`

Closes #6