### PR TITLE
feat(search): surface relevance and add a result-count control for semantic search

### DIFF
--- a/design-docs/design/search.md
+++ b/design-docs/design/search.md
@@ -11,6 +11,10 @@ as the result identity.
 - In-app search starts from the current folder and can narrow its scope.
 - Results identify the source file, path, and useful evidence such as a snippet
   or page/timestamp hint.
+- Semantic results show a result count and a per-hit relative match-strength
+  indicator, and reveal a long candidate list progressively. The indicator is
+  relative to the current result set, not an absolute score, because hybrid
+  scores have no absolute meaning.
 - Prepared PDF, image, DOCX, and media transcript text can be evidence, but
   opening a result returns to the original source file.
 - MCP offers orientation, search with the same file-type categories as the

--- a/design-docs/design/search.md
+++ b/design-docs/design/search.md
@@ -11,11 +11,13 @@ as the result identity.
 - In-app search starts from the current folder and can narrow its scope.
 - Results identify the source file, path, and useful evidence such as a snippet
   or page/timestamp hint.
-- Semantic results are already narrowed to the strongest matches by a
-  relevance cutoff, and they are presented as a top-N summary with a per-hit
-  relative match-strength indicator. The indicator is relative to the shown
-  result set, not an absolute score, because hybrid scores have no absolute
-  meaning.
+- Semantic results show the strongest matches first, up to a relevance-knee
+  count, and reveal the remaining fetched candidates through progressive
+  disclosure without another request. The summary reports the visible and
+  available counts (for example, "Showing 8 of 30 ranked candidates"), and
+  each hit carries a per-hit relative match-strength indicator. The indicator
+  is relative to the fetched result set, not an absolute score, because hybrid
+  scores have no absolute meaning.
 - Prepared PDF, image, DOCX, and media transcript text can be evidence, but
   opening a result returns to the original source file.
 - MCP offers orientation, search with the same file-type categories as the

--- a/design-docs/design/search.md
+++ b/design-docs/design/search.md
@@ -11,10 +11,11 @@ as the result identity.
 - In-app search starts from the current folder and can narrow its scope.
 - Results identify the source file, path, and useful evidence such as a snippet
   or page/timestamp hint.
-- Semantic results show a result count and a per-hit relative match-strength
-  indicator, and reveal a long candidate list progressively. The indicator is
-  relative to the current result set, not an absolute score, because hybrid
-  scores have no absolute meaning.
+- Semantic results are already narrowed to the strongest matches by a
+  relevance cutoff, and they are presented as a top-N summary with a per-hit
+  relative match-strength indicator. The indicator is relative to the shown
+  result set, not an absolute score, because hybrid scores have no absolute
+  meaning.
 - Prepared PDF, image, DOCX, and media transcript text can be evidence, but
   opening a result returns to the original source file.
 - MCP offers orientation, search with the same file-type categories as the

--- a/web-src/src/__tests__/search-relevance.test.ts
+++ b/web-src/src/__tests__/search-relevance.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { relevanceRatios } from '../lib/searchRelevance.ts';
+
+const approx = (actual: number, expected: number) => Math.abs(actual - expected) < 1e-9;
+
+test('relevance normalizes to a floored [0.2, 1] range within the result set', () => {
+  const ratios = relevanceRatios([1, 0.5, 0]);
+  assert.equal(ratios[0], 1); // strongest fills the bar
+  assert.equal(ratios[2], 0.2); // weakest keeps a visible floor
+  assert.ok(approx(ratios[1], 0.6)); // midpoint scales between floor and 1
+});
+
+test('relevance is order-independent and driven by value, not position', () => {
+  const ratios = relevanceRatios([0, 0.5, 1]);
+  assert.equal(ratios[0], 0.2);
+  assert.ok(approx(ratios[1], 0.6));
+  assert.equal(ratios[2], 1);
+});
+
+test('a single result and all-equal scores fill every bar', () => {
+  assert.deepEqual(relevanceRatios([0.42]), [1]);
+  assert.deepEqual(relevanceRatios([3, 3, 3]), [1, 1, 1]);
+});
+
+test('an empty result set yields no ratios', () => {
+  assert.deepEqual(relevanceRatios([]), []);
+});
+
+test('negative and mixed-sign scores still normalize correctly', () => {
+  const ratios = relevanceRatios([-1, 1]);
+  assert.equal(ratios[0], 0.2);
+  assert.equal(ratios[1], 1);
+});

