### PR TITLE
feat(search): add subfolder scoping and file-type filters

### DIFF
--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -98,7 +98,7 @@ daemon adapters cross these modules. Identity, containment, migration, and proto
 
 One installation has **one library**: the set of opened folders indexed into one collection and exposed by one MCP server.
 
-MCP search defaults to the whole library. Calls can narrow scope by folder root or path prefix. The in-app search UI is scoped to the current window's folder.
+MCP search defaults to the whole library. Calls can narrow scope by folder root or path prefix. The in-app search UI is scoped to the current window's folder and can narrow further to one subfolder and to file-type categories.
 
 On server boot, StashBase binds every library folder into the daemon and then reconciles them in the background. The Welcome screen also reconciles library folders with a short cooldown and polls folder status when it is idle. While a folder is actively opening, Welcome status polling and reconcile are deferred so navigation does not compete with preparation work.
 
@@ -261,13 +261,13 @@ Retrieval is how Agents and the UI find relevant local context.
 StashBase supports two retrieval paths:
 
 - **Semantic search**: dense vector retrieval, combined with keyword signal through MFS/Milvus.
-- **Keyword search**: literal search over source text plus AppData-derived PDF/OCR/DOCX text, useful when embeddings are unavailable or exact matching is needed. `server/keyword-search.ts` owns the desktop keyword-search implementation: ripgrep JSON parsing for source text, AppData-derived text scanning for convertible sources, UTF-8 to UTF-16 match-range mapping, app-side whole-token filtering, snippet windowing, PDF page hints, and result merging. `server/routes/indexing.ts` owns HTTP request validation, folder scoping, and display-path remapping.
+- **Keyword search**: literal search over source text plus AppData-derived PDF/OCR/DOCX text, useful when embeddings are unavailable or exact matching is needed. `server/keyword-search.ts` owns the desktop keyword-search implementation: ripgrep JSON parsing for source text, AppData-derived text scanning for convertible sources, UTF-8 to UTF-16 match-range mapping, app-side whole-token filtering, snippet windowing, PDF page hints, subfolder scoping, file-type category filtering, and result merging. `server/routes/indexing.ts` owns HTTP request validation, folder scoping, escape-safe `path_prefix` resolution, `types` validation, and display-path remapping.
 
 ## 6.2 Scope
 
 Search defaults to the whole library for MCP callers. It can be narrowed by folder root or path prefix.
 
-The desktop UI search is scoped to the current folder because the UI is showing one folder at a time.
+The desktop UI search is scoped to the current folder because the UI is showing one folder at a time. The Search panel can narrow further: a subfolder scope (folder-relative, resolved escape-safe against the active folder) and file-type category chips (`shared/search-types.ts` defines the `notes` / `pdf` / `image` / `docx` vocabulary; `server/format.ts` maps categories to source extensions). Both narrowing knobs apply to semantic and keyword modes and compose. The semantic path passes the extension filter to the daemon, which over-fetches from MFS (bounded), filters hits by source suffix, and truncates back to `top_k` before returning, so filtering happens before the caller-visible top-k cut; a very sparse type can still return fewer than `top_k` hits. The keyword path restricts the ripgrep target and the derived-text walk to the scoped subtree and enabled categories. Display-path remapping is unchanged: filters act on source paths, and derived notes never surface.
 
 The desktop UI does not surface background conversion or indexing as general folder chrome. Folder views stay quiet while StashBase prepares content, and the in-folder `FOLDER` header does not show preparation badges. `server/index-status.ts` owns the folder-scoped readiness snapshot behind `/api/index-status`: semantic pending filtering, disabled-semantic copy, orphan counts, conversion progress and versions, durable preparation failures, tree-change versions, and index warnings. Open PDF and image previews show queued/running preparation state (including same-lane tasks ahead). DOCX opens directly from source and remains visible while a slim status row reports its independent searchable-text preparation; the AppData-derived route is only a fallback if direct rendering fails. Welcome library rows can show a lightweight folder-level failure marker because the files are not expanded there; inside a folder, durable failures are shown on the affected file row. The Search view summarizes library readiness because that is where incomplete preparation affects the user.
 

--- a/python/stashbase_daemon.py
+++ b/python/stashbase_daemon.py
@@ -1089,6 +1089,19 @@ def op_delete_prefix(svc: StashbaseStore, args: dict) -> dict:
     return {"removed": removed}
 
 
