### PR TITLE
feat(markdown-preview): sanitize raw Markdown HTML

### DIFF
--- a/design-docs/markdown-rendering.md
+++ b/design-docs/markdown-rendering.md
@@ -8,7 +8,7 @@ The renderer recognizes `.md` and `.markdown` files as the `md` viewer format. T
 
 The implementation is split across these renderer modules:
 
-- [`web-src/src/markdown.ts`](../web-src/src/markdown.ts) owns Marked configuration, Markdown-to-HTML conversion, heading IDs, and the preview document's inline CSS.
+- [`web-src/src/markdown.ts`](../web-src/src/markdown.ts) owns Marked configuration, Markdown-to-HTML conversion, the document allowlist, heading IDs, and the preview document's inline CSS.
 - [`web-src/src/components/MarkdownPreview.tsx`](../web-src/src/components/MarkdownPreview.tsx) owns iframe installation and preview-specific DOM integration.
 - [`web-src/src/lib/previewIframe.ts`](../web-src/src/lib/previewIframe.ts) injects the local asset base and interprets link and image clicks.
 - [`web-src/src/components/findIframe.ts`](../web-src/src/components/findIframe.ts) implements in-preview find with the CSS Custom Highlight API.
@@ -38,6 +38,7 @@ The read-only render path is synchronous until the browser installs the generate
 folder-relative name + source Markdown
   -> renderMarkdown(content)
        -> documentMarkdown.parse(content)
+       -> sanitize parsed body fragment
        -> heading-ID post-pass
        -> complete HTML document + inline preview CSS
   -> injectAssetBase(document, assetBaseUrl(name))
@@ -75,15 +76,15 @@ The current preview renders Marked's standard block and inline constructs:
 - Inline and reference links, autolinks, and email links.
 - Images.
 - GFM tables and alignment attributes.
-- Escapes, entities, and raw HTML.
+- Escapes, entities, and allowlisted raw HTML.
 
 Fenced-code language labels are retained as `language-*` classes. No syntax-highlighting pass runs over those classes.
 
-Marked passes raw HTML through to the generated body. There is no sanitizer in the Markdown conversion path. YAML frontmatter has no preview-specific handling, and the renderer has no implementations for footnotes, wikilinks, embeds, callouts, math, Mermaid, definition lists, emoji shortcodes, MDX, or explicit heading-attribute syntax.
+Marked passes raw HTML into the parsed body, then `sanitize-html` applies a document-oriented allowlist before the preview document is assembled. It preserves ordinary structural and presentational elements, including tables, links, images, `details`, `summary`, `kbd`, `mark`, `sub`, and `sup`. It removes scripts, styles, frames and embedded content, forms, metadata, event-handler and inline-style attributes, frame targets, and non-HTTP(S) image protocols. Relative URLs remain valid; links additionally allow `mailto:`. Task-list inputs are normalized to disabled checkboxes. YAML frontmatter has no preview-specific handling, and the renderer has no implementations for footnotes, wikilinks, embeds, callouts, math, Mermaid, definition lists, emoji shortcodes, MDX, or explicit heading-attribute syntax.
 
 ## 5. Heading IDs and anchors
 
-After Marked returns HTML, `renderMarkdown()` runs a regular-expression pass over every `<h1>` through `<h6>`. It strips inline HTML tags from the heading body, decodes a small fixed set of HTML entities, and builds a slug from the resulting text.
+After Marked returns HTML and the body fragment is sanitized, `renderMarkdown()` runs a regular-expression pass over every `<h1>` through `<h6>`. It strips inline HTML tags from the heading body, decodes a small fixed set of HTML entities, and builds a slug from the resulting text. Any author-supplied heading `id` is removed before the generated ID is installed.
 
 Slug generation:
 