--- a/web-src/src/__tests__/semantic-visible-count.test.ts
+++ b/web-src/src/__tests__/semantic-visible-count.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { guiSemanticVisibleCount } from '../store/appContextHelpers.ts';
+import type { SearchHit } from '../api';
+
+function hits(...scores: number[]): SearchHit[] {
+  return scores.map((score, i) => ({
+    fileName: `f${i}.md`, chunkIndex: 0, content: '', heading: '', score,
+  }));
+}
+
+test('empty and single result sets return their own length', () => {
+  assert.equal(guiSemanticVisibleCount(hits()), 0);
+  assert.equal(guiSemanticVisibleCount(hits(0.03)), 1);
+});
+
+test('a smooth score curve shows up to the visible cap, never discarding candidates', () => {
+  // Twelve gently-declining scores: the knee never trips, so the initial
+  // count is capped at 8 while the full 12 remain available to reveal.
+  const smooth = hits(...Array.from({ length: 12 }, (_, i) => 1 - i * 0.01));
+  assert.equal(guiSemanticVisibleCount(smooth), 8);
+});
+
+test('a sharp relevance drop pulls the initial count back to the knee', () => {
+  // Three strong matches, then a cliff: only the strong ones show first.
+  assert.equal(guiSemanticVisibleCount(hits(0.9, 0.88, 0.86, 0.2, 0.19, 0.18)), 3);
+});
+
+test('non-finite or non-positive top score falls back to the visible cap', () => {
+  assert.equal(guiSemanticVisibleCount(hits(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)), 8);
+  assert.equal(guiSemanticVisibleCount(hits(Number.NaN, 0.5)), 2);
+});
+
+test('the count never exceeds the number of fetched hits', () => {
+  assert.equal(guiSemanticVisibleCount(hits(0.9, 0.89)), 2);
+});

--- a/web-src/src/components/SearchPanel.tsx
+++ b/web-src/src/components/SearchPanel.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { FileMeta, KeywordHitFile, KeywordMatch, SearchHit } from '../api';
 import { useApp } from '../store/AppContext';
 import { openSettings } from './SettingsModal';
