### PR TITLE
feat(markdown-preview): standardize document rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Test release CI gate
         run: pnpm test:release-gate
 
+      - name: Test renderer
+        run: pnpm test:renderer
+
       - name: Typecheck server + mcp
         run: pnpm exec tsc --noEmit
 

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -137,7 +137,7 @@ Different formats have different read and search paths. The product rule is: kee
 | PDF | Derived Markdown | Derived Markdown |
 | DOCX | Derived HTML | Extracted clean text from derived HTML |
 
-Markdown is edited, read, and indexed directly.
+Markdown is edited, read, and indexed directly. The renderer's read-only preview pipeline, iframe boundary, asset resolution, and navigation behavior are described in [markdown-rendering.md](markdown-rendering.md).
 
 HTML stays as the source file. StashBase extracts clean text from HTML only as an indexing representation, so embedding and change tracking can operate on stable text. When an Agent reads an HTML file, it reads the original HTML.
 

--- a/design-docs/markdown-rendering.md
+++ b/design-docs/markdown-rendering.md
@@ -1,0 +1,233 @@
+# Markdown Rendering
+
+This document describes the current read-only Markdown rendering path in the desktop app. It covers source loading, parsing, iframe installation, styling, navigation, find/highlight behavior, drag-and-drop forwarding, and the preview trust boundary. Markdown indexing and data ownership remain in [architecture.md](architecture.md) and [data-layer.md](data-layer.md).
+
+## 1. Scope and ownership
+
+The renderer recognizes `.md` and `.markdown` files as the `md` viewer format. The source file is the user-visible source of truth and is loaded as text through `GET /api/files/*`. Markdown preview does not read a derived representation and does not participate in indexing or conversion.
+
+The implementation is split across these renderer modules:
+
+- [`web-src/src/markdown.ts`](../web-src/src/markdown.ts) owns Marked configuration, Markdown-to-HTML conversion, heading IDs, and the preview document's inline CSS.
+- [`web-src/src/components/MarkdownPreview.tsx`](../web-src/src/components/MarkdownPreview.tsx) owns iframe installation and preview-specific DOM integration.
+- [`web-src/src/lib/previewIframe.ts`](../web-src/src/lib/previewIframe.ts) injects the local asset base and interprets link and image clicks.
+- [`web-src/src/components/findIframe.ts`](../web-src/src/components/findIframe.ts) implements in-preview find with the CSS Custom Highlight API.
+- [`web-src/src/hooks/useIframeDropForward.ts`](../web-src/src/hooks/useIframeDropForward.ts) forwards operating-system file drops from the iframe to the app window.
+- [`web-src/src/lib/previewMessages.ts`](../web-src/src/lib/previewMessages.ts) validates the source window for preview messages.
+- [`web-src/src/store/AppContext.tsx`](../web-src/src/store/AppContext.tsx) loads source content and owns navigation, pending anchors, pending search highlights, and find-controller registration.
+- [`web-src/src/App.tsx`](../web-src/src/App.tsx) receives preview navigation, image, and external-open messages.
+
+`web-src/src/markdown.ts` also exports `renderMarkdownInline()` for Agent response bodies. Document preview and inline rendering use separate configured `Marked` instances so changes to document parsing cannot alter the chat contract. Inline rendering keeps single-newline line breaks and returns only an HTML fragment rendered in the app DOM. It does not use the Markdown preview iframe, heading-ID pass, preview CSS, asset base, or preview interactions described below.
+
+## 2. View selection and source loading
+
+`server/format.ts` maps both `md` and `markdown` extensions to the `md` format. `GET /api/files/*` accepts Markdown and HTML note paths, reads their source bytes as text, and returns `{ name, format, content, version }`. Binary bundle assets are rejected by that route and remain available only through `/asset/*`.
+
+`AppContext.loadFile()` calls `api.getFile(name)` for Markdown files and stores the returned source content in the open tab. `MainPane` selects between two mutually exclusive Markdown surfaces:
+
+- When the tab is not in edit mode, `MainPane` mounts `MarkdownPreview` with the file's folder-relative name and source content.
+- When the tab is in edit mode, `MainPane` mounts the single-pane CodeMirror `CodeEditor`.
+
+The edit/preview toggle flushes any pending save before leaving edit mode. There is no split source/preview surface and no live-preview renderer.
+
+## 3. Render pipeline
+
+The read-only render path is synchronous until the browser installs the generated iframe document:
+
+```text
+folder-relative name + source Markdown
+  -> renderMarkdown(content)
+       -> documentMarkdown.parse(content)
+       -> heading-ID post-pass
+       -> complete HTML document + inline preview CSS
+  -> injectAssetBase(document, assetBaseUrl(name))
+  -> iframe srcDoc
+  -> native iframe load handler
+       -> install click and keyboard listeners
+       -> mark images as previewable
+       -> apply pending anchor/highlight/find state
+       -> attach file-drop forwarding
+```
+
+`MarkdownPreview` memoizes the complete HTML string by `[name, content]`. A source or path change produces a new `srcDoc` document. `loadedHtmlRef` records which HTML string has completed loading so pending anchors and search highlights are never applied to a stale iframe document.
+
+React's iframe `onLoad` prop is not used. A native `load` listener is installed for every HTML identity, with an immediate `readyState === 'complete'` check to cover the race where parsing finishes before the effect attaches. Cleanup removes listeners from both the iframe and the installed document.
+
+## 4. Markdown parser and emitted HTML
+
+The parser is `marked` 18.0.3. The module owns two isolated parser instances:
+
+```ts
+const documentMarkdown = new Marked({ gfm: true, breaks: false });
+const inlineMarkdown = new Marked({ gfm: true, breaks: true });
+```
+
+`gfm: true` enables Marked's GitHub Flavored Markdown behavior, including tables, strikethrough, task-list markup, and URL/email autolinking. In document preview, a single source newline inside a paragraph remains a soft break and collapses as ordinary HTML whitespace; two trailing spaces or a trailing backslash still emit `<br>`. Inline Agent output keeps `breaks: true`, where a single newline emits `<br>`.
+
+The current preview renders Marked's standard block and inline constructs:
+
+- ATX and Setext headings.
+- Paragraphs with CommonMark soft breaks and explicit hard breaks.
+- Strong, emphasis, and strikethrough.
+- Inline code and fenced or indented code blocks.
+- Ordered, unordered, nested, and task lists.
+- Blockquotes and horizontal rules.
+- Inline and reference links, autolinks, and email links.
+- Images.
+- GFM tables and alignment attributes.
+- Escapes, entities, and raw HTML.
+
+Fenced-code language labels are retained as `language-*` classes. No syntax-highlighting pass runs over those classes.
+
+Marked passes raw HTML through to the generated body. There is no sanitizer in the Markdown conversion path. YAML frontmatter has no preview-specific handling, and the renderer has no implementations for footnotes, wikilinks, embeds, callouts, math, Mermaid, definition lists, emoji shortcodes, MDX, or explicit heading-attribute syntax.
+
+## 5. Heading IDs and anchors
+
+After Marked returns HTML, `renderMarkdown()` runs a regular-expression pass over every `<h1>` through `<h6>`. It strips inline HTML tags from the heading body, decodes a small fixed set of HTML entities, and builds a slug from the resulting text.
+
+Slug generation:
+
+1. Lowercases the text.
+2. Retains Unicode letters, Unicode numbers, spaces, and hyphens.
+3. Removes other punctuation.
+4. Converts whitespace runs to `-`.
+5. Collapses repeated hyphens.
+6. Removes leading and trailing hyphens.
+7. Uses `section` when the result is empty.
+
+The first heading with a slug uses the base ID. Later duplicates append `-1`, `-2`, and so on, skipping any candidate already emitted for another heading base. Both the duplicate counters and the emitted-ID set are local to one document render, so every generated ID is deterministic and unique within that document.
+
+The generated ID is used by same-file links, cross-file links with fragments, outline/search-driven pending anchors, and `scrollIntoView()`. The renderer does not recognize `{#custom-id}` as explicit heading metadata; it remains heading text and contributes to the generated slug.
+
+## 6. Preview document and styles
+
+`renderMarkdown()` returns a complete document:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      ...
+    </style>
+  </head>
+  <body>
+    ...
+  </body>
+</html>
+```
+
+The iframe does not inherit the host page's styles, so all Markdown typography is embedded in this document. The current presentation is a white, Notion-influenced reading surface:
+
+- The body uses a `16px/1.7` system sans-serif stack with CJK fallbacks.
+- Content is centered with a maximum width of `820px` and `32px 56px 80px` padding.
+- Headings use a compact line height, bold weight, and increasing top margins; H1 and H2 have bottom borders.
+- Links use an underlined teal color with a stronger underline on hover.
+- Inline code and code blocks use the system monospace stack and warm/light-gray surfaces.
+- Code blocks scroll horizontally.
+- Blockquotes use a dark left border.
+- Lists, tables, table headers, images, and horizontal rules receive preview-local spacing and borders.
+- Images are limited to the reading-column width and keep their aspect ratio.
+- Images marked previewable use a zoom-in cursor.
+
+The outer `.viewer-shell` fills the main pane, clips overflow, and supplies a white background. Its iframe is absolutely positioned to fill the shell with no border. Scrolling occurs inside the iframe document.
+
+## 7. Relative assets
+
+Before the HTML is assigned to `srcDoc`, `injectAssetBase()` adds a `<base>` element to the generated `<head>`. `assetBaseUrl(name)` derives the base from the Markdown file's parent directory:
+
+```text
+/asset/__window/<window-id>/<encoded-note-directory>/
+```
+
+The window ID is embedded in the path rather than the query string so it propagates to relative image, stylesheet, font, and media URLs. The server strips the reserved `__window/<id>/` prefix before resolving the remaining folder-relative path.
+
+`/asset/*` resolves the target within the current folder and streams it with a known MIME type where available. The route supports images, SVG, CSS, JavaScript, JSON, fonts, PDF, audio, and video. Video formats that require range requests are sent with `sendFile()`; other assets use a read stream. Markdown itself is not fetched through `/asset/*` for rendering—the preview uses the source text already returned by `/api/files/*`.
+
+## 8. Iframe and trust boundary
+
+Markdown preview uses:
+
+```html
+<iframe sandbox="allow-same-origin" srcdoc="..."></iframe>
+```
+
+`allow-same-origin` lets the parent renderer access `contentDocument` and `contentWindow`. The sandbox omits `allow-scripts`, so scripts inside the Markdown document do not execute. The same-origin access is what enables direct click interception, keyboard handling, find ranges, search-result highlights, and file-drop forwarding.
+
+Raw HTML is not sanitized before entering `srcDoc`. The sandbox is therefore the active script-execution boundary, while raw HTML and CSS remain confined to the iframe's document. The generated document has no Content Security Policy.
+
+Messages that can cause navigation, lightbox display, or external opening are accepted only when `event.source` is the app window or the current `#previewFrame` window. Message payloads are type-checked again in `App.tsx`. Image lightbox messages accept only HTTP, HTTPS, data, and blob URLs. External-open messages accept only HTTP and HTTPS URLs.
+
+## 9. Link behavior
+
+The parent installs one delegated click listener on the iframe document. `previewClickHandler()` resolves the nearest image first and otherwise resolves the nearest anchor.
+
+Anchor behavior is based on the raw `href` and the browser-resolved URL:
+
+- `#fragment` sends `stashbase-nav` for the current Markdown path and requested anchor.
+- Same-origin `/asset/*` links ending in `.md`, `.markdown`, `.html`, or `.htm` send `stashbase-nav` with the decoded folder-relative path and optional fragment.
+- Other same-origin `/asset/*` links send `stashbase-open-external`; linked PDFs, media, images, and other assets therefore open through the system external-open path rather than changing the app shell.
+- HTTP and HTTPS links send `stashbase-open-external`.
+- Other schemes are not intercepted by the app-specific handler.
+
+`App.tsx` receives `stashbase-nav` and calls `AppContext.navigateTo()`. A same-file anchor updates the active tab's pending anchor without reloading the file. A different note activates an existing tab or opens a new pinned tab, then stores the pending anchor for the newly mounted preview. Following a note link does not replace the source tab.
+
+External URLs are passed to Electron's `openExternal` bridge when available, with a browser-window fallback. Same-origin asset URLs gain the current window ID as a query parameter when the path does not already carry window context, allowing the external browser request to resolve the correct open folder.
+
+## 10. Images and lightbox
+
+When an iframe document attaches, every image receives `data-stashbase-previewable="true"`. Clicking an image prevents the document's default action and posts `stashbase-preview-image` with its resolved `currentSrc` (or `src`) and alt text.
+
+`App.tsx` validates the message source and URL protocol, then opens the shared application lightbox. This applies to Markdown images and raw HTML `<img>` elements alike. The lightbox behavior lives outside the iframe; the Markdown document itself remains scriptless.
+
+## 11. In-preview find
+
+`MarkdownPreview` registers an iframe-backed `FindController` with `AppContext` for the duration of its mount. The controller resolves the live iframe document on every operation because `srcDoc` replacement invalidates prior `Document` and `Range` objects.
+
+Cmd/Ctrl+F inside the iframe prevents the browser's native find and opens the StashBase find bar. Cmd/Ctrl+G advances to the next result; Shift+Cmd/Ctrl+G moves to the previous result.
+
+Find walks body text nodes while excluding direct text children of `script`, `style`, and `noscript`. It supports literal matching, case sensitivity, and whole-word mode. Matches are stored as DOM `Range` objects and painted with the iframe window's CSS Custom Highlight registry:
+
+- `stash-find` paints non-current matches yellow.
+- `stash-find-current` paints the active match blue with white text.
+
+Next/previous navigation wraps and centers the active range in the iframe. When a content reload finishes while the find bar is open, the current query is scheduled again against the new document. Chromium's CSS Custom Highlight API is required; the Electron versions targeted by the app provide it.
+
+## 12. Search-result chunk highlight
+
+A search result can put `{ chunkText }` into the active tab's `pendingHighlight`. The Markdown preview applies it only after the iframe has loaded the current HTML.
+
+The matching path:
+
+1. Normalizes dashes, curly quotes, non-breaking spaces, zero-width spaces, and whitespace runs in the result text.
+2. Removes common Markdown wrappers, link destinations, images, fenced code, heading prefixes, and blockquote prefixes.
+3. Produces up to three unique 80-character anchors from the beginning, middle, and end of the cleaned text.
+4. Flattens iframe body text into a whitespace-normalized string while retaining a mapping back to each source text-node offset.
+5. Uses the first exact anchor found to construct a DOM `Range`.
+
+The range is painted as `stashbase-chunk`, smoothly centered, and removed after four seconds. The pending highlight is consumed only when a range is found and installed. The implementation uses the CSS Custom Highlight API and has no fallback path.
+
+## 13. File-drop forwarding
+
+An iframe consumes drag events before the app window's global drop handlers can see them. `useIframeDropForward()` attaches `dragover` and `drop` listeners to each live iframe document.
+
+For operating-system file drops it:
+
+1. Prevents the iframe's default handling.
+2. Collects `FileSystemEntry` objects synchronously from `DataTransfer.items` before Chromium invalidates them.
+3. Dispatches `stashbase:iframe-drop` on the parent window.
+
+The application's global drag/drop path receives that event and processes it the same way as a drop elsewhere in the app.
+
+## 14. Relationship to editing, search, and indexing
+
+Markdown preview is a renderer-only projection of the current source content:
+
+- Editing happens only in CodeMirror and saves source Markdown through `/api/files/*`.
+- Leaving edit mode flushes the pending save before remounting preview.
+- Preview HTML, generated heading IDs, injected styles, find styles, and highlight ranges are ephemeral and never written into the source file.
+- Source Markdown, not preview HTML, is the index input.
+- Search results refer back to the source Markdown path; pending anchors and chunk text are renderer navigation state stored on the open tab.
+
+The parser, preview document, and iframe interactions are entirely renderer-side. The server participates only in source loading/saving and folder-scoped asset streaming.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "build:desktop": "pnpm build && pnpm build:python-sidecar",
     "setup:python": "node scripts/setup-python.mjs",
     "test:python": "node scripts/test-python.mjs",
+    "test:renderer": "node --import tsx --test web-src/src/markdown.test.ts",
     "test:release-gate": "node --test scripts/require-green-ci.test.mjs",
     "prestart": "pnpm build:web",
     "electron": "electron .",

--- a/web-src/src/markdown.test.ts
+++ b/web-src/src/markdown.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { renderMarkdown, renderMarkdownInline } from './markdown.ts';
+
+test('document soft breaks collapse while inline soft breaks remain visible', () => {
+  const document = renderMarkdown('first line\nsecond line');
+  const inline = renderMarkdownInline('first line\nsecond line');
+
+  assert.match(document, /<p>first line\nsecond line<\/p>/);
+  assert.doesNotMatch(document, /<br\s*\/?\s*>/);
+  assert.match(inline, /first line<br>second line/);
+});
+
+test('document hard-break syntax creates line breaks', () => {
+  const document = renderMarkdown('spaces  \nbackslash\\\nnext');
+
+  assert.match(document, /<p>spaces<br>backslash<br>next<\/p>/);
+});
+
+test('document renderer preserves the GFM block baseline', () => {
+  const document = renderMarkdown([
+    '- item',
+    '- [x] done',
+    '',
+    '| Left | Right |',
+    '| --- | --- |',
+    '| one | two |',
+  ].join('\n'));
+
+  assert.match(document, /<ul>[\s\S]*<li>item<\/li>/);
+  assert.match(document, /<input checked="" disabled="" type="checkbox"> done/);
+  assert.match(document, /<table>[\s\S]*<th>Left<\/th>[\s\S]*<td>two<\/td>/);
+});
+
+test('document renderer preserves links, images, escapes, entities, and code', () => {
+  const document = renderMarkdown([
+    '[link](https://example.com) ![alt](image.png) \\*literal\\* &amp; `inline`',
+    '',
+    '```ts',
+    'const answer = 42;',
+    '```',
+    '',
+    '    indented code',
+  ].join('\n'));
+
+  assert.match(document, /<a href="https:\/\/example\.com">link<\/a>/);
+  assert.match(document, /<img src="image\.png" alt="alt">/);
+  assert.match(document, /\*literal\* &amp; <code>inline<\/code>/);
+  assert.match(document, /<pre><code class="language-ts">const answer = 42;\n<\/code><\/pre>/);
+  assert.match(document, /<pre><code>indented code\n<\/code><\/pre>/);
+});
+
+test('document headings have deterministic duplicate-safe Unicode anchors', () => {
+  const document = renderMarkdown('# Café 世界\n\n# Café 世界\n\n# !!!\n\n# !!!');
+
+  assert.match(document, /<h1 id="café-世界">Café 世界<\/h1>/);
+  assert.match(document, /<h1 id="café-世界-1">Café 世界<\/h1>/);
+  assert.match(document, /<h1 id="section">!!!<\/h1>/);
+  assert.match(document, /<h1 id="section-1">!!!<\/h1>/);
+});
+
+test('document heading anchors avoid collisions with generated suffixes', () => {
+  const document = renderMarkdown('# Foo\n\n# Foo-1\n\n# Foo');
+
+  assert.match(document, /<h1 id="foo">Foo<\/h1>/);
+  assert.match(document, /<h1 id="foo-1">Foo-1<\/h1>/);
+  assert.match(document, /<h1 id="foo-2">Foo<\/h1>/);
+});

--- a/web-src/src/markdown.ts
+++ b/web-src/src/markdown.ts
@@ -3,36 +3,32 @@
  * legacy `editor-src/code-editor.js:renderMarkdown` so visual parity
  * is preserved across the migration.
  *
- * Headings get stable `id="h-N"` attributes so in-doc anchor links can
- * scroll-to via fragment nav. Styles are inlined because the iframe is
- * sandboxed and wouldn't inherit the host page's CSS anyway.
+ * Headings get stable, duplicate-safe slug IDs so in-doc anchor links can
+ * scroll to fragment targets. Styles are inlined because the iframe is
+ * sandboxed and would not inherit the host page's CSS anyway.
  */