@@ -141,7 +142,7 @@ Before the HTML is assigned to `srcDoc`, `injectAssetBase()` adds a `<base>` ele
 /asset/__window/<window-id>/<encoded-note-directory>/
 ```
 
-The window ID is embedded in the path rather than the query string so it propagates to relative image, stylesheet, font, and media URLs. The server strips the reserved `__window/<id>/` prefix before resolving the remaining folder-relative path.
+The window ID is embedded in the path rather than the query string so it propagates to relative image and link URLs retained by the sanitizer. The server strips the reserved `__window/<id>/` prefix before resolving the remaining folder-relative path.
 
 `/asset/*` resolves the target within the current folder and streams it with a known MIME type where available. The route supports images, SVG, CSS, JavaScript, JSON, fonts, PDF, audio, and video. Video formats that require range requests are sent with `sendFile()`; other assets use a read stream. Markdown itself is not fetched through `/asset/*` for rendering—the preview uses the source text already returned by `/api/files/*`.
 
@@ -155,7 +156,7 @@ Markdown preview uses:
 
 `allow-same-origin` lets the parent renderer access `contentDocument` and `contentWindow`. The sandbox omits `allow-scripts`, so scripts inside the Markdown document do not execute. The same-origin access is what enables direct click interception, keyboard handling, find ranges, search-result highlights, and file-drop forwarding.
 
-Raw HTML is not sanitized before entering `srcDoc`. The sandbox is therefore the active script-execution boundary, while raw HTML and CSS remain confined to the iframe's document. The generated document has no Content Security Policy.
+Raw HTML is sanitized before entering `srcDoc`. Sanitization removes executable markup, unsafe URL protocols, embedded content, and document-level navigation vectors; the scriptless iframe remains an independent execution boundary. The generated document has no Content Security Policy. The trusted preview stylesheet and asset `<base>` are added outside the sanitized fragment.
 
 Messages that can cause navigation, lightbox display, or external opening are accepted only when `event.source` is the app window or the current `#previewFrame` window. Message payloads are type-checked again in `App.tsx`. Image lightbox messages accept only HTTP, HTTPS, data, and blob URLs. External-open messages accept only HTTP and HTTPS URLs.
 

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "pdfjs-dist": "^5.7.284",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "sanitize-html": "^2.17.6",
     "ws": "^8.20.1"
   },
   "devDependencies": {
@@ -225,6 +226,7 @@
     "@types/node": "^22.10.5",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/sanitize-html": "^2.16.1",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^9.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      sanitize-html:
+        specifier: ^2.17.6
+        version: 2.17.6
       ws:
         specifier: ^8.20.1
         version: 8.20.1
@@ -96,6 +99,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@types/sanitize-html':
+        specifier: ^2.16.1
+        version: 2.16.1
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -925,6 +931,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/sanitize-html@2.16.1':
+    resolution: {integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==}
+
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
 
@@ -1329,6 +1338,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -1353,6 +1365,10 @@ packages:
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   defer-to-connect@2.0.1:
     resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
@@ -1399,6 +1415,35 @@ packages:
     engines: {node: '>=8'}
     os: [darwin]
     hasBin: true
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -1452,6 +1497,18 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -1719,6 +1776,13 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -1810,6 +1874,10 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -1894,6 +1962,9 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+
+  launder@1.7.1:
+    resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
 
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
@@ -2185,6 +2256,9 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
+  parse-srcset@1.0.2:
+    resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2382,6 +2456,10 @@ packages:
 
   sanitize-filename@1.6.4:
     resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
+
+  sanitize-html@2.17.6:
+    resolution: {integrity: sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==}
+    engines: {node: '>=22.12.0'}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -3501,6 +3579,10 @@ snapshots:
     dependencies:
       '@types/node': 22.19.19
 
+  '@types/sanitize-html@2.16.1':
+    dependencies:
+      htmlparser2: 10.1.0
+
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
@@ -3961,6 +4043,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  dayjs@1.11.21: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -3974,6 +4058,8 @@ snapshots:
       mimic-response: 3.1.0
 
   deep-extend@0.6.0: {}
+
+  deepmerge@4.3.1: {}
 
   defer-to-connect@2.0.1: {}
 
@@ -4033,6 +4119,42 @@ snapshots:
       smart-buffer: 4.2.0
       verror: 1.10.1
     optional: true
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
+  domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -4122,6 +4244,12 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  entities@4.5.0: {}
+
+  entities@7.0.1: {}
+
+  entities@8.0.0: {}
+
   env-paths@2.2.1: {}
 
   err-code@2.0.3: {}
@@ -4206,8 +4334,7 @@ snapshots:
 
   escape-html@1.0.3: {}
 
-  escape-string-regexp@4.0.0:
-    optional: true
+  escape-string-regexp@4.0.0: {}
 
   esprima@4.0.1: {}
 
@@ -4520,6 +4647,20 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
+
   http-cache-semantics@4.2.0: {}
 
   http-errors@2.0.1:
@@ -4610,6 +4751,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-plain-object@5.0.0: {}
+
   is-promise@4.0.0: {}
 
   isarray@1.0.0: {}
@@ -4683,6 +4826,10 @@ snapshots:
       json-buffer: 3.0.1
 
   kind-of@6.0.3: {}
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.21
 
   lazy-val@1.0.5: {}
 
@@ -4921,6 +5068,8 @@ snapshots:
 
   pako@1.0.11: {}
 
+  parse-srcset@1.0.2: {}
+
   parseurl@1.3.3: {}
 
   path-is-absolute@1.0.1: {}
@@ -5149,6 +5298,16 @@ snapshots:
   sanitize-filename@1.6.4:
     dependencies:
       truncate-utf8-bytes: 1.0.2
+
+  sanitize-html@2.17.6:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 12.0.0
+      is-plain-object: 5.0.0
+      launder: 1.7.1
+      parse-srcset: 1.0.2
+      postcss: 8.5.14
 
   sax@1.6.0: {}
 

--- a/web-src/src/markdown.test.ts
+++ b/web-src/src/markdown.test.ts
@@ -15,7 +15,7 @@ test('document soft breaks collapse while inline soft breaks remain visible', ()
 test('document hard-break syntax creates line breaks', () => {
   const document = renderMarkdown('spaces  \nbackslash\\\nnext');
 
-  assert.match(document, /<p>spaces<br>backslash<br>next<\/p>/);
+  assert.match(document, /<p>spaces<br\s*\/>backslash<br\s*\/>next<\/p>/);
 });
 
 test('document renderer preserves the GFM block baseline', () => {
@@ -29,7 +29,11 @@ test('document renderer preserves the GFM block baseline', () => {
   ].join('\n'));
 
   assert.match(document, /<ul>[\s\S]*<li>item<\/li>/);
-  assert.match(document, /<input checked="" disabled="" type="checkbox"> done/);
+  const checkbox = document.match(/<input\b[^>]*>/)?.[0] ?? '';
+  assert.match(checkbox, /\btype="checkbox"/);
+  assert.match(checkbox, /\bchecked(?:="")?/);
+  assert.match(checkbox, /\bdisabled(?:="")?/);
+  assert.match(document, /\/?> done/);
   assert.match(document, /<table>[\s\S]*<th>Left<\/th>[\s\S]*<td>two<\/td>/);
 });
 
@@ -45,7 +49,7 @@ test('document renderer preserves links, images, escapes, entities, and code', (
   ].join('\n'));
 
   assert.match(document, /<a href="https:\/\/example\.com">link<\/a>/);
-  assert.match(document, /<img src="image\.png" alt="alt">/);
+  assert.match(document, /<img src="image\.png" alt="alt"\s*\/>/);
   assert.match(document, /\*literal\* &amp; <code>inline<\/code>/);
   assert.match(document, /<pre><code class="language-ts">const answer = 42;\n<\/code><\/pre>/);
   assert.match(document, /<pre><code>indented code\n<\/code><\/pre>/);
@@ -66,4 +70,60 @@ test('document heading anchors avoid collisions with generated suffixes', () => 
   assert.match(document, /<h1 id="foo">Foo<\/h1>/);
   assert.match(document, /<h1 id="foo-1">Foo-1<\/h1>/);
   assert.match(document, /<h1 id="foo-2">Foo<\/h1>/);
+});
+
+test('document renderer removes executable and navigation-breaking HTML', () => {
+  const document = renderMarkdown(`
+<script>alert('script')</script>
+<style>body { display: none }</style>
+<iframe src="https://example.com"></iframe>
+<object data="https://example.com/payload"></object>
+<embed src="https://example.com/payload">
+<base href="https://example.com/">
+<meta http-equiv="refresh" content="0;url=https://example.com">
+<form action="https://example.com"><button type="submit">Leave</button></form>
+<a href="javascript:alert('link')" target="_top" onclick="alert('click')">unsafe link</a>
+<a href="file:///etc/passwd">unsafe file</a>
+<p style="position:fixed" onmouseover="alert('hover')">styled text</p>
+<img src="javascript:alert('image')" onerror="alert('image error')">
+<img src="data:text/html,<script>alert('data')</script>">
+<img src="blob:https://example.com/unsafe">
+`);
+
+  const body = document.match(/<body>([\s\S]*)<\/body>/)?.[1] ?? '';
+  assert.doesNotMatch(body, /<(?:script|style|iframe|object|embed|base|form|button)\b/i);
+  assert.doesNotMatch(body, /<meta\b[^>]*http-equiv/i);
+  assert.doesNotMatch(body, /\s(?:onerror|onclick|onmouseover|style|target)=/i);
+  assert.doesNotMatch(body, /(?:javascript:|file:|data:|blob:)/i);
+  assert.match(body, />unsafe link<\/a>/);
+  assert.match(body, />unsafe file<\/a>/);
+  assert.match(body, /<img\s*\/>|<img>/);
+});
+
+test('document renderer preserves ordinary HTML and safe URLs', () => {
+  const document = renderMarkdown(`
+# Document
+
+| Name | Value |
+| --- | --- |
+| One | Two |
+
+<details open><summary>More</summary><p>Use <kbd>Cmd</kbd> + <mark>K</mark>, H<sub>2</sub>O, and x<sup>2</sup>.</p></details>
+
+[Relative note](other.md#section)
+
+![Relative image](images/example.png)
+
+- [x] Complete
+`);
+
+  assert.match(document, /<h1 id="document">Document<\/h1>/);
+  assert.match(document, /<table>/);
+  assert.match(document, /<details open(?:="")?><summary>More<\/summary>/);
+  assert.match(document, /<kbd>Cmd<\/kbd>/);
+  assert.match(document, /<mark>K<\/mark>/);
+  assert.match(document, /H<sub>2<\/sub>O/);
+  assert.match(document, /x<sup>2<\/sup>/);
+  assert.match(document, /href="other\.md#section"/);
+  assert.match(document, /src="images\/example\.png"/);
 });

--- a/web-src/src/markdown.ts
+++ b/web-src/src/markdown.ts
@@ -8,6 +8,7 @@
  * sandboxed and would not inherit the host page's CSS anyway.
  */
 import { Marked } from 'marked';