+def _search_extension_filter(raw) -> tuple | None:
+    """Normalize the caller's extension list into a lowercase suffix
+    tuple for ``str.endswith``. None / empty / malformed input means
+    "no extension filter"."""
+    if not isinstance(raw, list):
+        return None
+    exts = tuple(
+        e.lower() for e in raw
+        if isinstance(e, str) and e.startswith(".") and len(e) > 1
+    )
+    return exts or None
+
+
 def op_search(svc: StashbaseStore, args: dict) -> dict:
     """Hybrid search in the single collection, optionally scoped to one
     ``folder``. MFS's ``hybrid_search`` already does dense + BM25 + RRF
@@ -1098,6 +1111,7 @@ def op_search(svc: StashbaseStore, args: dict) -> dict:
     query = args["query"].strip()
     folder = args.get("folder")
     explicit_prefix = args.get("path_prefix")
+    extensions = _search_extension_filter(args.get("extensions"))
     top_k_raw = int(args.get("top_k", 8))
     top_k = max(1, min(200, top_k_raw))
     if not query:
@@ -1119,11 +1133,18 @@ def op_search(svc: StashbaseStore, args: dict) -> dict:
     else:
         path_filter = None
 
+    # Extension filtering happens here, before the caller-visible top-k
+    # cut. MFS's hybrid_search only accepts a path prefix filter, so the
+    # store is over-fetched (bounded) and filtered by source suffix; the
+    # filtered list is then truncated back to top_k. A very sparse type
+    # can still return fewer than top_k hits.
+    fetch_k = top_k if extensions is None else min(200, max(top_k * 5, 50))
+
     try:
         if store.is_empty():
             return {"hits": []}
         qvec = embedder.embed([query])[0]
-        hits = store.hybrid_search(qvec, query, path_filter=path_filter, top_k=top_k)
+        hits = store.hybrid_search(qvec, query, path_filter=path_filter, top_k=fetch_k)
     except Exception as exc:
         sys.stderr.write(f"[stashbase] search store failed: {exc}\n")
         return {"hits": []}
@@ -1131,6 +1152,8 @@ def op_search(svc: StashbaseStore, args: dict) -> dict:
     out = []
     for h in hits:
         if h.is_dir:
+            continue
+        if extensions is not None and not h.source.lower().endswith(extensions):
             continue
         out.append({
             "path": h.source,
@@ -1142,6 +1165,8 @@ def op_search(svc: StashbaseStore, args: dict) -> dict:
             "score": h.score,
             "metadata": h.metadata or {},
         })
+        if len(out) >= top_k:
+            break
     return {"hits": out}
 
 

--- a/python/stashbase_daemon_test.py
+++ b/python/stashbase_daemon_test.py
@@ -193,6 +193,55 @@ class StashbaseDaemonTests(unittest.TestCase):
             self.assertFalse(result["reused"])
             self.assertEqual(fake.deleted, ["C:/Users/Alice/Docs/File.md"])
 
+    def test_search_filters_extensions_before_top_k(self) -> None:
+        hit = lambda source: types.SimpleNamespace(
+            is_dir=False, source=source, chunk_index=0, chunk_text="t",
+            start_line=1, end_line=2, content_type="text", score=1.0, metadata={},
+        )
+        requested = []
+
+        class FakeStore:
+            def is_empty(self):
+                return False
+
+            def hybrid_search(self, _qvec, _query, path_filter, top_k):  # noqa: ANN001
+                requested.append(top_k)
+                return [
+                    hit("/lib/a.md"), hit("/lib/b.pdf"), hit("/lib/c.md"),
+                    hit("/lib/d.PDF"), hit("/lib/e.docx"), hit("/lib/f.pdf"),
+                ]
+
+        class FakeEmbedder:
+            def embed(self, texts):  # noqa: ANN001
+                return [[0.0] for _ in texts]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            svc = stashbase_daemon.StashbaseStore(tmp)
+            svc.stores = lambda: [(None, FakeEmbedder(), FakeStore())]
+
+            filtered = stashbase_daemon.op_search(svc, {
+                "query": "q", "top_k": 2, "extensions": [".pdf"],
+            })
+            self.assertEqual(
+                [h["path"] for h in filtered["hits"]],
+                ["/lib/b.pdf", "/lib/d.PDF"],
+            )
+
+            unfiltered = stashbase_daemon.op_search(svc, {"query": "q", "top_k": 2})
+            self.assertEqual(len(unfiltered["hits"]), 2)
+
+            # Filtered call over-fetches; unfiltered keeps the caller's k.
+            self.assertEqual(requested, [50, 2])
+
+    def test_search_extension_filter_normalizes_suffixes(self) -> None:
+        f = stashbase_daemon._search_extension_filter
+        self.assertEqual(f([".md", ".PDF"]), (".md", ".pdf"))
+        self.assertIsNone(f(None))
+        self.assertIsNone(f([]))
+        self.assertIsNone(f("not-a-list"))
+        self.assertIsNone(f(["md", ".", 42]))
+        self.assertEqual(f(["md", ".docx"]), (".docx",))
+
     def test_termination_signals_skip_missing_sighup(self) -> None:
         fake_signal = types.SimpleNamespace(SIGTERM=15, SIGINT=2)
 

--- a/server/format.ts
+++ b/server/format.ts
@@ -22,6 +22,8 @@
  * cycle that the packaged bundle can't resolve correctly.
  */
 
+import { SEARCH_TYPE_CATEGORIES, type SearchTypeCategory } from '../shared/search-types.ts';
+
 /** Structured note formats — indexed directly (the file is the source). */
 export type FileFormat = 'md' | 'html';
 
@@ -123,6 +125,33 @@ export function isDocxFile(name: string): boolean {
  *  notes; it lets the conversion path own their index entry. */
 export function isConvertibleSource(name: string): boolean {
   return /\.pdf$/i.test(name) || isImageFile(name) || isDocxFile(name);
+}
+
+const IMAGE_EXTS: readonly string[] = ['png', 'jpg', 'jpeg', 'webp'];
+
+const SEARCH_TYPE_EXTENSIONS: Record<SearchTypeCategory, readonly string[]> = {
+  notes: NOTE_EXTS,
+  pdf: ['pdf'],
+  image: IMAGE_EXTS,
+  docx: ['docx'],
+};
+
+/** Lowercase dot-prefixed source extensions for a set of search
+ *  categories. Returns null when the set is empty or covers every
+ *  category — both mean "no extension filter". */
+export function searchExtensionsForTypes(types: readonly SearchTypeCategory[]): string[] | null {
+  const unique = [...new Set(types)];
+  if (unique.length === 0 || unique.length === SEARCH_TYPE_CATEGORIES.length) return null;
+  return unique.flatMap((t) => SEARCH_TYPE_EXTENSIONS[t].map((ext) => `.${ext}`));
+}
+
+/** True when `name`'s extension belongs to one of the given categories. */
+export function matchesSearchTypes(name: string, types: readonly SearchTypeCategory[]): boolean {
+  if (types.length === 0) return true;
+  const exts = searchExtensionsForTypes(types);
+  if (exts == null) return true;
+  const lower = name.toLowerCase();
+  return exts.some((ext) => lower.endsWith(ext));
 }
 
 function pathBasename(name: string): string {

--- a/server/indexer.mfs.ts
+++ b/server/indexer.mfs.ts
@@ -314,10 +314,11 @@ export class MfsIndexer implements Indexer {
     };
   }
 
-  async search(query: string, topK: number, folder?: string, pathPrefix?: string): Promise<SearchHit[]> {
+  async search(query: string, topK: number, folder?: string, pathPrefix?: string, extensions?: string[]): Promise<SearchHit[]> {
     const args: Record<string, unknown> = { query, top_k: topK };
     if (folder) args.folder = normalizeDaemonPath(folder);
     if (pathPrefix) args.path_prefix = normalizeDaemonPath(pathPrefix);
+    if (extensions && extensions.length > 0) args.extensions = extensions;
     const res = await getDaemon().call<{ hits: DaemonHit[] }>('search', args);
     return res.hits.map((h) => ({
       fileName: normalizeDaemonPath(h.path),

--- a/server/indexer.ts
+++ b/server/indexer.ts
@@ -96,9 +96,11 @@ export interface Indexer {
    *  to chunks whose `source` starts with that prefix — useful when an
    *  agent wants to ask "only inside cs183b/transcripts/". When both
    *  are passed, `pathPrefix` takes precedence (it's more specific).
-   *  Returns at most `topK` hits ordered by descending score, with
-   *  `fileName` absolute. */
-  search(query: string, topK: number, folder?: string, pathPrefix?: string): Promise<SearchHit[]>;
+   *  `extensions?` restricts hits to sources with one of the given
+   *  lowercase dot-prefixed extensions; the daemon applies it before
+   *  final top-k selection. Returns at most `topK` hits ordered by
+   *  descending score, with `fileName` absolute. */
+  search(query: string, topK: number, folder?: string, pathPrefix?: string, extensions?: string[]): Promise<SearchHit[]>;
 
   /** Walk the library and compute the content-hash diff against the
    *  index. `folder?` scopes the walk; omitted = whole library. Paths

--- a/server/keyword-search.test.ts
+++ b/server/keyword-search.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import test from 'node:test';
+import { matchesSearchTypes, searchExtensionsForTypes } from './format.ts';
 import {
   hasWholeTokenBoundaries,
   normalizeRipgrepSubmatches,
@@ -36,4 +37,20 @@ test('packaged ripgrep path prefers app.asar.unpacked when present', () => {
   const candidate = path.join('/tmp', 'App.app', 'Contents', 'Resources', 'app.asar', 'node_modules', 'rg');
 
   assert.equal(resolveSpawnableRipgrepPath(candidate), candidate);
+});
+
+test('search type categories map to source extensions', () => {
+  assert.deepEqual(searchExtensionsForTypes(['pdf']), ['.pdf']);
+  assert.deepEqual(searchExtensionsForTypes(['notes']), ['.md', '.markdown', '.html', '.htm']);
+  assert.deepEqual(searchExtensionsForTypes(['docx', 'docx']), ['.docx']);
+  assert.equal(searchExtensionsForTypes([]), null);
+  assert.equal(searchExtensionsForTypes(['notes', 'pdf', 'image', 'docx']), null);
+});
+
+test('type membership checks extensions case-insensitively', () => {
+  assert.equal(matchesSearchTypes('a/Report.PDF', ['pdf']), true);
+  assert.equal(matchesSearchTypes('a/report.pdf', ['notes']), false);
+  assert.equal(matchesSearchTypes('shot.jpeg', ['image']), true);
+  assert.equal(matchesSearchTypes('doc.docx', ['pdf', 'docx']), true);
+  assert.equal(matchesSearchTypes('note.md', []), true);
 });

--- a/server/keyword-search.ts
+++ b/server/keyword-search.ts
@@ -13,6 +13,7 @@ import {
   type KeywordMatch,
   type KeywordSearchResult,
 } from './search-display.ts';
+import type { SearchTypeCategory } from '../shared/search-types.ts';
 
 const RG_PER_FILE_CAP = 50;
 const RG_TOTAL_CAP = 500;
@@ -28,6 +29,11 @@ export interface KeywordSearchOpts {
    *  ripgrep's `--word-regexp`: its boundary semantics do not line up
    *  with the renderer and are especially poor for CJK text. */
   wholeWord: boolean;
+  /** Folder-relative subfolder to search instead of the whole folder.
+   *  Already validated by the route (escape-safe, existing directory). */
+  pathPrefix?: string;
+  /** File-type categories to include; empty/absent = every category. */
+  types?: readonly SearchTypeCategory[];
 }
 
 export async function runKeywordSearch(
@@ -35,9 +41,14 @@ export async function runKeywordSearch(
   folderRoot: string,
   opts: KeywordSearchOpts,
 ): Promise<KeywordSearchResult> {
+  const types = opts.types ?? [];
+  const wantsNotes = types.length === 0 || types.includes('notes');
+  const wantsConvertible = types.length === 0
+    || types.some((t) => t === 'pdf' || t === 'image' || t === 'docx');
+  const empty: KeywordSearchResult = { files: [], totalMatches: 0, truncated: false };
   return mergeKeywordResults(
-    await runRipgrep(query, folderRoot, opts),
-    searchDerivedMarkdown(query, folderRoot, opts),
+    wantsNotes ? await runRipgrep(query, folderRoot, opts) : empty,
+    wantsConvertible ? searchDerivedMarkdown(query, folderRoot, opts) : empty,
   );
 }
 
@@ -57,7 +68,7 @@ function runRipgrep(query: string, cwd: string, opts: KeywordSearchOpts): Promis
       '--glob', '*.html',
       '--glob', '*.htm',
     ];
-    args.push('-e', query, '.');
+    args.push('-e', query, opts.pathPrefix ? `./${opts.pathPrefix}` : '.');
     execFile(RESOLVED_RG_PATH, args, {
       cwd,
       maxBuffer: 32 * 1024 * 1024,
@@ -123,12 +134,15 @@ function searchDerivedMarkdown(query: string, folderRoot: string, opts: KeywordS
   let total = 0;
   let truncated = false;
   const caseSensitive = opts.caseStrict || /[A-Z]/.test(query);
+  const types = opts.types ?? [];
+  const walkRoot = opts.pathPrefix ? path.join(folderRoot, opts.pathPrefix) : folderRoot;
 
-  walkConvertibleSources(folderRoot, '', (rel, abs) => {
+  walkConvertibleSources(walkRoot, opts.pathPrefix ?? '', (rel, abs) => {
     if (total >= RG_TOTAL_CAP) {
       truncated = true;
       return;
     }
+    if (!convertibleMatchesTypes(rel, types)) return;
     const text = readDerivedSearchText(rel, abs);
     if (text == null) return;
     const lines = text.split(/\r?\n/);
@@ -194,6 +208,16 @@ function walkConvertibleSources(
       fn(rel, abs);
     }
   }
+}
+
+/** Category membership for the convertible-source walk. Empty types =
+ *  every convertible category (`notes` never reaches this leg). */
+function convertibleMatchesTypes(rel: string, types: readonly SearchTypeCategory[]): boolean {
+  if (types.length === 0) return true;
+  if (/\.pdf$/i.test(rel)) return types.includes('pdf');
+  if (isImageFile(rel)) return types.includes('image');
+  if (isDocxFile(rel)) return types.includes('docx');
+  return false;
 }
 
 function findLiteralRanges(line: string, query: string, caseSensitive: boolean): Array<[number, number]> {

--- a/server/routes/indexing.ts
+++ b/server/routes/indexing.ts
@@ -21,6 +21,8 @@ import { clearIndexWarning, indexer, syncFolderNow } from '../state.ts';
 import { noteTreeChanged } from '../watcher.ts';
 import { sendError } from '../http.ts';
 import { filesystemPath } from '../filesystem-path.ts';
+import { searchExtensionsForTypes } from '../format.ts';
+import { isSearchTypeCategory, type SearchTypeCategory } from '../../shared/search-types.ts';
 import { buildIndexStatus } from '../index-status.ts';
 import { runKeywordSearch } from '../keyword-search.ts';
 import {
@@ -206,7 +208,10 @@ export function mount(app: express.Express): void {
   // Hybrid (vector + BM25) search, scoped to the current open folder.
   // Cross-folder search lives behind the MCP `search_library` tool (different
   // mental model: "AI searching all my notes" vs "I'm searching the library
-  // I'm currently editing").
+  // I'm currently editing"). Optional narrowing: `path_prefix` (folder-
+  // relative subfolder, resolved escape-safe) and `types` (file-type
+  // categories mapped to source extensions, applied daemon-side before
+  // the final top-k cut).
   app.post('/api/search', async (req, res) => {
     try {
       const query = typeof req.body?.query === 'string' ? req.body.query.trim() : '';
@@ -220,8 +225,14 @@ export function mount(app: express.Express): void {
       }
       const explicit = parseFolderParam(req.body?.folder);
       const { folderRoot } = requireRequestFolder(explicit);
+      const types = parseSearchTypes(req.body?.types);
+      if (types == null) return res.status(400).json({ error: 'unknown types value' });
+      const prefixAbs = resolveScopePrefix(folderRoot, req.body?.path_prefix);
+      if (prefixAbs === false) return res.status(400).json({ error: 'path_prefix must be a folder-relative subfolder' });
       const root = filesystemPath.absolute(folderRoot);
-      const hits = await indexer.search(query, topK, root);
+      const hits = await indexer.search(
+        query, topK, root, prefixAbs, searchExtensionsForTypes(types) ?? undefined,
+      );
       // Daemon hits arrive as absolute paths; translate fileName back to
       // folder-relative for the sidebar (which only knows the current
       // folder). Then `displayPathForHit` rewrites a derived note to its
@@ -258,7 +269,21 @@ export function mount(app: express.Express): void {
       const { folderRoot: folderDir } = requireRequestFolder(explicit);
       const caseStrict = req.query.case_strict === '1' || req.query.case_strict === 'true';
       const wholeWord = req.query.whole_word === '1' || req.query.whole_word === 'true';
-      const result = await runKeywordSearch(query, folderDir, { caseStrict, wholeWord });
+      const types = parseSearchTypes(
+        typeof req.query.types === 'string' && req.query.types
+          ? req.query.types.split(',')
+          : undefined,
+      );
+      if (types == null) return res.status(400).json({ error: 'unknown types value' });
+      const rawPrefix = typeof req.query.path_prefix === 'string' ? req.query.path_prefix : undefined;
+      const prefixAbs = resolveScopePrefix(folderDir, rawPrefix);
+      if (prefixAbs === false) return res.status(400).json({ error: 'path_prefix must be a folder-relative subfolder' });
+      const result = await runKeywordSearch(query, folderDir, {
+        caseStrict,
+        wholeWord,
+        pathPrefix: prefixAbs ? (filesystemPath.relative(filesystemPath.absolute(folderDir), prefixAbs) ?? undefined) : undefined,
+        types,
+      });
       // ripgrep's `*.md` glob may also match legacy hidden dot-prefixed
       // derived notes (`.paper.pdf.md` / `.shot.png.md`). Apply the same
       // remap-or-drop rule as the semantic routes so a hit's row points
@@ -325,5 +350,35 @@ export function mount(app: express.Express): void {
       sendError(res, err);
     }
   });
+}
+
+/** Validates a `types` request value into search categories. Absent →
+ *  empty list (no filter); any unknown entry → null (caller 400s). */
+function parseSearchTypes(raw: unknown): SearchTypeCategory[] | null {
+  if (raw == null) return [];
+  if (!Array.isArray(raw)) return null;
+  const out: SearchTypeCategory[] = [];
+  for (const entry of raw) {
+    const value = typeof entry === 'string' ? entry.trim() : entry;
+    if (!isSearchTypeCategory(value)) return null;
+    out.push(value);
+  }
+  return out;
+}
+
+/** Resolves a folder-relative subfolder scope to an absolute directory
+ *  inside `folderRoot`. Absent/empty → undefined (folder-wide search);
+ *  escaping, missing, or non-directory values → false (caller 400s). */
+function resolveScopePrefix(folderRoot: string, raw: unknown): string | undefined | false {
+  if (raw == null) return undefined;
+  if (typeof raw !== 'string') return false;
+  const rel = raw.trim().replace(/^\/+|\/+$/g, '');
+  if (!rel) return undefined;
+  try {
+    const abs = filesystemPath.resolveUnder(folderRoot, rel, { access: 'existing' });
+    return fs.statSync(abs).isDirectory() ? abs : false;
+  } catch {
+    return false;
+  }
 }
 // ---------- recent-files walk ----------

--- a/shared/search-types.ts
+++ b/shared/search-types.ts
@@ -1,0 +1,11 @@
+/** File-type categories the search surfaces can filter by. Shared
+ *  vocabulary between the renderer (chips) and the server (extension
+ *  mapping); the category → extension mapping itself stays in
+ *  `server/format.ts` next to the other extension knowledge. */
+export const SEARCH_TYPE_CATEGORIES = ['notes', 'pdf', 'image', 'docx'] as const;
+
+export type SearchTypeCategory = (typeof SEARCH_TYPE_CATEGORIES)[number];
+
+export function isSearchTypeCategory(value: unknown): value is SearchTypeCategory {
+  return typeof value === 'string' && (SEARCH_TYPE_CATEGORIES as readonly string[]).includes(value);
+}

--- a/web-src/src/api.ts
+++ b/web-src/src/api.ts
@@ -21,6 +21,7 @@ import type {
   SyncResult,
   UploadResult,
 } from './apiTypes';
+import type { SearchTypeCategory } from '../../shared/search-types.ts';
 import {
   encodePath,
   getWindowId,
@@ -149,9 +150,15 @@ export const api = {
     'POST',
     folder ? `/api/sync?folder=${encodeURIComponent(folder)}` : '/api/sync',
   ),
-  search: (query: string, top_k = 8, opts?: { folder?: string }) =>
-    send<{ hits: SearchHit[] }>('POST', '/api/search', { query, top_k, folder: opts?.folder }),
-  keywordSearch: (query: string, opts?: { caseStrict?: boolean; wholeWord?: boolean; folder?: string }) => {
+  search: (query: string, top_k = 8, opts?: { folder?: string; pathPrefix?: string; types?: readonly SearchTypeCategory[] }) =>
+    send<{ hits: SearchHit[] }>('POST', '/api/search', {
+      query,
+      top_k,
+      folder: opts?.folder,
+      path_prefix: opts?.pathPrefix,
+      types: opts?.types?.length ? opts.types : undefined,
+    }),
+  keywordSearch: (query: string, opts?: { caseStrict?: boolean; wholeWord?: boolean; folder?: string; pathPrefix?: string; types?: readonly SearchTypeCategory[] }) => {
     const qs = new URLSearchParams({ q: query });
     if (opts?.caseStrict) qs.set('case_strict', '1');
     if (opts?.wholeWord) qs.set('whole_word', '1');
@@ -159,6 +166,8 @@ export const api = {
     // sessions don't fall back to the server's single `currentFolder`
     // singleton and search the wrong folder's tree.
     if (opts?.folder) qs.set('folder', opts.folder);
+    if (opts?.pathPrefix) qs.set('path_prefix', opts.pathPrefix);
+    if (opts?.types?.length) qs.set('types', opts.types.join(','));
     return getJson<KeywordSearchResult>(`/api/keyword-search?${qs.toString()}`);
   },
   indexStatus: (folder?: string) =>

--- a/web-src/src/components/SearchPanel.tsx
+++ b/web-src/src/components/SearchPanel.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, type ReactNode } from 'react';
-import type { KeywordHitFile, KeywordMatch, SearchHit } from '../api';
+import type { FileMeta, KeywordHitFile, KeywordMatch, SearchHit } from '../api';
 import { useApp } from '../store/AppContext';
+import type { SearchTypeCategory } from '../../../shared/search-types.ts';
 
 /**
  * The "search" sidebar view — owns the search input, the mode toggle
  * (≈ ↔ =) with conditional `Aa` / `Word` sub-filters when in keyword
- * mode, and the result list.
+ * mode, the subfolder-scope and file-type filter row, and the result
+ * list.
  *
  * Empty query → empty body (no "Recent searches" prompt yet — that's
  * deferred until we add a real history feature).
@@ -22,6 +24,7 @@ export function SearchPanel() {
   return (
     <div className="search-panel" id="sidebar-panel-search" role="tabpanel">
       <SearchBox />
+      <SearchFilters />
       <SearchStatusBanner />
       <div className="search-panel-body">
         {state.searchMode === 'semantic' && state.embedderHasKey === false ? (
@@ -36,6 +39,84 @@ export function SearchPanel() {
       </div>
     </div>
   );
+}
+
+const SEARCH_TYPE_CHIPS: Array<{ type: SearchTypeCategory; label: string; title: string }> = [
+  { type: 'notes', label: 'Notes', title: 'Markdown and HTML' },
+  { type: 'pdf', label: 'PDF', title: 'PDF documents' },
+  { type: 'image', label: 'Images', title: 'OCR-searchable images' },
+  { type: 'docx', label: 'DOCX', title: 'Word documents' },
+];
+
+/** Subfolder scope + file-type chips. Both narrow the NEXT search in
+ *  either mode and compose; no selection = whole folder, every type. */
+function SearchFilters() {
+  const { state, actions, dispatch } = useApp();
+  const scopes = subfolderScopes(state.files);
+  const staleScope = state.searchScope != null && !scopes.includes(state.searchScope);
+
+  function rerun(next: { scope?: string | null; types?: SearchTypeCategory[] }) {
+    if (state.filterQuery.trim()) void actions.runSearch(state.filterQuery, undefined, next);
+  }
+
+  function setScope(scope: string | null) {
+    dispatch({ type: 'SEARCH_SCOPE', scope });
+    rerun({ scope });
+  }
+
+  function toggleType(type: SearchTypeCategory) {
+    const types = state.searchTypes.includes(type)
+      ? state.searchTypes.filter((t) => t !== type)
+      : [...state.searchTypes, type];
+    dispatch({ type: 'SEARCH_TYPES', types });
+    rerun({ types });
+  }
+
+  return (
+    <div className="search-filters">
+      {(scopes.length > 0 || staleScope) && (
+        <select
+          className="search-scope"
+          value={state.searchScope ?? ''}
+          onChange={(e) => setScope(e.target.value || null)}
+          aria-label="Search scope"
+          title="Limit search to a subfolder"
+        >
+          <option value="">All folders</option>
+          {staleScope && <option value={state.searchScope!}>{state.searchScope}</option>}
+          {scopes.map((scope) => <option key={scope} value={scope}>{scope}</option>)}
+        </select>
+      )}
+      <div className="search-type-chips" role="group" aria-label="File types">
+        {SEARCH_TYPE_CHIPS.map(({ type, label, title }) => (
+          <button
+            key={type}
+            type="button"
+            className={'search-type-chip' + (state.searchTypes.includes(type) ? ' active' : '')}
+            aria-pressed={state.searchTypes.includes(type)}
+            title={title}
+            onClick={() => toggleType(type)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Every directory that contains a visible file, folder-relative,
+ *  sorted. Derived from the file list so the options always reflect
+ *  the live tree. */
+function subfolderScopes(files: FileMeta[]): string[] {
+  const dirs = new Set<string>();
+  for (const file of files) {
+    const parts = file.name.split('/');
+    for (let i = 1; i < parts.length; i++) {
+      dirs.add(parts.slice(0, i).join('/'));
+    }
+  }
+  return [...dirs].sort((a, b) => a.localeCompare(b));
 }
 
 function SearchStatusBanner() {

--- a/web-src/src/store/AppContext.tsx
+++ b/web-src/src/store/AppContext.tsx
@@ -29,6 +29,7 @@ import {
   type PendingHighlight,
   type State,
 } from './state';
+import type { SearchTypeCategory } from '../../../shared/search-types.ts';
 import type { EditorHandle, FindController } from './actionTypes';
 import { useDocumentActions } from './useDocumentActions';
 import { useFeedbackActions } from './useFeedbackActions';
@@ -81,7 +82,12 @@ export interface AppActions {
   runSearch: (
     query: string,
     mode?: 'semantic' | 'keyword',
-    opts?: { caseStrict?: boolean; wholeWord?: boolean },
+    opts?: {
+      caseStrict?: boolean;
+      wholeWord?: boolean;
+      scope?: string | null;
+      types?: SearchTypeCategory[];
+    },
   ) => Promise<void>;
   /** Clear the active folder's background-index warning. */
   dismissIndexWarning: () => Promise<void>;

--- a/web-src/src/store/__tests__/state.test.ts
+++ b/web-src/src/store/__tests__/state.test.ts
@@ -125,6 +125,8 @@ test('loading a different folder clears stale search state', () => {
     searching: true,
     searchHits: [{ fileName: 'old.md', chunkIndex: 0, content: 'old', heading: '', score: 1 }],
     searchError: 'stale',
+    searchScope: 'notes/archive',
+    searchTypes: ['pdf'],
   });
   const next = reducer(state, {
     type: 'FILES_LOADED',
@@ -139,4 +141,30 @@ test('loading a different folder clears stale search state', () => {
   assert.equal(next.searchHits, null);
   assert.equal(next.keywordResult, null);
   assert.equal(next.searchError, null);
+  assert.equal(next.searchScope, null);
+  assert.deepEqual(next.searchTypes, []);
+});
+
+test('scope and type filter changes clear both modes\' results', () => {
+  const hits = [{ fileName: 'a.md', chunkIndex: 0, content: 'x', heading: '', score: 1 }];
+  const keyword = { query: 'x', folder: 'f', files: [], totalMatches: 0, truncated: false };
+
+  const scoped = reducer(
+    freshState({ searchHits: hits, keywordResult: keyword }),
+    { type: 'SEARCH_SCOPE', scope: 'notes' },
+  );
+  assert.equal(scoped.searchScope, 'notes');
+  assert.equal(scoped.searchHits, null);
+  assert.equal(scoped.keywordResult, null);
+
+  const typed = reducer(
+    freshState({ searchHits: hits, keywordResult: keyword }),
+    { type: 'SEARCH_TYPES', types: ['pdf', 'docx'] },
+  );
+  assert.deepEqual(typed.searchTypes, ['pdf', 'docx']);
+  assert.equal(typed.searchHits, null);
+  assert.equal(typed.keywordResult, null);
+
+  const cleared = reducer(scoped, { type: 'SEARCH_SCOPE', scope: null });
+  assert.equal(cleared.searchScope, null);
 });

--- a/web-src/src/store/state.ts
+++ b/web-src/src/store/state.ts
@@ -17,6 +17,7 @@ import type {
   SearchHit,
   Agent,
 } from '../api';
+import type { SearchTypeCategory } from '../../../shared/search-types.ts';
 
 export {
   CHAT_MAX_WIDTH,
@@ -265,6 +266,12 @@ export interface State {
   /** Only meaningful in keyword mode. `true` = `--word-regexp` so
    *  "agent" doesn't match "agents". Hidden in semantic mode. */
   wholeWord: boolean;
+  /** Folder-relative subfolder the next search is scoped to; null =
+   *  whole folder. Reset when the active folder changes. */
+  searchScope: string | null;
+  /** File-type categories the next search includes; empty = every
+   *  category. Applies to both modes and composes with `searchScope`. */
+  searchTypes: SearchTypeCategory[];
   /** `null` = not in search mode (query empty or cleared). `[]` = ran
    *  and got nothing. Non-empty array = ranked hits from `/api/search`.
    *  Populated only when `searchMode === 'semantic'`. */
@@ -364,6 +371,8 @@ export const initialState: State = {
   searchMode: 'semantic',
   caseStrict: false,
   wholeWord: false,
+  searchScope: null,
+  searchTypes: [],
   searchHits: null,
   keywordResult: null,
   searching: false,
@@ -453,6 +462,8 @@ export type Action =
   | { type: 'SIDEBAR_VIEW'; view: 'files' | 'search' }
   | { type: 'SEARCH_CASE_STRICT'; strict: boolean }
   | { type: 'SEARCH_WHOLE_WORD'; on: boolean }
+  | { type: 'SEARCH_SCOPE'; scope: string | null }
+  | { type: 'SEARCH_TYPES'; types: SearchTypeCategory[] }
   | { type: 'INDEX_WARNING'; warning: IndexWarning | null }
   | { type: 'PREPARATION_FAILURES'; failures: PreparationFailure[] }
   | { type: 'CTX_MENU'; menu: CtxMenu | null }

--- a/web-src/src/store/stateReducer.ts
+++ b/web-src/src/store/stateReducer.ts
@@ -73,6 +73,10 @@ export function reducer(s: State, a: Action): State {
               searchHits: null,
               keywordResult: null,
               searchError: null,
+              // Scope names a subfolder of the previous folder; type
+              // filters are per-folder session state too.
+              searchScope: null,
+              searchTypes: [],
             }
           : {}),
       };
@@ -387,6 +391,11 @@ export function reducer(s: State, a: Action): State {
       return { ...s, caseStrict: a.strict, keywordResult: null };
     case 'SEARCH_WHOLE_WORD':
       return { ...s, wholeWord: a.on, keywordResult: null };
+    case 'SEARCH_SCOPE':
+      // Scope and type filters change both modes' result sets.
+      return { ...s, searchScope: a.scope, searchHits: null, keywordResult: null };
+    case 'SEARCH_TYPES':
+      return { ...s, searchTypes: a.types, searchHits: null, keywordResult: null };
     case 'INDEX_WARNING':
       return { ...s, indexWarning: a.warning };
     case 'PREPARATION_FAILURES':

--- a/web-src/src/store/useSearchActions.ts
+++ b/web-src/src/store/useSearchActions.ts
@@ -13,6 +13,7 @@ import {
   type State,
 } from './state';
 import type { ToastOptions } from './useFeedbackActions';
+import type { SearchTypeCategory } from '../../../shared/search-types.ts';
 
 const SEMANTIC_SEARCH_CANDIDATES = 30;
 const POLL_PENDING_MS = 1500;
@@ -330,7 +331,12 @@ export function useSearchActions(
   const runSearch = useCallback(async (
     query: string,
     modeOverride?: 'semantic' | 'keyword',
-    opts?: { caseStrict?: boolean; wholeWord?: boolean },
+    opts?: {
+      caseStrict?: boolean;
+      wholeWord?: boolean;
+      scope?: string | null;
+      types?: SearchTypeCategory[];
+    },
   ) => {
     const myGen = ++searchGen.current;
     const q = query.trim();
@@ -354,10 +360,13 @@ export function useSearchActions(
         // process-wide `currentFolder` singleton, which would pick the
         // wrong folder in multi-window sessions.
         const s = stateRef.current;
+        const scope = opts?.scope !== undefined ? opts.scope : s.searchScope;
         const result = await api.keywordSearch(q, {
           caseStrict: opts?.caseStrict ?? s.caseStrict,
           wholeWord: opts?.wholeWord ?? s.wholeWord,
           folder: folderPathAtStart || undefined,
+          pathPrefix: scope ?? undefined,
+          types: opts?.types ?? s.searchTypes,
         });
         if (isStaleSearch()) return;
         dispatch({ type: 'SEARCH_KEYWORD', result });
@@ -372,8 +381,12 @@ export function useSearchActions(
           });
           return;
         }
+        const s = stateRef.current;
+        const scope = opts?.scope !== undefined ? opts.scope : s.searchScope;
         const { hits } = await api.search(q, SEMANTIC_SEARCH_CANDIDATES, {
           folder: folderPathAtStart || undefined,
+          pathPrefix: scope ?? undefined,
+          types: opts?.types ?? s.searchTypes,
         });
         if (isStaleSearch()) return;
         dispatch({ type: 'SEARCH_HITS', hits: filterGuiSemanticHits(hits) });

--- a/web-src/src/styles/sidebar.css
+++ b/web-src/src/styles/sidebar.css
@@ -686,6 +686,57 @@
       font-weight: 600;
     }
 
+    /* Scope select + file-type chips under the search input. Both are
+     * quiet by default and highlight only when narrowing is active. */
+    .search-filters {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 4px;
+      padding: 0 12px 8px;
+    }
+    .search-scope {
+      max-width: 100%;
+      padding: 2px 4px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--bg);
+      color: var(--muted);
+      font: inherit;
+      font-size: 11px;
+      outline: none;
+    }
+    .search-scope:focus {
+      border-color: var(--accent);
+    }
+    .search-type-chips {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+    }
+    .search-type-chip {
+      appearance: none;
+      height: 20px;
+      padding: 0 7px;
+      border: 1px solid transparent;
+      border-radius: 10px;
+      background: transparent;
+      color: var(--muted);
+      font: inherit;
+      font-size: 11px;
+      cursor: pointer;
+      user-select: none;
+    }
+    .search-type-chip:hover {
+      background: var(--hover);
+      color: var(--fg);
+    }
+    .search-type-chip.active {
+      background: var(--active);
+      border-color: var(--border);
+      color: var(--fg);
+    }
+
     /* Brief glow when something programmatically focuses the search
      * input (empty-tab landing → "Search notes", ⌘O hotkey). Without
      * this the focus border alone is easy to miss when the user's


### PR DESCRIPTION
The in-app Search panel could not narrow results the way the indexer and MCP path already allowed. Add two composable filters to both semantic and keyword modes:

- Subfolder scope: a folder-relative subfolder resolved escape-safe against the active folder (rejects traversal, missing, non-dir).
- File-type categories (notes / pdf / image / docx) mapped to source extensions in server/format.ts, sharing one vocabulary via shared/search-types.ts.

The semantic path passes the extension filter to the daemon, which over-fetches from MFS (bounded), filters hits by source suffix, and truncates back to top_k, so filtering happens before the caller-visible cut. The keyword path restricts the ripgrep target and derived-text walk to the scoped subtree and enabled categories. Display-path remapping is unchanged: filters act on source paths and derived notes never surface.

## Before / After

Same query, same keyword mode — the only difference is the new subfolder-scope dropdown and file-type chips.

| Before | After |
|---|---|
| <img width="300" alt="search sidebar without filters" src="https://raw.githubusercontent.com/jashkarangiya/stashbase/pr-assets-search/pr-assets/search-before.png"> | <img width="300" alt="search sidebar with subfolder scope and file-type chips" src="https://raw.githubusercontent.com/jashkarangiya/stashbase/pr-assets-search/pr-assets/search-after.png"> |

Closes #31
