### PR TITLE
feat(agent): orient the built-in panel inside MemFlywheel memory stores

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -303,6 +303,8 @@ It runs the user's installed Agent CLI in the current folder and relies on the s
 
 Each opened folder has one root-level `AGENTS.md` file for durable Agent instructions about that folder. Built-in Codex uses it directly through the normal folder context. Built-in Claude uses a root-level `CLAUDE.md` bridge that contains only `@AGENTS.md`; the bridge is created on first Claude launch if missing. Both files are ordinary Markdown source files, so the user can edit or delete them.
 
+Every session starts with a short orientation preamble (`server/agent-preamble.ts`): the current folder plus the library MCP tool surface. When the opened folder is a [MemFlywheel](https://github.com/iflytek/memflywheel) memory store — a root `MEMORY.md` index plus a `.memflywheel/` trace directory — the preamble also describes the store layout (index cues, typed memory documents, source traces, learned skills) so the agent reads the index first instead of bulk-loading memory files.
+
 Packaged builds resolve the user-installed `claude` and `codex` executables explicitly, including common Homebrew paths, npm global paths, and Windows npm command shims, before launching the built-in panel. This keeps the panel aligned with the user's normal CLI setup instead of depending on optional SDK binaries bundled in `node_modules`.
 
 The key architectural point is:

--- a/server/agent-preamble.ts
+++ b/server/agent-preamble.ts
@@ -16,6 +16,7 @@
  * folders tears the session down), so the live context here — current folder,
  * sibling folders — is always current.
  */
+import fs from 'node:fs';
 import path from 'node:path';
 
 export function buildStashbasePreamble(cwd: string): string {
@@ -30,5 +31,34 @@ export function buildStashbasePreamble(cwd: string): string {
     '- `reindex` refreshes the index after you create, edit, delete, or move files so search reflects the latest content on disk.',
   ];
 
+  const memoryStore = memflywheelStoreLines(cwd);
+  if (memoryStore.length) lines.push('', ...memoryStore);
+
   return lines.join('\n');
+}
+
+/**
+ * MemFlywheel (https://github.com/iflytek/memflywheel) stores agent memory as
+ * ordinary Markdown: a root `MEMORY.md` index over typed memory documents,
+ * with source traces and learned skills alongside. Those files index and
+ * search like any other Markdown, but a bare folder listing invites the model
+ * to bulk-load every memory file. When the opened folder is such a store,
+ * orient the model on the layout so it reads the index first and follows it.
+ *
+ * Detection requires both the index and the `.memflywheel/` trace directory —
+ * a folder that merely contains a MEMORY.md is not a store.
+ */
+function memflywheelStoreLines(cwd: string): string[] {
+  try {
+    if (!fs.statSync(path.join(cwd, 'MEMORY.md')).isFile()) return [];
+    if (!fs.statSync(path.join(cwd, '.memflywheel')).isDirectory()) return [];
+  } catch {
+    return [];
+  }
+  return [
+    'This folder is a MemFlywheel memory store: file-native agent memory kept as Markdown.',
+    '- `MEMORY.md` is the index of memory cues. Read it first and follow its links instead of scanning the folder.',
+    '- Typed subfolders (for example `preference/`, `workflow/`) hold the memory bodies the index points to.',
+    '- `.memflywheel/sources/` holds JSONL source traces behind each memory; `learned-skills/*/SKILL.md` holds learned skills. Open these only when a memory body is not enough.',
+  ];
 }


### PR DESCRIPTION
## What

When the folder opened in StashBase is a [MemFlywheel](https://github.com/iflytek/memflywheel) file-native memory store — a root `MEMORY.md` index plus a `.memflywheel/` trace directory — the built-in agent panel's session preamble now describes the store layout, so the agent reads the index first and follows it to memory bodies, source traces (`.memflywheel/sources/`), and learned skills (`learned-skills/*/SKILL.md`) progressively.

Ordinary folders are unaffected: detection requires both markers, so a folder that merely contains a `MEMORY.md` is not misclassified.

## Why

MemFlywheel stores agent long-term memory as plain Markdown, which makes StashBase a natural way to browse and semantically search it — indexing and `search_library` already work on these stores today with zero changes. The gap is the built-in panel: without orientation it treats the store as a random folder and tends to bulk-load memory files instead of following the `MEMORY.md` cues, which is exactly the progressive-read discipline the store layout is designed for. One small preamble addition fixes that for both the Claude and Codex panels (both go through `buildStashbasePreamble`).

## Changes

- `server/agent-preamble.ts`: detect a MemFlywheel store at cwd (`MEMORY.md` file + `.memflywheel/` directory) and append four orientation lines; sync `fs.statSync` in a try/catch, same pattern as `agent-rules.ts`.
- `design-docs/architecture.md` §8: document the preamble behavior in the same change, per the repo's doc contract.

## Verification

- Smoke-ran the preamble builder both ways (Node `--experimental-strip-types`): a plain folder produces the unchanged 6-line preamble; a folder with `MEMORY.md` + `.memflywheel/` gets the store section appended.
- No new dependencies, no settings surface, no change to agent transport, MCP, indexing, or permissions.

## Context

I'm from the iFlytek Astron open-source community that builds MemFlywheel, and I use both projects — this came out of pointing StashBase at a real memory store. Happy to adjust wording, detection markers, or placement however you prefer.

If you're open to it once this lands, it would be great to see StashBase mentioned in MemFlywheel's adopter thread (iflytek/memflywheel#18) — we'd also gladly link StashBase from the MemFlywheel docs as a way to browse and search memory stores. No obligation either way, of course.
