### PR TITLE
fix(agent): show install guidance for unavailable built-in agents

### DIFF
--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -23,6 +23,10 @@ Community contributions can land as useful first iterations, but the long-term d
 - Keep the panel renderer-led. Do not change agent transport, session persistence, MCP, indexing, or permission policy just to support presentation changes.
 - Prefer small, familiar agent-chat affordances over a bespoke workbench UI.
 - Treat user-action states as first-class. Permission approvals, retry actions, and stopped-turn editing must remain visible and directly actionable.
+- A discovered missing Agent CLI is a setup state, not a disabled launcher or a
+  generic connection failure. Keep its install command copyable and let the
+  user re-run discovery after installation; do not conflate it with an
+  installed runtime that has failed.
 - Keep background activity compact. Tool calls may be grouped or summarized, but the user must be able to inspect them when needed.
 - File outputs should be easy to open, but artifact UI should stay lightweight. Prefer rows or compact affordances over large delivery cards.
 - Streaming should not steal the user's scroll position. If the user has scrolled away from the bottom, show a clear jump-to-latest affordance.

--- a/design-docs/design/agent-panel.md
+++ b/design-docs/design/agent-panel.md
@@ -18,6 +18,9 @@ context, not a separate AI workspace.
 - Agent file outputs and local file links lead back into the local workspace.
 - Agent response Markdown supports GFM, but treats raw HTML and remote images
   as inert content; only workspace-relative links and HTTP(S) links are active.
+- If a supported Agent CLI is missing, its launcher opens a compact setup state
+  with the copyable install command and a runtime-refresh action. A missing CLI
+  is distinct from a runtime that is installed but failed to start.
 
 ## Experience Contract
 

