### PR TITLE
fix(markdown): improve dark menu contrast

### DIFF
--- a/code-review/markdown-rendering.md
+++ b/code-review/markdown-rendering.md
@@ -25,7 +25,10 @@ CodeMirror Markdown editor, HTML preview, or iframe document surface.
   bridge. Milkdown's frame stylesheet assigns its variables directly on its
   root, so inherited app tokens alone are insufficient: keep the bridge more
   specific than the package selector and map its menus, placeholders, tooltips,
-  and code blocks to the active light/dark roles.
+  and code blocks to the active light/dark roles. Crepe uses its outline token
+  for contextual-toolbar and slash-menu glyphs, so those controls need explicit
+  inactive, hover, and active colors rather than inheriting the subtle border
+  role.
 - The Agent-message Markdown renderer remains separate from document Markdown.
 
 ## Integration invariants

--- a/design-docs/design/markdown.md
+++ b/design-docs/design/markdown.md
@@ -24,6 +24,8 @@ Agent without a conversion layer becoming the product.
   outside the visual document body. GitHub alert markers render as accessible
   styled blockquotes while retaining their standard Markdown source.
 - Inline and block LaTex math are available through Crepe's KaTeX feature.
+- Contextual authoring controls retain distinct inactive, hover, and active
+  states in both light and dark themes.
 - Find, anchors, search-result highlighting, local-link navigation, and image
   activation attach to the Markdown document DOM in both modes.
 - Safe local links remain in StashBase; external HTTP(S) links use the system

--- a/web-src/src/styles/mainpane.css
+++ b/web-src/src/styles/mainpane.css
@@ -321,7 +321,62 @@
     }
     .crepe-shell .milkdown-code-block .cm-cursor { border-left-color: var(--focus-ring); }
     .crepe-shell .milkdown-code-block .cm-lineNumbers .cm-gutterElement { color: var(--crepe-color-on-surface-variant); }
-    .crepe-shell .crepe-toolbar, .crepe-shell .crepe-link-tooltip, .crepe-shell .crepe-slash-menu { color: var(--fg); }
+    .crepe-shell .crepe-link-tooltip, .crepe-shell .crepe-slash-menu { color: var(--fg); }
+    /* Crepe uses its outline token for toolbar glyphs. That token correctly
+       maps to our subtle borders elsewhere, but makes inactive controls
+       disappear on the dark raised surface. Give this compact selection menu
+       a deliberate, readable state ladder instead. */
+    .crepe-shell .milkdown-toolbar {
+      background: var(--surface-raised);
+      border: 1px solid color-mix(in srgb, var(--stroke-strong) 58%, transparent);
+      box-shadow: 0 14px 30px rgba(var(--shadow-color), .32), 0 3px 8px rgba(var(--shadow-color), .2);
+    }
+    .crepe-shell .milkdown-toolbar .divider {
+      background: color-mix(in srgb, var(--stroke-strong) 62%, transparent);
+    }
+    .crepe-shell .milkdown .milkdown-toolbar .toolbar-item svg {
+      color: color-mix(in srgb, var(--fg) 78%, var(--bg));
+      fill: color-mix(in srgb, var(--fg) 78%, var(--bg));
+    }
+    .crepe-shell .milkdown-toolbar .toolbar-item:hover {
+      background: color-mix(in srgb, var(--fg) 9%, transparent);
+    }
+    .crepe-shell .milkdown .milkdown-toolbar .toolbar-item:hover svg {
+      color: var(--fg);
+      fill: var(--fg);
+    }
+    .crepe-shell .milkdown-toolbar .toolbar-item.active {
+      background: color-mix(in srgb, var(--accent) 16%, transparent);
+    }
+    .crepe-shell .milkdown .milkdown-toolbar .toolbar-item.active svg {
+      color: var(--accent);
+      fill: var(--accent);
+    }
+    .crepe-shell .milkdown .milkdown-slash-menu {
+      background: var(--surface-raised);
+      border: 1px solid color-mix(in srgb, var(--stroke-strong) 58%, transparent);
+      box-shadow: 0 18px 38px rgba(var(--shadow-color), .34), 0 4px 10px rgba(var(--shadow-color), .2);
+    }
+    .crepe-shell .milkdown .milkdown-slash-menu .tab-group {
+      border-bottom-color: color-mix(in srgb, var(--stroke-strong) 52%, transparent);
+    }
+    .crepe-shell .milkdown .milkdown-slash-menu .tab-group ul li:hover,
+    .crepe-shell .milkdown .milkdown-slash-menu .menu-groups .menu-group li.hover {
+      background: color-mix(in srgb, var(--fg) 9%, transparent);
+    }
+    .crepe-shell .milkdown .milkdown-slash-menu .tab-group ul li.selected,
+    .crepe-shell .milkdown .milkdown-slash-menu .menu-groups .menu-group li.active {
+      background: color-mix(in srgb, var(--accent) 16%, transparent);
+    }
+    .crepe-shell .milkdown .milkdown-slash-menu .menu-groups .menu-group li svg {
+      color: color-mix(in srgb, var(--fg) 78%, var(--bg));
+      fill: color-mix(in srgb, var(--fg) 78%, var(--bg));
+    }
+    .crepe-shell .milkdown .milkdown-slash-menu .menu-groups .menu-group li.hover svg,
+    .crepe-shell .milkdown .milkdown-slash-menu .menu-groups .menu-group li.active svg {
+      color: var(--fg);
+      fill: var(--fg);
+    }
     /* Crepe sizes its edit field and existing-link preview independently.
        Treat both as one responsive popover so switching between them does not
        make the surrounding document jump. */


### PR DESCRIPTION
## Summary

- improve contrast for inactive Milkdown contextual-toolbar and slash-menu icons in dark mode
- add distinct hover, keyboard-selected, and active states while retaining the StashBase theme palette
- document the editor-menu color contract for future Milkdown theme updates

## Why

Milkdown uses its outline color for menu glyphs. StashBase maps that token to the subtle border role, which left inactive controls difficult to see against dark menu surfaces.

## User impact

Markdown formatting controls and slash-menu block icons remain clearly visible in dark mode, with selected actions still identifiable through the cyan accent.

## Documentation

Updated the Markdown design guide and maintainer review contract to preserve the dark-theme interaction-state requirement.

## Validation

- `git diff --check`
- `pnpm typecheck`
- `pnpm test:renderer` (62 passing)
- `npx vite build --config web-src/vite.config.ts`