### PR TITLE
feat(markdown-preview): hide frontmatter and render alerts

### DIFF
--- a/design-docs/markdown-rendering.md
+++ b/design-docs/markdown-rendering.md
@@ -66,7 +66,7 @@ const documentMarkdown = new Marked({
   gfm: true,
   breaks: false,
 });
-documentMarkdown.use(markedFootnote(), gfmHeadingId());
+documentMarkdown.use(markedFootnote({ prefixId: 'footnote:' }), gfmHeadingId(), markedAlert());
 const inlineMarkdown = new Marked({ gfm: true, breaks: true });
 ```
 
@@ -85,11 +85,13 @@ The current preview renders Marked's standard block and inline constructs:
 - GFM tables and alignment attributes.
 - Escapes, entities, and allowlisted raw HTML.
 
-Document preview additionally recognizes `marked-footnote`'s GFM `[^label]` references and `[^label]: definition` blocks. Referenced definitions appear in one trailing semantic footnote section. Its `footnote:` ID prefix is disjoint from GitHub heading slugs, so footnote targets cannot collide with generated heading anchors. The package generates a screen-reader-only section label, reference and backlink data attributes, unique repeated-reference IDs, and backlinks to every originating reference. This extension exists only on the document parser, so inline Agent output treats footnote syntax as ordinary text.
+Document preview removes valid, explicitly closed leading YAML frontmatter before parsing. It leaves malformed or unterminated delimiters as visible source. It additionally recognizes `marked-footnote`'s GFM `[^label]` references and `[^label]: definition` blocks. Referenced definitions appear in one trailing semantic footnote section. Its `footnote:` ID prefix is disjoint from GitHub heading slugs, so footnote targets cannot collide with generated heading anchors. The package generates a screen-reader-only section label, reference and backlink data attributes, unique repeated-reference IDs, and backlinks to every originating reference. This extension exists only on the document parser, so inline Agent output treats footnote syntax as ordinary text.
+
+The document parser also uses `marked-alert` for standard GitHub alert blockquotes: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, and `CAUTION`. Their package-native icon and title markup survives the sanitizer; the outer alert receives a readable landmark label and preview-local color treatment. Alert parsing and styling are document-only, so Agent-message Markdown keeps the source blockquote syntax.
 
 Fenced-code language labels are retained as `language-*` classes. No syntax-highlighting pass runs over those classes.
 
-Marked passes raw HTML into the parsed body, then `sanitize-html` applies a document-oriented allowlist before the preview document is assembled. It preserves ordinary structural and presentational elements, including tables, links, images, `details`, `summary`, `kbd`, `mark`, `sub`, and `sup`. It removes scripts, styles, frames and embedded content, forms, metadata, event-handler and inline-style attributes, frame targets, and non-HTTP(S) image protocols. Relative URLs remain valid; links additionally allow `mailto:`. Task-list inputs are normalized to disabled checkboxes. YAML frontmatter has no preview-specific handling, and the renderer has no implementations for wikilinks, embeds, callouts, math, Mermaid, definition lists, emoji shortcodes, MDX, or explicit heading-attribute syntax.
+Marked passes raw HTML into the parsed body, then `sanitize-html` applies a document-oriented allowlist before the preview document is assembled. It preserves ordinary structural and presentational elements, including tables, links, images, `details`, `summary`, `kbd`, `mark`, `sub`, and `sup`, plus the restricted SVG elements and classes emitted by `marked-alert`. It removes scripts, styles, frames and embedded content, forms, metadata, event-handler and inline-style attributes, frame targets, and non-HTTP(S) image protocols. Relative URLs remain valid; links additionally allow `mailto:`. Task-list inputs are normalized to disabled checkboxes. The renderer has no implementations for wikilinks, embeds, math, Mermaid, definition lists, emoji shortcodes, MDX, or explicit heading-attribute syntax.
 
 ## 5. Heading IDs and anchors
 
@@ -125,7 +127,7 @@ The iframe does not inherit the host page's styles, so all Markdown typography i
 - Footnote references use compact superscript links. The trailing footnote section uses smaller muted text, highlights the targeted entry, and gives references and backlinks a visible keyboard-focus outline.
 - Inline code and code blocks use the system monospace stack and warm/light-gray surfaces.
 - Code blocks scroll horizontally.
-- Blockquotes use a dark left border.
+- Blockquotes use a dark left border. GitHub alert blocks use preview-local colored borders, backgrounds, icons, and readable titles.
 - Lists, tables, table headers, images, and horizontal rules receive preview-local spacing and borders.
 - Images are limited to the reading-column width and keep their aspect ratio.
 - Images marked previewable use a zoom-in cursor.

--- a/package.json
+++ b/package.json
@@ -210,10 +210,10 @@
     "better-sqlite3": "^12.10.0",
     "codemirror": "^6.0.2",
     "express": "^4.21.2",
-    "gray-matter": "^4.0.3",
     "github-slugger": "^2.0.0",
     "mammoth": "^1.12.0",
     "marked": "^18.0.3",
+    "marked-alert": "2.1.2",
     "marked-footnote": "^1.4.0",
     "marked-gfm-heading-id": "^4.1.4",
     "multer": "^1.4.5-lts.1",
@@ -221,7 +221,8 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "sanitize-html": "^2.17.6",
-    "ws": "^8.20.1"
+    "ws": "^8.20.1",
+    "yaml": "2.9.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,15 +56,15 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
-      gray-matter:
-        specifier: ^4.0.3
-        version: 4.0.3
       mammoth:
         specifier: ^1.12.0
         version: 1.12.0
       marked:
         specifier: ^18.0.3
         version: 18.0.3
+      marked-alert:
+        specifier: 2.1.2
+        version: 2.1.2(marked@18.0.3)
       marked-footnote:
         specifier: ^1.4.0
         version: 1.4.0(marked@18.0.3)
@@ -89,6 +89,9 @@ importers:
       ws:
         specifier: ^8.20.1
         version: 8.20.1
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -116,7 +119,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))
+        version: 6.0.1(vite@8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -140,7 +143,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.12
-        version: 8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)
+        version: 8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
     optionalDependencies:
       '@vscode/ripgrep-darwin-arm64':
         specifier: 1.18.0
@@ -1566,11 +1569,6 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -1603,10 +1601,6 @@ packages:
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
-
-  extend-shallow@2.0.1:
-    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
-    engines: {node: '>=0.10.0'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -1757,10 +1751,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  gray-matter@4.0.3:
-    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
-    engines: {node: '>=6.0'}
-
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1862,10 +1852,6 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  is-extendable@0.1.1:
-    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
-    engines: {node: '>=0.10.0'}
-
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1927,10 +1913,6 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -1970,10 +1952,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  kind-of@6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
-    engines: {node: '>=0.10.0'}
 
   launder@1.7.1:
     resolution: {integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==}
@@ -2076,6 +2054,11 @@ packages:
     resolution: {integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==}
     engines: {node: '>=12.0.0'}
     hasBin: true
+
+  marked-alert@2.1.2:
+    resolution: {integrity: sha512-EFNRZ08d8L/iEIPLTlQMDjvwIsj03gxWCczYTht6DCiHJIZhMk4NK5gtPY9UqAYb09eV5VGT+jD4lp396E0I+w==}
+    peerDependencies:
+      marked: '>=7.0.0'
 
   marked-footnote@1.4.0:
     resolution: {integrity: sha512-fZTxAhI1TcLEs5UOjCfYfTHpyKGaWQevbxaGTEA68B51l7i87SctPFtHETYqPkEN0ka5opvy4Dy1l/yXVC+hmg==}
@@ -2490,10 +2473,6 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  section-matter@1.0.0:
-    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
-    engines: {node: '>=4'}
-
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
@@ -2632,10 +2611,6 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  strip-bom-string@1.0.0:
-    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
-    engines: {node: '>=0.10.0'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -2882,6 +2857,11 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -3632,10 +3612,10 @@ snapshots:
       '@types/node': 22.19.19
     optional: true
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vscode/ripgrep-darwin-arm64@1.18.0':
     optional: true
@@ -4358,8 +4338,6 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  esprima@4.0.1: {}
-
   etag@1.8.1: {}
 
   eventsource-parser@3.0.8: {}
@@ -4445,10 +4423,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  extend-shallow@2.0.1:
-    dependencies:
-      is-extendable: 0.1.1
 
   extract-zip@2.0.1:
     dependencies:
@@ -4641,13 +4615,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  gray-matter@4.0.3:
-    dependencies:
-      js-yaml: 3.14.2
-      kind-of: 6.0.3
-      section-matter: 1.0.0
-      strip-bom-string: 1.0.0
-
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -4761,8 +4728,6 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  is-extendable@0.1.1: {}
-
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -4800,11 +4765,6 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -4848,8 +4808,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  kind-of@6.0.3: {}
 
   launder@1.7.1:
     dependencies:
@@ -4936,6 +4894,10 @@ snapshots:
       path-is-absolute: 1.0.1
       underscore: 1.13.8
       xmlbuilder: 10.1.1
+
+  marked-alert@2.1.2(marked@18.0.3):
+    dependencies:
+      marked: 18.0.3
 
   marked-footnote@1.4.0(marked@18.0.3):
     dependencies:
@@ -5346,11 +5308,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  section-matter@1.0.0:
-    dependencies:
-      extend-shallow: 2.0.1
-      kind-of: 6.0.3
-
   semver-compare@1.0.0:
     optional: true
 
@@ -5522,8 +5479,6 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-bom-string@1.0.0: {}
-
   strip-json-comments@2.0.1: {}
 
   style-mod@4.1.3: {}
@@ -5666,7 +5621,7 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite@8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0):
+  vite@8.0.12(@types/node@22.19.19)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -5679,6 +5634,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
+      yaml: 2.9.0
 
   w3c-keyname@2.2.8: {}
 
@@ -5715,6 +5671,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/web-src/src/markdown/__tests__/frontmatter-alerts.test.ts
+++ b/web-src/src/markdown/__tests__/frontmatter-alerts.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { renderMarkdown, renderMarkdownInline } from '../../markdown.ts';
+
+test('document preview omits valid leading YAML frontmatter', () => {
+  const source = [
+    '---',
+    'title: Release notes',
+    'tags:',
+    '  - product',
+    '---',
+    '',
+    '# Visible title',
+  ].join('\n');
+  const document = renderMarkdown(source);
+  const inline = renderMarkdownInline(source);
+
+  assert.doesNotMatch(document, /title: Release notes|tags:|product/);
+  assert.match(document, /<h1 id="visible-title">Visible title<\/h1>/);
+  assert.match(inline, /title: Release notes/);
+});
+
+test('document preview omits valid CR-only YAML frontmatter', () => {
+  const source = '---\rtitle: Release notes\r---\r# Visible title';
+  const document = renderMarkdown(source);
+
+  assert.doesNotMatch(document, /title: Release notes/);
+  assert.match(document, /<h1 id="visible-title">Visible title<\/h1>/);
+});
+
+test('malformed or unterminated frontmatter remains visible source', () => {
+  for (const source of [
+    '---\ntitle: [broken\n---\n\n# Visible title',
+    '---\ntitle: Unclosed\n\n# Visible title',
+  ]) {
+    const document = renderMarkdown(source);
+
+    assert.match(document, /title:/);
+    assert.match(document, /Visible title/);
+  }
+});
+
+test('document preview renders GitHub alert variants with accessible labels', () => {
+  const document = renderMarkdown([
+    '> [!NOTE]',
+    '> Helpful context.',
+    '',
+    '> [!TIP]',
+    '> Practical guidance.',
+    '',
+    '> [!IMPORTANT]',
+    '> Critical details.',
+    '',
+    '> [!WARNING]',
+    '> Proceed carefully.',
+    '',
+    '> [!CAUTION]',
+    '> Destructive action ahead.',
+  ].join('\n'));
+
+  for (const variant of ['note', 'tip', 'important', 'warning', 'caution']) {
+    assert.match(document, new RegExp(`<div[^>]*class="markdown-alert markdown-alert-${variant}"[^>]*>`));
+    assert.match(document, new RegExp(`class="markdown-alert-title"[^>]*>[\\s\\S]*?${variant[0].toUpperCase()}${variant.slice(1)}<\\/p>`));
+  }
+  assert.match(document, /aria-label="Note"/);
+  assert.match(document, /<svg[^>]*viewbox="0 0 16 16"[^>]*aria-hidden="true">/);
+  assert.match(document, /Helpful context\./);
+});
+
+test('alert output stays sanitized and Agent messages remain isolated', () => {
+  const source = '> [!WARNING]\n> <script>alert("unsafe")</script>\n> [unsafe](javascript:alert("unsafe"))';
+  const document = renderMarkdown(source);
+  const inline = renderMarkdownInline(source);
+
+  assert.match(document, /markdown-alert-warning/);
+  assert.doesNotMatch(document, /<script|javascript:/i);
+  assert.doesNotMatch(inline, /markdown-alert/);
+  assert.match(inline, /\[!WARNING\]/);
+});

--- a/web-src/src/markdown/documentRenderer.ts
+++ b/web-src/src/markdown/documentRenderer.ts
@@ -1,7 +1,9 @@
 import markedFootnote from 'marked-footnote';
 import { gfmHeadingId } from 'marked-gfm-heading-id';
 import { Marked } from 'marked';
+import markedAlert from 'marked-alert';
 
+import { stripLeadingYamlFrontmatter } from './frontmatter';
 import { normalizeHeadingIds, stripRawHeadingIds } from './headingIds';
 import { createPreviewDocument } from './previewDocument';
 import { sanitizeMarkdownHtml } from './sanitization';
@@ -11,12 +13,12 @@ export function renderDocumentMarkdown(markdown: string): string {
   const documentMarkdown = new Marked({ gfm: true, breaks: false });
   // GitHub heading slugs omit colons, so this keeps package-generated
   // footnote targets disjoint from document heading anchors.
-  documentMarkdown.use(markedFootnote({ prefixId: 'footnote:' }), gfmHeadingId());
+  documentMarkdown.use(markedFootnote({ prefixId: 'footnote:' }), gfmHeadingId(), markedAlert());
   documentMarkdown.use({
     renderer: {
       html: ({ text }) => stripRawHeadingIds(text),
     },
   });
-  const parsed = documentMarkdown.parse(markdown, { async: false }) as string;
+  const parsed = documentMarkdown.parse(stripLeadingYamlFrontmatter(markdown), { async: false }) as string;
   return createPreviewDocument(normalizeHeadingIds(sanitizeMarkdownHtml(parsed)));
 }

--- a/web-src/src/markdown/frontmatter.ts
+++ b/web-src/src/markdown/frontmatter.ts
@@ -1,0 +1,17 @@
+import { parseDocument } from 'yaml';
+
+const OPENING_DELIMITER = /^(?:\uFEFF)?---[\t ]*(?:\r\n?|\n)/;
+const CLOSING_DELIMITER = /^(?:---|\.\.\.)[\t ]*(?:\r\n?|\n|$)/gm;
+
+/** Removes only valid, explicitly closed leading YAML frontmatter. */
+export function stripLeadingYamlFrontmatter(markdown: string): string {
+  const opening = OPENING_DELIMITER.exec(markdown);
+  if (!opening) return markdown;
+
+  CLOSING_DELIMITER.lastIndex = opening[0].length;
+  const closing = CLOSING_DELIMITER.exec(markdown);
+  if (!closing) return markdown;
+
+  const frontmatter = parseDocument(markdown.slice(opening[0].length, closing.index));
+  return frontmatter.errors.length === 0 ? markdown.slice(CLOSING_DELIMITER.lastIndex) : markdown;
+}

--- a/web-src/src/markdown/previewDocument.ts
+++ b/web-src/src/markdown/previewDocument.ts
@@ -61,6 +61,20 @@ blockquote {
   border-left: 3px solid rgb(55, 53, 47);
   color: inherit;
 }
+.markdown-alert {
+  --alert-color: #0969da;
+  --alert-background: #ddf4ff;
+  margin: 1em 0; padding: 12px 16px;
+  border-left: 4px solid var(--alert-color); border-radius: 4px;
+  background: var(--alert-background);
+}
+.markdown-alert-title { display: flex; align-items: center; gap: 0.45em; margin: 0; font-weight: 700; color: var(--alert-color); }
+.markdown-alert-title svg { width: 1em; height: 1em; fill: currentColor; flex: 0 0 auto; }
+.markdown-alert > :not(.markdown-alert-title) { margin: 0.55em 0 0; }
+.markdown-alert-tip { --alert-color: #1a7f37; --alert-background: #dafbe1; }
+.markdown-alert-important { --alert-color: #8250df; --alert-background: #fbefff; }
+.markdown-alert-warning { --alert-color: #9a6700; --alert-background: #fff8c5; }
+.markdown-alert-caution { --alert-color: #cf222e; --alert-background: #ffebe9; }
 ul, ol { padding-left: 1.6em; margin: 0.9em 0; }
 li { margin: 0.35em 0; }
 table { border-collapse: collapse; margin: 0.5em 0; font-size: 0.95em; }

--- a/web-src/src/markdown/sanitization.ts
+++ b/web-src/src/markdown/sanitization.ts
@@ -2,7 +2,14 @@ import sanitizeHtml from 'sanitize-html';
 
 /** Applies the document-preview trust policy to parsed Markdown HTML. */
 export function sanitizeMarkdownHtml(html: string): string {
-  return sanitizeHtml(html, MARKDOWN_SANITIZE_OPTIONS);
+  return addAlertLandmarks(sanitizeHtml(html, MARKDOWN_SANITIZE_OPTIONS));
+}
+
+function addAlertLandmarks(html: string): string {
+  return html.replace(
+    /<div class="markdown-alert markdown-alert-(note|tip|important|warning|caution)">/g,
+    (_match, variant: string) => `<div class="markdown-alert markdown-alert-${variant}" role="note" aria-label="${variant[0].toUpperCase()}${variant.slice(1)}">`,
+  );
 }
 
 const MARKDOWN_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
@@ -12,11 +19,11 @@ const MARKDOWN_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     'div', 'dl', 'dt', 'em', 'figcaption', 'figure', 'h1', 'h2', 'h3',
     'h4', 'h5', 'h6', 'hr', 'i', 'img', 'input', 'ins', 'kbd', 'li',
     'main', 'mark', 'ol', 'p', 'pre', 'q', 's', 'samp', 'section', 'small',
-    'span', 'strong', 'sub', 'summary', 'sup', 'table', 'tbody', 'td',
-    'tfoot', 'th', 'thead', 'tr', 'u', 'ul', 'var',
+    'span', 'strong', 'sub', 'summary', 'sup', 'svg', 'table', 'tbody', 'td',
+    'tfoot', 'th', 'thead', 'tr', 'u', 'ul', 'var', 'path',
   ],
   allowedAttributes: {
-    '*': ['id', 'title', 'dir', 'lang', 'aria-*'],
+    '*': ['id', 'title', 'dir', 'lang', 'aria-*', 'role'],
     a: ['href', 'data-footnote:ref', 'data-footnote:backref', 'aria-describedby'],
     blockquote: ['cite'],
     code: ['class'],
@@ -33,11 +40,16 @@ const MARKDOWN_SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     td: ['colspan', 'rowspan', 'headers', 'align'],
     th: ['colspan', 'rowspan', 'headers', 'scope', 'align'],
     section: ['class', 'data-footnotes'],
+    svg: ['class', 'viewbox', 'width', 'height', 'aria-hidden'],
+    path: ['d'],
     ul: ['class'],
   },
   allowedClasses: {
     section: ['footnotes'],
     h2: ['sr-only'],
+    div: [/^markdown-alert(?:-(?:note|tip|important|warning|caution))?$/],
+    p: ['markdown-alert-title'],
+    svg: ['octicon', 'mr-2', /^octicon-[a-z-]+$/],
   },
   allowedSchemes: ['http', 'https', 'mailto'],
   allowedSchemesByTag: {


### PR DESCRIPTION
## Summary

- hide valid, closed YAML frontmatter in document preview while keeping malformed or unterminated source visible
- render GitHub `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, and `CAUTION` alerts with sanitized accessible markup and preview-local styling
- keep Agent-message Markdown unchanged and document the current rendering behavior

## Root cause

Document preview passed all Markdown directly to Marked and had no alert extension or sanitizer rules for the package-native alert markup.

## Validation

- `pnpm test:renderer`
- `npx tsc --noEmit`
- `npx vite build --config web-src/vite.config.ts`

Closes #27