--- a/server/__tests__/agent-contract.test.ts
+++ b/server/__tests__/agent-contract.test.ts
@@ -60,9 +60,15 @@ test('Shared Agent Contract retains lifecycle, streaming, approval, session, and
 });
 
 test('capability discovery reports supported, unavailable, and failed runtimes without changing adapter metadata', () => {
+  const expectedInstallHints = {
+    claude: 'npm install -g @anthropic-ai/claude-code',
+    codex: 'npm install -g @openai/codex',
+  } as const;
   for (const adapter of BUILT_IN_AGENT_ADAPTERS) {
     assert.equal(runtimeDescriptorFor(adapter, `/native/${adapter.id}`).state, 'available');
-    assert.equal(runtimeDescriptorFor(adapter, null).state, 'unavailable');
+    const unavailable = runtimeDescriptorFor(adapter, null);
+    assert.equal(unavailable.state, 'unavailable');
+    assert.equal(unavailable.installHint, expectedInstallHints[adapter.id]);
   }
   const adapter = BUILT_IN_AGENT_ADAPTERS[0]!;
 

--- a/web-src/src/components/AgentView.tsx
+++ b/web-src/src/components/AgentView.tsx
@@ -11,7 +11,7 @@
  * See design-docs/architecture.md §8 for the shared library path.
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { api, getWindowId, type AgentContextFile, type AgentsResponse } from '../api';
+import { api, getWindowId, type Agent, type AgentContextFile, type AgentsResponse } from '../api';
 import { AGENT_META, type AgentKind } from '../agentCatalog';
 import { FILE_MIME } from '../dragMime';
 import { acceptsAgentContextDrop, dragPayloadKinds } from '../dragRouting';
@@ -67,6 +67,7 @@ export function AgentView({
   const { state, dispatch, actions } = useApp();
   const meta = AGENT_META[agent];
   const runtime = state.agents.find((candidate) => candidate.id === agent);
+  const runtimeUnavailable = runtime?.state === 'unavailable';
   const capabilities = runtime?.capabilities ?? meta.capabilities;
   const folderPathRef = useRef(state.folderPath);
   folderPathRef.current = state.folderPath;
@@ -123,12 +124,34 @@ export function AgentView({
     mountedRef.current = false;
   }, []);
 
+  // A launcher can be clicked before the chrome's initial discovery request
+  // settles. Keep that tab out of the WebSocket path until its runtime has a
+  // descriptor, so a missing CLI never briefly becomes a generic failure.
+  useEffect(() => {
+    if (!runtime) void refreshRuntimes();
+  }, [runtime]);
+
   function setTurnBusy(active: boolean) {
     turnActiveRef.current = active;
     setTurnActive(active);
   }
 
   useEffect(() => {
+    if (!runtime) {
+      readyRef.current = false;
+      setPhase('connecting');
+      setFatal(null);
+      return;
+    }
+    // Discovery is authoritative once it has returned. Do not open a socket
+    // for a known-missing CLI: the setup card below is the actionable state,
+    // rather than a generic connection failure.
+    if (runtimeUnavailable) {
+      readyRef.current = false;
+      setPhase('closed');
+      setFatal(null);
+      return;
+    }
     readyRef.current = false;
     // Consume-and-clear the resume id: it belongs to this one connection,
     // so a later reconnect (Retry / effort change) starts fresh instead of
@@ -170,7 +193,7 @@ export function AgentView({
       try { ws.send(JSON.stringify({ t: 'close' })); } catch { /* gone */ }
       ws.close();
     };
-  }, [nonce, runtime?.endpoint, agent, meta.shortName]);
+  }, [nonce, runtime?.endpoint, runtimeUnavailable, agent, meta.shortName]);
 
   /** Tear down and start a fresh session (Retry button / after the user
    *  reopens a folder). */
@@ -191,10 +214,14 @@ export function AgentView({
 
   /** Refresh after a failed or successful connection so the chrome reflects
    * the contract's in-memory available/failed state. */
-  function refreshRuntimes() {
-    void api.listAgents().then((result: AgentsResponse) => {
+  async function refreshRuntimes() {
+    try {
+      const result: AgentsResponse = await api.listAgents();
       dispatch({ type: 'AGENTS_LOADED', agents: result.clis });
-    }).catch(() => { /* retain the last known catalog */ });
+    } catch {
+      // Retain the last known catalog so an unavailable runtime remains
+      // actionable even while the local server is restarting.
+    }
   }
 
   /** Open a past session from the History dropdown: paint its transcript,
@@ -711,28 +738,46 @@ export function AgentView({
           </Button>
         </div>
       </div>
-      <MessageList
-        blocks={blocks}
-        queuedTurns={queuedTurns}
-        turnActive={turnActive}
-        phase={phase}
-        fatal={fatal}
-        agentName={meta.name}
-        agentShortName={meta.shortName}
-        Icon={meta.Icon}
-        editableUserMessageIds={editableUserMessageIds}
-        onPermission={replyPermission}
-        onSteerQueued={steerQueuedPrompt}
-        onCopyUserMessage={copyUserMessage}
-        onResendUserMessage={send}
-        onRetry={reconnect}
-        onOpenArtifact={(path) => {
-          const folder = folderPathRef.current;
-          const rel = path.startsWith(`${folder}/`) ? path.slice(folder.length + 1) : path;
-          if (isSafeFolderRelativePath(rel)) void actions.selectFile(rel);
-        }}
-      />
-      {phase === 'closed' && (
+      {!runtime ? (
+        <AgentRuntimeChecking name={meta.name} onRefresh={() => void refreshRuntimes()} />
+      ) : runtimeUnavailable ? (
+        <AgentRuntimeSetup
+          runtime={runtime}
+          fallbackName={meta.name}
+          onCopy={() => {
+            if (!runtime) return;
+            void copyText(runtime.installHint).then((copied) => {
+              actions.toast(
+                copied ? 'Install command copied.' : 'Could not copy install command.',
+                { level: copied ? 'info' : 'error' },
+              );
+            });
+          }}
+          onRefresh={() => void refreshRuntimes()}
+        />
+      ) : <>
+        <MessageList
+          blocks={blocks}
+          queuedTurns={queuedTurns}
+          turnActive={turnActive}
+          phase={phase}
+          fatal={fatal}
+          agentName={meta.name}
+          agentShortName={meta.shortName}
+          Icon={meta.Icon}
+          editableUserMessageIds={editableUserMessageIds}
+          onPermission={replyPermission}
+          onSteerQueued={steerQueuedPrompt}
+          onCopyUserMessage={copyUserMessage}
+          onResendUserMessage={send}
+          onRetry={reconnect}
+          onOpenArtifact={(path) => {
+            const folder = folderPathRef.current;
+            const rel = path.startsWith(`${folder}/`) ? path.slice(folder.length + 1) : path;
+            if (isSafeFolderRelativePath(rel)) void actions.selectFile(rel);
+          }}
+        />
+        {phase === 'closed' && (
         !fatal && (
           <div className="agent-ended">
             <span>Session ended.</span>
@@ -760,8 +805,79 @@ export function AgentView({
         onSend={send}
         onStop={stop}
       />
+      </>}
     </div>
   );
+}
+
+function AgentRuntimeSetup({
+  runtime,
+  fallbackName,
+  onCopy,
+  onRefresh,
+}: {
+  runtime: Agent | undefined;
+  fallbackName: string;
+  onCopy: () => void;
+  onRefresh: () => void;
+}) {
+  const name = runtime?.label ?? fallbackName;
+  const installHint = runtime?.installHint ?? '';
+  return (
+    <div className="agent-runtime-setup" role="status">
+      <div className="agent-runtime-setup-card">
+        <h2>{name} is not installed</h2>
+        <p>Install its CLI to start a built-in chat.</p>
+        <code>{installHint}</code>
+        <div className="agent-runtime-setup-actions">
+          <Button className="agent-btn primary" onPress={onCopy}>Copy command</Button>
+          <Button className="agent-btn" onPress={onRefresh}>Refresh status</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentRuntimeChecking({ name, onRefresh }: { name: string; onRefresh: () => void }) {
+  return (
+    <div className="agent-runtime-setup" role="status">
+      <div className="agent-runtime-setup-card">
+        <h2>Checking {name}</h2>
+        <p>Checking whether its local CLI is installed.</p>
+        <div className="agent-runtime-setup-actions">
+          <Button className="agent-btn" onPress={onRefresh}>Refresh status</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Clipboard access can be unavailable in an unfocused Electron webview. */
+async function copyText(value: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch {
+    // Fall through to the legacy path below.
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    try {
+      textarea.select();
+      return document.execCommand('copy');
+    } finally {
+      textarea.remove();
+    }
+  } catch {
+    return false;
+  }
 }
 
 function shouldRefreshAfterTool(name: string | undefined): boolean {

--- a/web-src/src/components/ChatLaunchButtons.tsx
+++ b/web-src/src/components/ChatLaunchButtons.tsx
@@ -69,7 +69,9 @@ function LaunchButton({
 }) {
   const unavailable = runtime?.state === 'unavailable';
   const label = runtime?.state && runtime.state !== 'available'
-    ? `${agent.launcherLabel} is ${runtime.state}${runtime.error ? `: ${runtime.error}` : ''}`
+    ? unavailable
+      ? `${agent.launcherLabel} is unavailable. Click for setup.`
+      : `${agent.launcherLabel} is ${runtime.state}${runtime.error ? `: ${runtime.error}` : ''}`
     : active ? `Hide ${agent.launcherLabel} chat` : `Show ${agent.launcherLabel} chat`;
   const Icon = agent.Icon;
   const { tipProps, tip } = useHoverTip(label, 'bottom');
@@ -79,7 +81,6 @@ function LaunchButton({
       type="button"
       aria-label={label}
       onClick={onClick}
-      disabled={unavailable}
       {...tipProps}
     >
       <Icon />

--- a/web-src/src/styles/chat.css
+++ b/web-src/src/styles/chat.css
@@ -473,6 +473,35 @@
       min-height: 180px;
       padding: 24px 8px;
     }
+    .agent-runtime-setup {
+      flex: 1;
+      display: grid;
+      place-items: center;
+      min-height: 180px;
+      padding: 24px 12px;
+    }
+    .agent-runtime-setup-card {
+      width: min(440px, 100%);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--pane);
+      padding: 16px;
+      color: var(--fg);
+    }
+    .agent-runtime-setup-card h2 { margin: 0; font-size: calc(14px * var(--ui-scale)); }
+    .agent-runtime-setup-card p { margin: 7px 0 12px; color: var(--muted); font-size: calc(12.5px * var(--ui-scale)); line-height: 1.5; }
+    .agent-runtime-setup-card code {
+      display: block;
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg);
+      padding: 8px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: calc(12px * var(--ui-scale));
+      white-space: nowrap;
+    }
+    .agent-runtime-setup-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
     .agent-fatal-card,
     .agent-fatal-inline {
       border: 1px solid rgba(220, 38, 38, 0.22);


### PR DESCRIPTION
## Summary

- keep unavailable Claude Code and Codex launchers actionable and open a compact setup state
- show the exact install command with copy support and refresh runtime discovery after installation
- avoid generic connection failures while initial runtime discovery is pending, while retaining a distinct failed-runtime path
- document the Agent Panel runtime-guidance contract and cover both install hints

## Why

The server already reports unavailable Agent runtimes with installation hints, but disabled launchers made a missing CLI appear unresponsive.

## User impact

Users can see what is missing, copy the correct install command, and refresh the runtime state without restarting StashBase. Claude Code and Codex remain independent.

## Documentation

Updated the Agent Panel design guide and maintainer review contract for the unavailable-versus-failed runtime distinction.

## Validation

- `git diff --check`
- `pnpm typecheck`
- `pnpm test:agent`
- `npx vite build --config web-src/vite.config.ts`

Closes #62