### PR TITLE
feat(markdown-editor): present fenced code with whole-block reveal

### DIFF
--- a/design-docs/design/markdown.md
+++ b/design-docs/design/markdown.md
@@ -14,6 +14,12 @@ without a conversion layer becoming the product.
   changing their source offsets: click reveals source, modifier-click or
   keyboard activation follows safe local links in StashBase and HTTP(S) links
   through the system browser.
+- In Live Editing, fenced code presents as an inert monospace block with its
+  fences and language label concealed; entering or selecting inside reveals
+  them as one editable construct and leaving restores the block, all without
+  changing source. The parser owns block boundaries, so backticks inside
+  content and unterminated fences do not corrupt them, and the language label
+  is only concealed markup — never parsed or executed.
 - Safe local links remain in StashBase; external links retain their normal
   browser behaviour.
 - Agent responses and Markdown documents remain distinct presentation contexts.

--- a/web-src/src/__tests__/code-editor.test.ts
+++ b/web-src/src/__tests__/code-editor.test.ts
@@ -86,6 +86,10 @@ test('Live Editing and Reading View share the supported Markdown construct subse
     '',
     '---',
     '',
+    '```ts',
+    'const value = 42;',
+    '```',
+    '',
   ].join('\n');
 
   const projectedKinds = new Set(
@@ -98,6 +102,7 @@ test('Live Editing and Reading View share the supported Markdown construct subse
     'strong',
     'strikethrough',
     'inline-code',
+    'fenced-code',
     'horizontal-rule',
   ]));
   assert.equal(
@@ -120,6 +125,7 @@ test('Live Editing and Reading View share the supported Markdown construct subse
   assert.match(readingView, /<del>strikethrough<\/del>/);
   assert.match(readingView, /<code>inline code<\/code>/);
   assert.match(readingView, /<hr\s*\/?>/);
+  assert.match(readingView, /<pre><code class="language-ts">/);
 });
 
 test('inactive Markdown constructs hide only recognized syntax and reveal every intersected construct', () => {
@@ -162,6 +168,83 @@ test('inactive Markdown constructs hide only recognized syntax and reveal every 
     { from: 14, to: 18 },
     { from: 25, to: 29 },
   ]);
+});
+
+test('Live fenced code presents an inert block and reveals its fences on entry', () => {
+  const doc = '```ts\nconst x = 1;\n```\n\nafter';
+
+  const inactive = describeLiveMarkdownProjection(markdownState(doc, { anchor: doc.length }));
+  assert.equal(inactive.length, 1);
+  assert.equal(inactive[0].kind, 'fenced-code');
+  assert.equal(inactive[0].from, 0);
+  assert.equal(inactive[0].active, false);
+
+  // Inactive conceals exactly the two fences and the language label.
+  assert.deepEqual(
+    hiddenMarkdownMarkupRanges(markdownState(doc, { anchor: doc.length }))
+      .map((range) => markdownState(doc).sliceDoc(range.from, range.to)),
+    ['```', 'ts', '```'],
+  );
+
+  // A cursor anywhere inside the block reveals it and conceals nothing.
+  const inside = doc.indexOf('const') + 2;
+  const active = describeLiveMarkdownProjection(markdownState(doc, { anchor: inside }));
+  assert.equal(active.length, 1);
+  assert.equal(active[0].active, true);
+  assert.deepEqual(hiddenMarkdownMarkupRanges(markdownState(doc, { anchor: inside })), []);
+
+  // Leaving the block restores its inactive presentation, and the
+  // projection never rewrites source in either state.
+  assert.equal(describeLiveMarkdownProjection(markdownState(doc, { anchor: doc.length }))[0].active, false);
+  assert.equal(markdownState(doc, { anchor: inside }).doc.toString(), doc);
+});
+
+test('Live fenced code stays safe across labels, unknown languages, and fenced content', () => {
+  // Unlabeled, known, and unknown-language blocks all project one block
+  // without throwing; the label is only concealed markup, never parsed.
+  for (const info of ['', 'ts', 'totally-unknown-language']) {
+    const doc = '```' + info + '\nvalue\n```\n\nafter';
+    const projected = describeLiveMarkdownProjection(markdownState(doc, { anchor: doc.length }));
+    assert.equal(projected.filter((construct) => construct.kind === 'fenced-code').length, 1);
+  }
+
+  // Backticks mid-line are content, not a fence, so the block stays whole.
+  const withTicks = '```\na ``` b\nc\n```\n\nafter';
+  assert.equal(
+    describeLiveMarkdownProjection(markdownState(withTicks, { anchor: withTicks.length }))
+      .filter((construct) => construct.kind === 'fenced-code').length,
+    1,
+  );
+
+  // An unterminated fence uses the parser-defined boundary and never throws.
+  const unterminated = '```ts\nstill going';
+  assert.doesNotThrow(() => describeLiveMarkdownProjection(markdownState(unterminated, { anchor: 0 })));
+
+  // Reading View remains the independent authority for fenced rendering.
+  assert.match(renderMarkdown('```ts\nconst x = 1;\n```'), /<pre><code class="language-ts">/);
+});
+
+test('Find and undo operate on fenced-code source through Live Editing concealment', () => {
+  // Find searches the document, so concealed fences and content stay
+  // reachable: the token inside the block is matched.
+  const doc = '```ts\nconst needle = 42;\n```';
+  let searchState = EditorState.create({
+    doc,
+    extensions: [markdown({ base: markdownLanguage }), search()],
+  });
+  const searchView = {
+    get state() { return searchState; },
+    dispatch(spec: Parameters<EditorState['update']>[0]) { searchState = searchState.update(spec).state; },
+  } as unknown as EditorView;
+  assert.equal(applyEditorQuery(searchView, 'needle', false, false, false).total, 1);
+
+  // The projection adds no history, so an edit inside a block undoes as
+  // one ordinary edit back to the exact source.
+  const editView = testView(markdownState(doc, { anchor: doc.indexOf('needle') }));
+  editView.dispatch({ changes: { from: doc.indexOf('needle'), insert: 'X' } });
+  assert.equal(editView.state.doc.toString(), doc.replace('needle', 'Xneedle'));
+  assert.equal(undo(editView), true);
+  assert.equal(editView.state.doc.toString(), doc);
 });
 
 test('Live projection limits work to visible parsed ranges and falls back to source while composing', () => {

--- a/web-src/src/components/CodeEditor.tsx
+++ b/web-src/src/components/CodeEditor.tsx
@@ -131,6 +131,11 @@ export function CodeEditor({
           borderRadius: '4px',
           padding: '0.1em 0.25em',
         },
+        '.cm-live-code-block': {
+          fontFamily: '"SF Mono", "JetBrains Mono", Menlo, Consolas, monospace',
+          fontSize: '0.9em',
+          backgroundColor: 'rgba(175, 184, 193, 0.16)',
+        },
         '.cm-live-strikethrough': { textDecoration: 'line-through' },
         '.cm-live-link': {
           color: '#0e7490',

--- a/web-src/src/components/liveMarkdown.ts
+++ b/web-src/src/components/liveMarkdown.ts
@@ -2,7 +2,7 @@ import { syntaxTree } from '@codemirror/language';
 import { StateEffect, StateField, type EditorState } from '@codemirror/state';
 import { Decoration, type DecorationSet, EditorView, type ViewUpdate, ViewPlugin, WidgetType } from '@codemirror/view';
 
-type ConstructKind = 'heading' | 'emphasis' | 'strong' | 'strikethrough' | 'inline-code' | 'horizontal-rule' | 'link';
+type ConstructKind = 'heading' | 'emphasis' | 'strong' | 'strikethrough' | 'inline-code' | 'fenced-code' | 'horizontal-rule' | 'link';
 
 export type ProjectionRange = { from: number; to: number };
 
@@ -26,6 +26,10 @@ type ProjectionRule = {
   nodeNames: readonly string[];
   markerNames: readonly string[];
   level?: (nodeName: string) => number | undefined;
+  /** Class applied to every line the construct spans, giving block
+   *  forms a stable full-width presentation independent of the
+   *  active/inactive marker reveal. */
+  lineClass?: string;
   sourceRanges?: (state: EditorState, construct: Construct) => ProjectionRange[];
   decorations: (construct: Construct, active: boolean) => Decoration[];
 };
@@ -132,6 +136,18 @@ const projectionRules: readonly ProjectionRule[] = [
     nodeNames: ['InlineCode'],
     markerNames: ['CodeMark'],
     decorations: () => [Decoration.mark({ class: 'cm-live-inline-code' })],
+  },
+  {
+    // The block is presented as an inert monospace surface; entering it
+    // reveals the concealed fences and language label as one construct.
+    // The parser owns the boundaries, so backticks inside content and
+    // unterminated fences never split a block. The label is never parsed
+    // or executed — it is only concealed markup.
+    kind: 'fenced-code',
+    nodeNames: ['FencedCode'],
+    markerNames: ['CodeMark', 'CodeInfo'],
+    lineClass: 'cm-live-code-block',
+    decorations: () => [],
   },
   {
     kind: 'horizontal-rule',
@@ -282,6 +298,15 @@ function buildDecorations(view: EditorView, onLinkActivate: LiveMarkdownLinkActi
     }
     for (const decoration of construct.rule.decorations(construct, active)) {
       markers.push({ from: construct.from, to: construct.to, decoration });
+    }
+    if (construct.rule.lineClass) {
+      const lineDecoration = Decoration.line({ class: construct.rule.lineClass });
+      for (let pos = construct.from; pos <= construct.to;) {
+        const line = state.doc.lineAt(pos);
+        markers.push({ from: line.from, to: line.from, decoration: lineDecoration });
+        if (line.to >= construct.to) break;
+        pos = line.to + 1;
+      }
     }
     if (!active) {
       for (const marker of sourceRangesFor(state, construct)) {


### PR DESCRIPTION
Adds fenced code as a Live Editing construct so code blocks read as blocks instead of raw prose, following the existing construct and reveal pattern.

## What it does

- Inactive fenced code renders as an inert monospace surface with the fences and language label concealed.
- Entering or selecting anywhere inside the block reveals both fences and the language label as one editable construct, and leaving restores the block.
- The projection never changes source or history. A small line-class capability on the projection rule gives the block its full-width presentation.
- The parser owns block boundaries, so backticks inside content and unterminated fences never split a block, and the language label is only concealed markup that is never parsed or executed.
- Reading View fenced rendering stays independently authoritative.

## Before / After

| Before | After |
|---|---|
| <img width="360" alt="fenced block as raw source" src="https://raw.githubusercontent.com/jashkarangiya/stashbase/pr-assets-live-code/pr-assets/code-before.png"> | <img width="360" alt="fenced block as an inert monospace block" src="https://raw.githubusercontent.com/jashkarangiya/stashbase/pr-assets-live-code/pr-assets/code-after.png"> |

Before, a fenced block shows raw ``` fences in the body font and reads like prose. After, it is an inert monospace block with the fences and label concealed.

Entering the block reveals its fences and label as one editable construct, while other blocks stay concealed:

<img width="440" alt="editing a fenced block reveals its fences" src="https://raw.githubusercontent.com/jashkarangiya/stashbase/pr-assets-live-code/pr-assets/code-revealed.png">

## Acceptance checklist

- [x] Inactive fenced code has a stable monospace block presentation.
- [x] Entering or selecting inside reveals both fences and its language label.
- [x] Leaving restores the inactive presentation without changing source or history.
- [x] Labeled, unlabeled, and unknown-language blocks remain readable.
- [x] Fence characters inside content and incomplete fences do not corrupt boundaries.
- [x] Code is never executed and raw HTML is never promoted into a live widget.
- [x] Selection, copy/cut, Find, undo/redo, autosave, and scroll stability are regression-covered.
- [x] Reading View fenced rendering remains independently authoritative.
- [x] Current-state design documentation updated.
- [x] Typecheck and renderer build pass.

## Verification

The renderer test suite passes, including new fenced-code tests for reveal and restore, labeled, unlabeled, and unknown languages, fenced content, unterminated fences, Find, and undo. Typecheck and renderer build pass. I also drove it in the app to confirm the block presentation, per-block reveal, and no console errors.

Closes #50