+import sanitizeHtml from 'sanitize-html';
 
 const documentMarkdown = new Marked({ gfm: true, breaks: false });
 const inlineMarkdown = new Marked({ gfm: true, breaks: true });
@@ -22,6 +23,7 @@ export function renderMarkdownInline(md: string): string {
 
 export function renderMarkdown(md: string): string {
   let html = documentMarkdown.parse(md ?? '', { async: false }) as string;
+  html = sanitizeHtml(html, MARKDOWN_SANITIZE_OPTIONS);
   const nextSuffix = new Map<string, number>();
   const usedSlugs = new Set<string>();
   html = html.replace(
@@ -29,11 +31,59 @@ export function renderMarkdown(md: string): string {
     (_match, level: string, attrs: string | undefined, inner: string) => {
       const text = stripInlineTags(inner).trim();
       const id = nextSlug(text, nextSuffix, usedSlugs);
-      return `<h${level} id="${id}"${attrs ?? ''}>${inner}</h${level}>`;
+      const safeAttrs = (attrs ?? '').replace(/\sid=(?:"[^"]*"|'[^']*'|[^\s>]+)/i, '');
+      return `<h${level} id="${id}"${safeAttrs}>${inner}</h${level}>`;
     },
   );
   return `<!doctype html><html><head><meta charset="utf-8"><style>${PREVIEW_CSS}</style></head><body>${html}</body></html>`;
 }
+
+const MARKDOWN_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    'a', 'abbr', 'address', 'article', 'aside', 'b', 'blockquote', 'br',
+    'caption', 'cite', 'code', 'col', 'colgroup', 'dd', 'del', 'details',
+    'div', 'dl', 'dt', 'em', 'figcaption', 'figure', 'h1', 'h2', 'h3',
+    'h4', 'h5', 'h6', 'hr', 'i', 'img', 'input', 'ins', 'kbd', 'li',
+    'main', 'mark', 'ol', 'p', 'pre', 'q', 's', 'samp', 'section', 'small',
+    'span', 'strong', 'sub', 'summary', 'sup', 'table', 'tbody', 'td',
+    'tfoot', 'th', 'thead', 'tr', 'u', 'ul', 'var',
+  ],
+  allowedAttributes: {
+    '*': ['id', 'title', 'dir', 'lang', 'aria-*'],
+    a: ['href'],
+    blockquote: ['cite'],
+    code: ['class'],
+    col: ['span'],
+    colgroup: ['span'],
+    del: ['cite', 'datetime'],
+    details: ['open'],
+    img: ['src', 'alt', 'width', 'height', 'loading'],
+    input: ['type', 'checked', 'disabled'],
+    ins: ['cite', 'datetime'],
+    li: ['class', 'value'],
+    ol: ['start', 'reversed', 'type'],
+    q: ['cite'],
+    td: ['colspan', 'rowspan', 'headers', 'align'],
+    th: ['colspan', 'rowspan', 'headers', 'scope', 'align'],
+    ul: ['class'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedSchemesByTag: {
+    img: ['http', 'https'],
+  },
+  allowProtocolRelative: false,
+  disallowedTagsMode: 'discard',
+  transformTags: {
+    input: (_tagName, attributes) => ({
+      tagName: 'input',
+      attribs: {
+        type: 'checkbox',
+        disabled: '',
+        ...(Object.hasOwn(attributes, 'checked') ? { checked: '' } : {}),
+      },
+    }),
+  },
+};
 
 /** Kebab-case heading slug. Mirrors GitHub's approach: lowercase, drop
  *  punctuation, collapse folders to dashes. Cross-file anchor links use


### PR DESCRIPTION
## Summary

- sanitize raw Markdown HTML with a document-oriented allowlist before it enters the preview document
- preserve ordinary structural and presentational HTML while removing executable markup, embedded content, unsafe protocols, and navigation-breaking vectors
- retain the existing scriptless iframe as an independent defense
- add removal and preservation regression tests and update the Markdown rendering design documentation

## Why

Marked passes raw HTML through its parser. The scriptless iframe prevents script execution, but raw styles, embedded documents, unsafe URLs, event handlers, and document-level navigation markup could still reach the reader. Sanitizing the parsed body fragment adds a separate boundary without weakening normal Markdown rendering.

## Impact

Markdown preview continues to support tables, links, images, details/summary, keyboard and highlight markup, subscript, superscript, GFM task lists, relative assets, and generated heading anchors. Unsafe raw HTML is removed before the trusted preview stylesheet and asset base are added.

## Validation

- `pnpm test:renderer`
- `npx tsc --noEmit`
- `npx tsc --noEmit -p web-src/tsconfig.json`
- `npx vite build --config web-src/vite.config.ts`

Closes #19