-import { marked } from 'marked';
+import { Marked } from 'marked';
 
-// `breaks: true` makes single newlines render as <br> instead of
-// collapsing to folders. Matches GitHub / Obsidian default and "what you
-// see in the editor is what you see in the preview" — important for
-// transcripts and other line-per-thought notes where the author meant
-// the line break literally. Prose with soft-wrap at 72 columns is
-// uncommon enough in this app's audience to make it the right trade.
-marked.use({ gfm: true, breaks: true });
+const documentMarkdown = new Marked({ gfm: true, breaks: false });
+const inlineMarkdown = new Marked({ gfm: true, breaks: true });
 
 /** Markdown → HTML *fragment* (no `<html>`/`<style>` wrapper), for
  *  rendering inline inside the app's own DOM — chat bubbles use this so
  *  assistant prose, code blocks, and lists render in place rather than
  *  in a sandboxed iframe. Styling comes from the host page's CSS. */
 export function renderMarkdownInline(md: string): string {
-  return marked.parse(md ?? '', { async: false }) as string;
+  return inlineMarkdown.parse(md ?? '', { async: false }) as string;
 }
 
 export function renderMarkdown(md: string): string {
-  let html = marked.parse(md ?? '', { async: false }) as string;
-  const taken = new Map<string, number>();
+  let html = documentMarkdown.parse(md ?? '', { async: false }) as string;
+  const nextSuffix = new Map<string, number>();
+  const usedSlugs = new Set<string>();
   html = html.replace(
     /<h([1-6])(\s[^>]*)?>([\s\S]*?)<\/h\1>/g,
     (_match, level: string, attrs: string | undefined, inner: string) => {
       const text = stripInlineTags(inner).trim();
-      const id = nextSlug(text, taken);
+      const id = nextSlug(text, nextSuffix, usedSlugs);
       return `<h${level} id="${id}"${attrs ?? ''}>${inner}</h${level}>`;
     },
   );
@@ -51,11 +47,21 @@ export function slugifyHeading(text: string): string {
     .replace(/^-|-$/g, '');
 }
 
-function nextSlug(text: string, taken: Map<string, number>): string {
+function nextSlug(
+  text: string,
+  nextSuffix: Map<string, number>,
+  usedSlugs: Set<string>,
+): string {
   const base = slugifyHeading(text) || 'section';
-  const n = taken.get(base) ?? 0;
-  taken.set(base, n + 1);
-  return n === 0 ? base : `${base}-${n}`;
+  let suffix = nextSuffix.get(base) ?? 0;
+  let candidate = suffix === 0 ? base : `${base}-${suffix}`;
+  while (usedSlugs.has(candidate)) {
+    suffix += 1;
+    candidate = `${base}-${suffix}`;
+  }
+  nextSuffix.set(base, suffix + 1);
+  usedSlugs.add(candidate);
+  return candidate;
 }
 
 function stripInlineTags(html: string): string {
@@ -124,4 +130,3 @@ img { max-width: 100%; height: auto; border-radius: 3px; }
 img[data-stashbase-previewable="true"] { cursor: zoom-in; }
 hr { border: 0; border-top: 1px solid rgb(236, 238, 241); margin: 1em 0; }
 `;
-


### PR DESCRIPTION
## Summary

- isolate document Markdown parsing from inline and chat rendering
- use CommonMark soft-break behavior in document previews while preserving explicit hard breaks
- keep GFM tables, task lists, links, images, code, escapes, and entities covered by renderer tests
- preserve deterministic, duplicate-safe Unicode heading anchors, including suffix collisions
- document the Markdown preview pipeline and run renderer tests in CI on Ubuntu and Windows

## Why

Document preview previously shared a process-global Marked configuration with inline and chat output. The shared breaks setting forced ordinary source newlines to render as line breaks and allowed preview changes to alter the chat contract.

## Validation

- pnpm test:renderer
- pnpm test:release-gate
- pnpm test:python
- pnpm exec tsc --noEmit
- pnpm exec tsc --noEmit -p web-src/tsconfig.json
- pnpm build

Closes #18