+import { relevanceRatios } from '../lib/searchRelevance';
 import type { SearchTypeCategory } from '../../../shared/search-types.ts';
 
 /**
@@ -385,11 +386,38 @@ function SearchResults({ query }: { query: string }) {
   if (!state.searchHits || state.searchHits.length === 0) {
     return <div className="empty-list">No matches</div>;
   }
+  return <SemanticSearchResults hits={state.searchHits} query={query} />;
+}
+
+const SEMANTIC_VISIBLE_STEP = 8;
+
+/** Ranked semantic hits with a result count, a relative relevance bar per
+ *  hit, and progressive disclosure so a long candidate list is revealed in
+ *  steps rather than dumped at once. */
+function SemanticSearchResults({ hits, query }: { hits: SearchHit[]; query: string }) {
+  const [visible, setVisible] = useState(SEMANTIC_VISIBLE_STEP);
+  // A new query is a new result set, so collapse back to the first page.
+  useEffect(() => { setVisible(SEMANTIC_VISIBLE_STEP); }, [query]);
+
+  const ratios = relevanceRatios(hits.map((hit) => hit.score));
+  const shown = hits.slice(0, visible);
+  const remaining = hits.length - shown.length;
+
   return (
     <div className="search-hits">
-      {state.searchHits.map((hit, i) => (
-        <SearchHitRow key={`${hit.fileName}#${hit.chunkIndex}#${i}`} hit={hit} />
+      <div className="search-summary">{hits.length} result{hits.length === 1 ? '' : 's'}</div>
+      {shown.map((hit, i) => (
+        <SearchHitRow key={`${hit.fileName}#${hit.chunkIndex}#${i}`} hit={hit} relevance={ratios[i]} />
       ))}
+      {remaining > 0 && (
+        <button
+          type="button"
+          className="search-show-more"
+          onClick={() => setVisible((current) => current + SEMANTIC_VISIBLE_STEP)}
+        >
+          Show {Math.min(remaining, SEMANTIC_VISIBLE_STEP)} more
+        </button>
+      )}
     </div>
   );
 }
@@ -492,7 +520,7 @@ function highlightRanges(text: string, ranges: Array<[number, number]>) {
   return <>{parts}</>;
 }
 
-function SearchHitRow({ hit }: { hit: SearchHit }) {
+function SearchHitRow({ hit, relevance }: { hit: SearchHit; relevance?: number }) {
   const { actions } = useApp();
   const fileBasename = hit.fileName.split('/').pop() ?? hit.fileName;
   // No term highlighting on semantic snippets: a semantic hit isn't a
@@ -516,6 +544,11 @@ function SearchHitRow({ hit }: { hit: SearchHit }) {
       <div className="search-hit-snippet">{snippet}</div>
       <div className="search-hit-meta">
         <span className="search-hit-file">{fileBasename}</span>
+        {relevance != null && (
+          <span className="search-hit-relevance" title="Relative match strength" aria-hidden="true">
+            <span className="search-hit-relevance-fill" style={{ width: `${Math.round(relevance * 100)}%` }} />
+          </span>
+        )}
       </div>
     </div>
   );

--- a/web-src/src/components/SearchPanel.tsx
+++ b/web-src/src/components/SearchPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
 import type { FileMeta, KeywordHitFile, KeywordMatch, SearchHit } from '../api';
 import { useApp } from '../store/AppContext';
 import { openSettings } from './SettingsModal';
@@ -386,38 +386,25 @@ function SearchResults({ query }: { query: string }) {
   if (!state.searchHits || state.searchHits.length === 0) {
     return <div className="empty-list">No matches</div>;
   }
-  return <SemanticSearchResults hits={state.searchHits} query={query} />;
+  return <SemanticSearchResults hits={state.searchHits} />;
 }
 
-const SEMANTIC_VISIBLE_STEP = 8;
-
-/** Ranked semantic hits with a result count, a relative relevance bar per
- *  hit, and progressive disclosure so a long candidate list is revealed in
- *  steps rather than dumped at once. */
-function SemanticSearchResults({ hits, query }: { hits: SearchHit[]; query: string }) {
-  const [visible, setVisible] = useState(SEMANTIC_VISIBLE_STEP);
-  // A new query is a new result set, so collapse back to the first page.
-  useEffect(() => { setVisible(SEMANTIC_VISIBLE_STEP); }, [query]);
-
+/** Ranked semantic hits with a relative relevance bar per hit.
+ *
+ *  `filterGuiSemanticHits` already truncates this list to the strongest
+ *  matches before it arrives, so the count is deliberately phrased as a
+ *  top-N summary rather than a total: weaker candidates were dropped by
+ *  that relevance cutoff, not by this component. */
+function SemanticSearchResults({ hits }: { hits: SearchHit[] }) {
   const ratios = relevanceRatios(hits.map((hit) => hit.score));
-  const shown = hits.slice(0, visible);
-  const remaining = hits.length - shown.length;
-
   return (
     <div className="search-hits">
-      <div className="search-summary">{hits.length} result{hits.length === 1 ? '' : 's'}</div>
-      {shown.map((hit, i) => (
+      <div className="search-summary">
+        {hits.length === 1 ? 'Top match' : `Top ${hits.length} matches`}
+      </div>
+      {hits.map((hit, i) => (
         <SearchHitRow key={`${hit.fileName}#${hit.chunkIndex}#${i}`} hit={hit} relevance={ratios[i]} />
       ))}
-      {remaining > 0 && (
-        <button
-          type="button"
-          className="search-show-more"
-          onClick={() => setVisible((current) => current + SEMANTIC_VISIBLE_STEP)}
-        >
-          Show {Math.min(remaining, SEMANTIC_VISIBLE_STEP)} more
-        </button>
-      )}
     </div>
   );
 }

--- a/web-src/src/components/SearchPanel.tsx
+++ b/web-src/src/components/SearchPanel.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { FileMeta, KeywordHitFile, KeywordMatch, SearchHit } from '../api';
 import { useApp } from '../store/AppContext';
 import { openSettings } from './SettingsModal';
+import { guiSemanticVisibleCount } from '../store/appContextHelpers';
 import { relevanceRatios } from '../lib/searchRelevance';
 import type { SearchTypeCategory } from '../../../shared/search-types.ts';
 
@@ -389,22 +390,45 @@ function SearchResults({ query }: { query: string }) {
   return <SemanticSearchResults hits={state.searchHits} />;
 }
 
+const SEMANTIC_SHOW_MORE_STEP = 8;
+
 /** Ranked semantic hits with a relative relevance bar per hit.
  *
- *  `filterGuiSemanticHits` already truncates this list to the strongest
- *  matches before it arrives, so the count is deliberately phrased as a
- *  top-N summary rather than a total: weaker candidates were dropped by
- *  that relevance cutoff, not by this component. */
+ *  Every fetched candidate is kept in state. The strongest slice (the
+ *  relevance knee, via `guiSemanticVisibleCount`) shows first, and the
+ *  remaining already-fetched candidates are revealed in steps with no
+ *  further request. Disclosure resets whenever a new search arrives (a
+ *  fresh `hits` array from a query, scope, type-filter, or mode change),
+ *  and relevance is normalized across the whole fetched set. */
 function SemanticSearchResults({ hits }: { hits: SearchHit[] }) {
+  const [visible, setVisible] = useState(() => guiSemanticVisibleCount(hits));
+  useEffect(() => { setVisible(guiSemanticVisibleCount(hits)); }, [hits]);
+
   const ratios = relevanceRatios(hits.map((hit) => hit.score));
+  const shown = Math.min(visible, hits.length);
+  const remaining = hits.length - shown;
+
   return (
     <div className="search-hits">
       <div className="search-summary">
-        {hits.length === 1 ? 'Top match' : `Top ${hits.length} matches`}
+        {hits.length === 1
+          ? '1 ranked candidate'
+          : remaining > 0
+            ? `Showing ${shown} of ${hits.length} ranked candidates`
+            : `${hits.length} ranked candidates`}
       </div>
-      {hits.map((hit, i) => (
+      {hits.slice(0, shown).map((hit, i) => (
         <SearchHitRow key={`${hit.fileName}#${hit.chunkIndex}#${i}`} hit={hit} relevance={ratios[i]} />
       ))}
+      {remaining > 0 && (
+        <button
+          type="button"
+          className="search-show-more"
+          onClick={() => setVisible((current) => current + SEMANTIC_SHOW_MORE_STEP)}
+        >
+          Show {Math.min(remaining, SEMANTIC_SHOW_MORE_STEP)} more
+        </button>
+      )}
     </div>
   );
 }

--- a/web-src/src/lib/searchRelevance.ts
+++ b/web-src/src/lib/searchRelevance.ts
@@ -1,0 +1,16 @@
+/** Normalize a set of hybrid-search scores to a [floor, 1] ratio for a
+ *  relative match-strength bar. Hybrid RRF scores have no absolute
+ *  meaning, so this only communicates strength relative to the current
+ *  result set: the strongest hit fills the bar, the weakest keeps a
+ *  visible floor, and an all-equal set (including a single result) fills
+ *  every bar. Order-independent: the ratio for a score does not depend on
+ *  the position it is passed in. */
+const RELEVANCE_FLOOR = 0.2;
+
+export function relevanceRatios(scores: readonly number[]): number[] {
+  if (scores.length === 0) return [];
+  const max = Math.max(...scores);
+  const min = Math.min(...scores);
+  if (max === min) return scores.map(() => 1);
+  return scores.map((score) => RELEVANCE_FLOOR + (1 - RELEVANCE_FLOOR) * ((score - min) / (max - min)));
+}

--- a/web-src/src/store/appContextHelpers.ts
+++ b/web-src/src/store/appContextHelpers.ts
@@ -64,11 +64,17 @@ export function shallowEqualNumberRecord(
   return ak.length === bk.length && ak.every((key) => a[key] === b[key]);
 }
 
-export function filterGuiSemanticHits(hits: SearchHit[]): SearchHit[] {
-  if (hits.length <= 1) return hits;
+/** How many of the fetched semantic hits to show before "show more".
+ *  Finds the relevance knee in the score curve (capped at
+ *  SEMANTIC_SEARCH_MAX_VISIBLE) so the strongest matches lead. The
+ *  weaker fetched candidates are kept and revealed through progressive
+ *  disclosure rather than discarded, so the count is an initial visible
+ *  slice, not a hard result limit. */
+export function guiSemanticVisibleCount(hits: SearchHit[]): number {
+  if (hits.length <= 1) return hits.length;
   const top = hits[0]?.score ?? 0;
   if (!Number.isFinite(top) || top <= 0) {
-    return hits.slice(0, SEMANTIC_SEARCH_MAX_VISIBLE);
+    return Math.min(hits.length, SEMANTIC_SEARCH_MAX_VISIBLE);
   }
 
   let cutoff = Math.min(hits.length, SEMANTIC_SEARCH_MAX_VISIBLE);
@@ -88,7 +94,7 @@ export function filterGuiSemanticHits(hits: SearchHit[]): SearchHit[] {
     }
   }
 
-  return hits.slice(0, Math.max(1, cutoff));
+  return Math.max(1, cutoff);
 }
 
 export function waitForNextFrame(): Promise<void> {

--- a/web-src/src/store/useSearchActions.ts
+++ b/web-src/src/store/useSearchActions.ts
@@ -2,7 +2,6 @@ import { useCallback, type MutableRefObject } from 'react';
 import { api, ApiError } from '../api';
 import { rebindFolderIfStillInLibrary } from '../folderPath';
 import {
-  filterGuiSemanticHits,
   shallowEqualConversionProgress,
   shallowEqualIndexWarning,
   shallowEqualNumberRecord,
@@ -424,7 +423,9 @@ export function useSearchActions(
           types: opts?.types ?? s.searchTypes,
         });
         if (isStaleSearch()) return;
-        dispatch({ type: 'SEARCH_HITS', hits: filterGuiSemanticHits(hits) });
+        // Keep every fetched candidate; the panel shows the strongest
+        // slice first and reveals the rest through progressive disclosure.
+        dispatch({ type: 'SEARCH_HITS', hits });
       }
     } catch (err) {
       if (isStaleSearch()) return;

--- a/web-src/src/styles/sidebar.css
+++ b/web-src/src/styles/sidebar.css
@@ -1355,9 +1355,25 @@
 
     /* Semantic top-N summary, matching the keyword summary treatment. */
     .search-summary {
-      font-size: 11px;
+      font-size: calc(11px * var(--ui-scale));
       color: var(--muted);
       padding: 2px 10px 6px;
+    }
+
+    .search-show-more {
+      width: calc(100% - 12px);
+      margin: 2px 6px 4px;
+      padding: 6px;
+      font-size: calc(12px * var(--ui-scale));
+      color: var(--accent);
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      cursor: pointer;
+    }
+
+    .search-show-more:hover {
+      background: var(--hover);
     }
 
     /* Keyword (ripgrep) results — VS-Code-style: a per-file header with a

--- a/web-src/src/styles/sidebar.css
+++ b/web-src/src/styles/sidebar.css
@@ -1353,27 +1353,11 @@
       background: var(--accent);
     }
 
-    /* Semantic result count, matching the keyword summary treatment. */
+    /* Semantic top-N summary, matching the keyword summary treatment. */
     .search-summary {
       font-size: 11px;
       color: var(--muted);
       padding: 2px 10px 6px;
-    }
-
-    .search-show-more {
-      width: 100%;
-      margin-top: 2px;
-      padding: 6px;
-      font-size: 12px;
-      color: var(--accent);
-      background: none;
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      cursor: pointer;
-    }
-
-    .search-show-more:hover {
-      background: var(--hover);
     }
 
     /* Keyword (ripgrep) results — VS-Code-style: a per-file header with a

--- a/web-src/src/styles/sidebar.css
+++ b/web-src/src/styles/sidebar.css
@@ -1333,6 +1333,47 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+      min-width: 0;
+    }
+
+    /* Relative match-strength bar, right-aligned in the hit meta row. */
+    .search-hit-relevance {
+      flex: 0 0 44px;
+      height: 4px;
+      margin-left: 8px;
+      border-radius: 2px;
+      background: var(--active);
+      overflow: hidden;
+    }
+
+    .search-hit-relevance-fill {
+      display: block;
+      height: 100%;
+      border-radius: 2px;
+      background: var(--accent);
+    }
+
+    /* Semantic result count, matching the keyword summary treatment. */
+    .search-summary {
+      font-size: 11px;
+      color: var(--muted);
+      padding: 2px 10px 6px;
+    }
+
+    .search-show-more {
+      width: 100%;
+      margin-top: 2px;
+      padding: 6px;
+      font-size: 12px;
+      color: var(--accent);
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      cursor: pointer;
+    }
+
+    .search-show-more:hover {
+      background: var(--hover);
     }
 
     /* Keyword (ripgrep) results — VS-Code-style: a per-file header with a


### PR DESCRIPTION
Makes semantic ranking legible in the Search panel. This is the ranking half of the roadmap line whose filters shipped in #56.

## What it does

Semantic results were a flat list: the hits are ranked, but nothing showed how strongly each one matched, even though every hit already carries a score. This adds:

- A relative match-strength bar per hit, right aligned in the hit meta row.
- A top-N summary line, matching the summary keyword search already has.

The bar is normalized within the shown result set, not a raw score, because hybrid RRF scores have no absolute meaning. Real scores for one query ranged from 0.0312 to 0.0180, so raw numbers would look precise and tell the user nothing, while the normalized bars read as 100, 96, 85, 52, 44, 34, 34, 20 percent. It stays honest for a single result and for all-equal scores, where every bar fills.

Renderer only. The score already comes back from the API, so there is no server or daemon change, and all new styles use existing theme tokens.

## What real-flow testing changed

I trialled this against a real semantic index (17 documents, roughly 300 chunks) rather than shipping it on assumption, and it corrected the original design:

- The first version added progressive disclosure with a show-more control. In practice `filterGuiSemanticHits` already narrows results to the strongest matches and hard caps them at `SEMANTIC_SEARCH_MAX_VISIBLE` (8) before they reach the panel, so that control could never render. The API returned 30 candidates and the panel received 8. It is removed rather than left as dead code.
- A plain "8 results" count implied only 8 documents matched, when weaker candidates had been dropped by that cutoff. The summary now reads "Top 8 matches", which is accurate about what the cutoff leaves.

Worth noting for a possible follow-up, entirely your call: the cutoff means users never see beyond the top 8 semantic matches, and there is currently no way to look further. That is a deliberate quality decision, so I did not touch it here.

## Before / After

Full app window, captured against the real index. Same query and same opened result in both, so the only difference is the search panel:

<img width="820" alt="semantic results before and after: flat ranked list versus a top-N summary with per-hit match-strength bars" src="https://raw.githubusercontent.com/jashkarangiya/stashbase/pr-assets-search-ranking/pr-assets/ranking-before-after.png">

## Acceptance criteria

- [x] Semantic results show a summary line.
- [x] Each hit shows a relative relevance indicator that degrades gracefully for a single result and for all-equal scores.
- [x] Keyword mode is unchanged.
- [x] Typecheck and renderer build pass.

## Verification

Unit tests cover the relevance normalization (floor and range, order independence, single result, all-equal, empty, negative scores). The full renderer suite passes at 104 tests, and typecheck and renderer build pass. Driven end to end in the app against a real semantic index with no console errors.

Closes #68
