### PR TITLE
feat(agent): paste clipboard images as chat attachments

### DIFF
--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -30,7 +30,7 @@ Community contributions can land as useful first iterations, but the long-term d
 - Keep background activity compact. Tool calls may be grouped or summarized, but the user must be able to inspect them when needed.
 - File outputs should be easy to open, but artifact UI should stay lightweight. Prefer rows or compact affordances over large delivery cards.
 - Streaming should not steal the user's scroll position. If the user has scrolled away from the bottom, show a clear jump-to-latest affordance.
-- The current document is never implicit agent context. Users attach files by drag/drop, file picker, or `@` mention.
+- The current document is never implicit agent context. Users attach files by drag/drop, file picker, `@` mention, or a composer-focused image paste. Image paste must reuse transient attachments, preserve accompanying text, and suppress the competing clipboard library-import offer.
 - The top-bar Claude and Codex icons select or toggle existing chats. Creating a new chat belongs to the in-panel `+`.
 
 ## Current Baseline

--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -52,8 +52,20 @@ The accepted baseline includes:
   semantics, including permission decisions and destructive history
   confirmation. CodeMirror remains the owner of composer text, selection,
   undo, and mention-key handoff; keep its presentation chat-like and its
-  height capped so the transcript retains reading space. When a permission
-  action removes its own controls, restore focus to the persistent tool-card
-  trigger.
+  height capped so the transcript retains reading space. Image attachments
+  show renderer-local thumbnails, never their transient filesystem paths;
+  sent thumbnails remain available for the current transcript, while their URLs
+  are revoked when removed, the transcript is replaced, or the panel unmounts.
+  Restored Claude and Codex sessions may recreate thumbnails only for live
+  transient image files through the scoped local preview route; never expose
+  an arbitrary path found in a transcript. The route resolves the real target
+  under a non-symlinked private attachment root before it reads it. When a
+  permission action removes its own controls, restore focus to the persistent
+  tool-card trigger.
+- Image-preview controls float over the image: Download and Close at the top
+  right, and a bottom-centred zoom group. They need accessible names and hover
+  titles; do not replace their semantic buttons with non-interactive artwork.
+  Use clean, optically centred `+` and `−` line glyphs for zoom rather than
+  ornate magnifying-glass icons; keep the floating control surfaces borderless.
 
 These are still implementation details, not a new product category. If the panel starts to feel heavier than VS Code/Codex/Claude Code side chat, the preferred follow-up is to reduce visual weight rather than add more structure.

--- a/design-docs/design/agent-panel.md
+++ b/design-docs/design/agent-panel.md
@@ -10,8 +10,10 @@ context, not a separate AI workspace.
   prior chat history.
 - The panel supports streaming responses, stop and retry paths, queued
   follow-ups, and inspectable tool activity.
-- Users explicitly attach context through mentions, file selection, or drag and
-  drop; the current document is never implicit Agent context.
+- Users explicitly attach context through mentions, file selection, drag and
+  drop, or pasting an image while the composer is focused; the current
+  document is never implicit Agent context. Pasted images are transient chat
+  attachments, never library imports.
 - Permission requests remain actionable. Limited edit workflows can be
   streamlined, while deletion, commands, network access, and broader access
   stay explicit approval decisions.

--- a/design-docs/design/agent-panel.md
+++ b/design-docs/design/agent-panel.md
@@ -36,7 +36,10 @@ context, not a separate AI workspace.
 - Popup controls use maintained accessible primitives while the CodeMirror
   composer remains responsible for typed content and mention keystrokes. The
   composer presents as a capped-height chat input, with ranked file and folder mentions,
-  visible attachment chips, and clear Send/Stop states rather than editor UI.
+  image attachment thumbnails that remain visible in sent messages and restored
+  history while their transient files are available, open the existing image
+  preview with floating image actions and bottom-centered zoom controls, and clear
+  Send/Stop states rather than editor UI.
 - The panel complements external MCP clients; it does not replace the
   bring-your-own-agent direction.
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -548,15 +548,38 @@ function isLiveMainWindow(win) {
 // Default-on; toggleable from the renderer via `clipboard:setWatch`.
 let clipboardWatchEnabled = true;
 let lastClipboardOfferHash = null;
+const agentComposerFocusedContents = new Set();
 
 function clipboardImageFilename() {
   const stamp = new Date().toISOString().replace(/[:.]/g, '-');
   return `clipboard-${stamp}.png`;
 }
 
+function markCurrentClipboardImageHandled() {
+  let img;
+  try {
+    img = clipboard.readImage();
+  } catch {
+    return false;
+  }
+  if (!img || img.isEmpty()) return false;
+  let png;
+  try {
+    png = img.toPNG();
+  } catch {
+    return false;
+  }
+  if (!png || !png.length) return false;
+  lastClipboardOfferHash = crypto.createHash('sha1').update(png).digest('hex');
+  return true;
+}
+
 function offerClipboardImage(win) {
   if (!clipboardWatchEnabled) return;
   if (!win || win.isDestroyed()) return;
+  // A focused Agent composer claims clipboard images as transient chat
+  // context, so do not race the explicit paste with a library-import offer.
+  if (agentComposerFocusedContents.has(win.webContents.id)) return;
   let img;
   try {
     img = clipboard.readImage();
@@ -678,6 +701,7 @@ async function createWindow(initialFolder) {
     });
   });
   win.on('closed', () => {
+    agentComposerFocusedContents.delete(webContentsId);
     rendererFlush.cancel(webContentsId);
     mainWindows.delete(win);
     windowRegistry.remove(windowId);
@@ -892,6 +916,19 @@ ipcMain.handle('clipboard:setWatch', (_event, enabled) => {
 // image; remember the hash so re-focus doesn't re-offer the same one.
 ipcMain.on('clipboard:markHandled', (_event, hash) => {
   if (typeof hash === 'string' && hash) lastClipboardOfferHash = hash;
+});
+
+ipcMain.on('clipboard:markCurrentImageHandled', (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!isLiveMainWindow(win)) return;
+  markCurrentClipboardImageHandled();
+});
+
+ipcMain.on('clipboard:setAgentComposerFocused', (event, focused) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!isLiveMainWindow(win)) return;
+  if (focused === true) agentComposerFocusedContents.add(event.sender.id);
+  else agentComposerFocusedContents.delete(event.sender.id);
 });
 
 const initialWindowFlight = createSingleFlight(() => app.whenReady().then(() => createWindow()));

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -99,4 +99,10 @@ contextBridge.exposeInMainWorld('electron', {
   /** Tell main an offered clipboard image was handled so it isn't
    *  re-offered on the next focus. */
   markClipboardHandled: (hash) => ipcRenderer.send('clipboard:markHandled', hash),
+  /** Mark the image currently being pasted as handled without exposing the
+   * native clipboard bytes to the renderer a second time. */
+  markCurrentClipboardImageHandled: () => ipcRenderer.send('clipboard:markCurrentImageHandled'),
+  /** While the Agent composer owns focus, pasted images become temporary
+   * chat context instead of candidates for library import. */
+  setAgentComposerFocused: (focused) => ipcRenderer.send('clipboard:setAgentComposerFocused', focused === true),
 });

--- a/server/agent-history-attachments.ts
+++ b/server/agent-history-attachments.ts
@@ -1,0 +1,41 @@
+import path from 'node:path';
+import { isTransientAttachmentPath, transientAttachmentPreviewUrl } from './routes/attach.ts';
+
+export interface RestoredImageAttachment {
+  path: string;
+  name: string;
+  previewUrl: string;
+}
+
+/** Rehydrate the generated attachment suffix into UI attachment data when
+ * replaying either supported Agent runtime's persisted transcript. */
+export function restoreHistoryImageAttachments(text: string): { text: string; attachments: RestoredImageAttachment[] } {
+  const marker = '\n\nAttached files:\n';
+  const offset = text.lastIndexOf(marker);
+  if (offset < 0) return { text, attachments: [] };
+  const before = text.slice(0, offset);
+  const attachments: RestoredImageAttachment[] = [];
+  const remaining = text.slice(offset + marker.length).split('\n').filter((line) => {
+    if (!line.startsWith('- ')) return true;
+    const attachment = historyImageAttachment(line.slice(2).trim());
+    if (!attachment) return true;
+    attachments.push(attachment);
+    return false;
+  });
+  return { text: remaining.length ? `${before}${marker}${remaining.join('\n')}` : before, attachments };
+}
+
+/** Build a preview only for an image written by StashBase's transient upload
+ * route. Transcript text must never grant read access to arbitrary paths. */
+export function historyImageAttachment(candidate: string): RestoredImageAttachment | null {
+  if (!isTransientAttachmentPath(candidate) || !isPreviewableImage(candidate)) return null;
+  return {
+    path: candidate,
+    name: path.basename(candidate),
+    previewUrl: transientAttachmentPreviewUrl(candidate),
+  };
+}
+
+function isPreviewableImage(filePath: string): boolean {
+  return ['.avif', '.gif', '.jpeg', '.jpg', '.png', '.webp'].includes(path.extname(filePath).toLowerCase());
+}

--- a/server/codex-history.test.ts
+++ b/server/codex-history.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { codexThreadToBlocks } from './codex-history.ts';
+import { transcriptToBlocks } from './routes/sessions.ts';
+
+test('restores a transient image attachment from the persisted prompt marker', () => {
+  const imagePath = path.join(os.tmpdir(), 'stashbase-attachments', 'batch-1', 'image.png');
+  const blocks = codexThreadToBlocks({
+    turns: [{
+      items: [{
+        type: 'userMessage',
+        content: [{
+          type: 'text',
+          text: `check what is written in the image\n\nAttached files:\n- ${imagePath}`,
+        }],
+      }],
+    }],
+  });
+
+  assert.deepEqual(blocks, [{
+    kind: 'user',
+    id: 'c0',
+    text: 'check what is written in the image',
+    attachments: [{
+      path: imagePath,
+      name: 'image.png',
+      previewUrl: `/api/agent/attachment-preview?path=${encodeURIComponent(imagePath)}`,
+    }],
+  }]);
+});
+
+test('does not expose arbitrary filesystem paths embedded in a prompt', () => {
+  const blocks = codexThreadToBlocks({
+    turns: [{
+      items: [{
+        type: 'userMessage',
+        content: [{
+          type: 'text',
+          text: 'keep this\n\nAttached files:\n- /Users/someone/private.png',
+        }],
+      }],
+    }],
+  });
+
+  assert.deepEqual(blocks, [{
+    kind: 'user',
+    id: 'c0',
+    text: 'keep this\n\nAttached files:\n- /Users/someone/private.png',
+  }]);
+});
+
+test('restores the same attachment thumbnail for a Claude SDK transcript', () => {
+  const imagePath = path.join(os.tmpdir(), 'stashbase-attachments', 'batch-2', 'image.png');
+  const blocks = transcriptToBlocks([{
+    type: 'user',
+    message: { content: `review the attached image\n\nAttached files:\n- ${imagePath}` },
+  }]);
+
+  assert.deepEqual(blocks, [{
+    kind: 'user',
+    id: 'h0',
+    text: 'review the attached image',
+    attachments: [{
+      path: imagePath,
+      name: 'image.png',
+      previewUrl: `/api/agent/attachment-preview?path=${encodeURIComponent(imagePath)}`,
+    }],
+  }]);
+});

--- a/server/codex-history.ts
+++ b/server/codex-history.ts
@@ -16,6 +16,7 @@ import {
   type JsonObject,
 } from './codex-protocol.ts';
 import { CodexRpcPeer } from './codex-rpc-transport.ts';
+import { historyImageAttachment, restoreHistoryImageAttachments, type RestoredImageAttachment } from './agent-history-attachments.ts';
 
 const log = logger('codex-history');
 
@@ -28,10 +29,14 @@ export interface CodexSessionRow {
 }
 
 export type CodexSessionBlock =
-  | { kind: 'user'; id: string; text: string }
+  | { kind: 'user'; id: string; text: string; attachments?: CodexImageAttachment[] }
   | { kind: 'assistant'; id: string; text: string }
   | { kind: 'thinking'; id: string; text: string }
   | { kind: 'tool'; id: string; name: string; input: Record<string, unknown>; status: 'done' | 'error'; result?: string };
+
+/** A restored transcript can only preview images originally uploaded through
+ * StashBase's transient attachment route. */
+export type CodexImageAttachment = RestoredImageAttachment;
 
 export async function listCodexSessions(folder: string | null): Promise<CodexSessionRow[]> {
   const cwd = folder ?? process.cwd();
@@ -324,7 +329,7 @@ function rolloutToolName(name: string): string {
   return name || 'Tool call';
 }
 
-function codexThreadToBlocks(thread: JsonObject, rolloutTools: RolloutToolsByTurn = new Map()): CodexSessionBlock[] {
+export function codexThreadToBlocks(thread: JsonObject, rolloutTools: RolloutToolsByTurn = new Map()): CodexSessionBlock[] {
   const blocks: CodexSessionBlock[] = [];
   let seq = 0;
   const id = () => `c${seq++}`;
@@ -352,8 +357,15 @@ function codexThreadToBlocks(thread: JsonObject, rolloutTools: RolloutToolsByTur
       const item = objectValue(raw);
       const type = stringValue(item.type);
       if (type === 'userMessage') {
-        const text = userInputText(item.content);
-        if (text.trim()) blocks.push({ kind: 'user', id: id(), text });
+        const userMessage = userInput(item.content);
+        if (userMessage.text.trim() || userMessage.attachments.length) {
+          blocks.push({
+            kind: 'user',
+            id: id(),
+            text: userMessage.text,
+            ...(userMessage.attachments.length ? { attachments: userMessage.attachments } : {}),
+          });
+        }
         continue;
       }
       if (type === 'agentMessage') {
@@ -397,18 +409,32 @@ function codexThreadToBlocks(thread: JsonObject, rolloutTools: RolloutToolsByTur
   return blocks;
 }
 
-function userInputText(value: unknown): string {
-  if (!Array.isArray(value)) return '';
-  return value
+function userInput(value: unknown): { text: string; attachments: CodexImageAttachment[] } {
+  if (!Array.isArray(value)) return { text: '', attachments: [] };
+  const attachments: CodexImageAttachment[] = [];
+  const text = value
     .map((input) => {
       const obj = objectValue(input);
       if (stringValue(obj.type) === 'text') return stringValue(obj.text);
       if (stringValue(obj.type) === 'image') return stringValue(obj.url);
-      if (stringValue(obj.type) === 'localImage') return stringValue(obj.path);
+      if (stringValue(obj.type) === 'localImage') {
+        addHistoryImageAttachment(attachments, stringValue(obj.path));
+        return '';
+      }
       return stringValue(obj.name) || stringValue(obj.path);
     })
     .filter(Boolean)
     .join('\n');
+  const restored = restoreHistoryImageAttachments(text);
+  for (const attachment of restored.attachments) addHistoryImageAttachment(attachments, attachment.path);
+  return { text: restored.text, attachments };
+}
+
+function addHistoryImageAttachment(attachments: CodexImageAttachment[], candidate: string): void {
+  const attachment = historyImageAttachment(candidate);
+  if (!attachment) return;
+  if (attachments.some((attachment) => attachment.path === candidate)) return;
+  attachments.push(attachment);
 }
 
 function stringArray(value: unknown): string[] {

--- a/server/routes/attach.test.ts
+++ b/server/routes/attach.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { attachRoot, transientAttachmentPreviewPath } from './attach.ts';
+
+test('attachment previews reject a transient-tree symlink to an outside file', () => {
+  fs.mkdirSync(attachRoot(), { recursive: true, mode: 0o700 });
+  const batch = fs.mkdtempSync(path.join(attachRoot(), 'preview-test-'));
+  const outside = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-outside-')), 'secret.png');
+  const uploaded = path.join(batch, 'uploaded.png');
+  const linked = path.join(batch, 'image.png');
+  try {
+    fs.writeFileSync(uploaded, 'not an image');
+    fs.writeFileSync(outside, 'not an image');
+    fs.symlinkSync(outside, linked);
+
+    assert.equal(transientAttachmentPreviewPath(uploaded), fs.realpathSync(uploaded));
+    assert.equal(transientAttachmentPreviewPath(linked), null);
+  } finally {
+    fs.rmSync(batch, { recursive: true, force: true });
+    fs.rmSync(path.dirname(outside), { recursive: true, force: true });
+  }
+});

--- a/server/routes/attach.ts
+++ b/server/routes/attach.ts
@@ -25,8 +25,57 @@ const upload = multer({
 const ATTACHMENT_MAX_AGE_MS = 24 * 60 * 60_000;
 
 /** Root for transient attachment files, outside any folder. */
-function attachRoot(): string {
+export function attachRoot(): string {
   return path.join(os.tmpdir(), 'stashbase-attachments');
+}
+
+/** Create the shared transient root privately, and never follow a pre-existing
+ * symlink at that location. */
+function ensureAttachmentRoot(): string | null {
+  const root = attachRoot();
+  try {
+    fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+    const stat = fs.lstatSync(root);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return null;
+    fs.chmodSync(root, 0o700);
+    return root;
+  } catch {
+    return null;
+  }
+}
+
+/** Only files created by this route may be read back for a restored chat
+ * preview. This deliberately rejects arbitrary local paths from a session
+ * transcript. */
+export function isTransientAttachmentPath(candidate: string): boolean {
+  const root = path.resolve(attachRoot());
+  const relative = path.relative(root, path.resolve(candidate));
+  return Boolean(relative) && !relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative);
+}
+
+/** Resolve a preview target only after proving that its real filesystem path
+ * remains inside the real attachment root. This blocks transcript-provided
+ * paths that enter the temp tree through a symlink and point elsewhere. */
+export function transientAttachmentPreviewPath(candidate: string): string | null {
+  if (!isTransientAttachmentPath(candidate)) return null;
+  try {
+    const root = attachRoot();
+    const rootStat = fs.lstatSync(root);
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return null;
+    const realRoot = fs.realpathSync(root);
+    const realCandidate = fs.realpathSync(candidate);
+    const relative = path.relative(realRoot, realCandidate);
+    if (!relative || relative.startsWith(`..${path.sep}`) || relative === '..' || path.isAbsolute(relative)) return null;
+    return fs.statSync(realCandidate).isFile() ? realCandidate : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Relative renderer URL for a transient image. The route validates the path
+ * again when it is fetched. */
+export function transientAttachmentPreviewUrl(filePath: string): string {
+  return `/api/agent/attachment-preview?path=${encodeURIComponent(filePath)}`;
 }
 
 export function safeAttachmentName(original: string): string {
@@ -81,11 +130,13 @@ export function mount(app: express.Express): void {
       }
       const files = (req.files as Express.Multer.File[]) ?? [];
       if (files.length === 0) { res.status(400).json({ error: 'no files' }); return; }
-      cleanupStaleAttachments();
+      const root = ensureAttachmentRoot();
+      if (!root) { res.status(500).json({ error: 'could not secure attachment storage' }); return; }
+      cleanupStaleAttachments(root);
       // One throwaway dir per batch so same-named files never collide.
-      const dir = path.join(attachRoot(), randomUUID());
+      const dir = path.join(root, randomUUID());
       try {
-        fs.mkdirSync(dir, { recursive: true });
+        fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
       } catch (err: unknown) {
         res.status(500).json({ error: errorMessage(err) });
         return;
@@ -96,7 +147,7 @@ export function mount(app: express.Express): void {
         const name = uniqueAttachmentName(f.originalname || 'file', usedNames);
         try {
           const abs = path.join(dir, name);
-          fs.writeFileSync(abs, f.buffer);
+          fs.writeFileSync(abs, f.buffer, { mode: 0o600 });
           out.push({ name, path: abs });
         } catch (err: unknown) {
           log.warn(`attach: write ${name} failed: ${errorMessage(err)}`);
@@ -109,6 +160,36 @@ export function mount(app: express.Express): void {
       res.json({ files: out });
     });
   });
+
+  app.get('/api/agent/attachment-preview', (req, res) => {
+    const filePath = typeof req.query.path === 'string' ? req.query.path : '';
+    const type = imageContentType(filePath);
+    if (!type) {
+      res.status(404).end();
+      return;
+    }
+    const previewPath = transientAttachmentPreviewPath(filePath);
+    if (!previewPath) {
+      res.status(404).end();
+      return;
+    }
+    res.type(type);
+    res.set('Cache-Control', 'private, max-age=3600');
+    res.set('X-Content-Type-Options', 'nosniff');
+    res.sendFile(previewPath);
+  });
+}
+
+function imageContentType(filePath: string): string | null {
+  switch (path.extname(filePath).toLowerCase()) {
+    case '.avif': return 'image/avif';
+    case '.gif': return 'image/gif';
+    case '.jpeg':
+    case '.jpg': return 'image/jpeg';
+    case '.png': return 'image/png';
+    case '.webp': return 'image/webp';
+    default: return null;
+  }
 }
 
 function sendAttachError(res: express.Response, err: unknown): void {

--- a/server/routes/sessions.ts
+++ b/server/routes/sessions.ts
@@ -31,6 +31,7 @@ import { getCurrentFolder } from '../folder.ts';
 import { filesystemPath } from '../filesystem-path.ts';
 import { sendError } from '../http.ts';
 import { agentAdapter, type AgentHistoryActions } from '../agent-contract.ts';
+import { restoreHistoryImageAttachments, type RestoredImageAttachment } from '../agent-history-attachments.ts';
 
 /** Trimmed session row sent to the client. */
 interface SessionRow {
@@ -157,7 +158,7 @@ export function sessionInfoMatchesFolder(info: { cwd?: unknown } | null | undefi
  *  AgentView's `Block` union (history tools are always settled: 'done' or
  *  'error'). */
 type WireBlock =
-  | { kind: 'user'; id: string; text: string }
+  | { kind: 'user'; id: string; text: string; attachments?: RestoredImageAttachment[] }
   | { kind: 'assistant'; id: string; text: string }
   | { kind: 'thinking'; id: string; text: string }
   | { kind: 'tool'; id: string; name: string; input: Record<string, unknown>; status: 'done' | 'error'; result?: string };
@@ -166,7 +167,7 @@ type WireBlock =
  *  `tool_result` (which arrives as a later user-role message) back onto
  *  its originating `tool_use` block by id — the same correlation the live
  *  WS path does, just replayed from disk. */
-function transcriptToBlocks(msgs: Array<{ type: string; message: unknown }>): WireBlock[] {
+export function transcriptToBlocks(msgs: Array<{ type: string; message: unknown }>): WireBlock[] {
   const blocks: WireBlock[] = [];
   const toolById = new Map<string, Extract<WireBlock, { kind: 'tool' }>>();
   let seq = 0;
@@ -178,7 +179,7 @@ function transcriptToBlocks(msgs: Array<{ type: string; message: unknown }>): Wi
 
     if (m.type === 'user') {
       if (typeof content === 'string') {
-        if (content.trim()) blocks.push({ kind: 'user', id: id(), text: content });
+        appendUserBlock(blocks, id, content);
         continue;
       }
       if (Array.isArray(content)) {
@@ -194,8 +195,7 @@ function transcriptToBlocks(msgs: Array<{ type: string; message: unknown }>): Wi
             }
           }
         }
-        const joined = texts.join('\n').trim();
-        if (joined) blocks.push({ kind: 'user', id: id(), text: joined });
+        appendUserBlock(blocks, id, texts.join('\n').trim());
       }
       continue;
     }
@@ -221,6 +221,17 @@ function transcriptToBlocks(msgs: Array<{ type: string; message: unknown }>): Wi
     }
   }
   return blocks;
+}
+
+function appendUserBlock(blocks: WireBlock[], id: () => string, text: string): void {
+  const restored = restoreHistoryImageAttachments(text);
+  if (!restored.text.trim() && restored.attachments.length === 0) return;
+  blocks.push({
+    kind: 'user',
+    id: id(),
+    text: restored.text,
+    ...(restored.attachments.length ? { attachments: restored.attachments } : {}),
+  });
 }
 
 /** Stringify a tool_result `content` (string, or text/other blocks) — the

--- a/web-src/src/__tests__/agent-clipboard-attachments.test.ts
+++ b/web-src/src/__tests__/agent-clipboard-attachments.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { clipboardImageFiles, handleComposerPaste } from '../components/agent/clipboardAttachments';
+
+function image(type: string, name = ''): File {
+  return new File(['image-bytes'], name, { type });
+}
+
+test('clipboard image files receive generated, type-appropriate names', () => {
+  const files = clipboardImageFiles({
+    files: [image('image/png'), image('image/jpeg', 'photo.jpg')],
+  } as unknown as DataTransfer, new Date('2026-07-31T12:34:56.789Z'));
+
+  assert.deepEqual(files.map((file) => file.name), [
+    'clipboard-2026-07-31T12-34-56-789Z.png',
+    'photo.jpg',
+  ]);
+  assert.deepEqual(files.map((file) => file.type), ['image/png', 'image/jpeg']);
+});
+
+test('clipboard extraction ignores text and non-image files', () => {
+  const files = clipboardImageFiles({
+    files: [
+      new File(['plain text'], 'note.txt', { type: 'text/plain' }),
+      image('image/webp'),
+    ],
+  } as unknown as DataTransfer, new Date('2026-07-31T12:34:56.789Z'));
+
+  assert.deepEqual(files.map((file) => file.name), ['clipboard-2026-07-31T12-34-56-789Z.webp']);
+});
+
+test('clipboard extraction accepts an image DataTransfer item when files is empty', () => {
+  const pastedImage = image('image/png');
+  const files = clipboardImageFiles({
+    files: [],
+    items: [{ kind: 'file', type: 'image/png', getAsFile: () => pastedImage }],
+  } as unknown as DataTransfer, new Date('2026-07-31T12:34:56.789Z'));
+
+  assert.deepEqual(files.map((file) => file.name), ['clipboard-2026-07-31T12-34-56-789Z.png']);
+});
+
+test('composer paste attaches clipboard images without cancelling mixed text paste', () => {
+  let attached: File[] = [];
+  const allowNativePaste = handleComposerPaste({
+    files: [image('image/png')],
+    items: [],
+    getData: (type: string) => type === 'text/plain' ? 'keep this text' : '',
+  } as unknown as DataTransfer, false, (files) => { attached = files; }, new Date('2026-07-31T12:34:56.789Z'));
+
+  assert.equal(allowNativePaste, false);
+  assert.equal(attached.length, 1);
+  assert.equal(attached[0].name, 'clipboard-2026-07-31T12-34-56-789Z.png');
+});
+
+test('composer text-only or disabled paste does not create an attachment', () => {
+  let calls = 0;
+  const textOnly = { files: [], items: [], getData: () => 'keep this text' } as unknown as DataTransfer;
+  const imageOnly = { files: [image('image/png')], items: [] } as unknown as DataTransfer;
+
+  assert.equal(handleComposerPaste(textOnly, false, () => { calls += 1; }), false);
+  assert.equal(handleComposerPaste(imageOnly, true, () => { calls += 1; }), false);
+  assert.equal(calls, 0);
+});

--- a/web-src/src/apiTypes.ts
+++ b/web-src/src/apiTypes.ts
@@ -101,7 +101,7 @@ export interface SessionInfo {
  *  AgentView's `Block` (history tools are always settled), so it drops
  *  straight into `setBlocks`. */
 export type SessionBlock =
-  | { kind: 'user'; id: string; text: string }
+  | { kind: 'user'; id: string; text: string; attachments?: Array<{ path: string; name: string; dims?: string; previewUrl?: string }> }
   | { kind: 'assistant'; id: string; text: string }
   | { kind: 'thinking'; id: string; text: string }
   | { kind: 'tool'; id: string; name: string; input: Record<string, unknown>; status: 'done' | 'error'; result?: string };

--- a/web-src/src/components/AgentView.tsx
+++ b/web-src/src/components/AgentView.tsx
@@ -72,6 +72,7 @@ export function AgentView({
   const folderPathRef = useRef(state.folderPath);
   folderPathRef.current = state.folderPath;
   const mountedRef = useRef(true);
+  const attachmentPreviewUrlsRef = useRef(new Set<string>());
   const uploadCountRef = useRef(0);
   const [blocks, setBlocks] = useState<Block[]>([]);
   const [editableUserMessageIds, setEditableUserMessageIds] = useState<Set<string>>(() => new Set());
@@ -120,9 +121,43 @@ export function AgentView({
   const openKind = useRef<'assistant' | 'thinking' | null>(null);
   const knownFilePaths = useMemo(() => new Set(state.files.map((f) => f.name)), [state.files]);
 
-  useEffect(() => () => {
-    mountedRef.current = false;
+  useEffect(() => {
+    // Fast Refresh runs an effect cleanup before reapplying it while keeping
+    // refs and state. Re-arm this guard on every mount so a live attachment
+    // upload can settle instead of leaving the composer on “Uploading…”.
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      setAgentComposerFocused(false);
+      releaseAllAttachmentPreviews();
+    };
   }, []);
+
+  function releaseAllAttachmentPreviews() {
+    for (const url of attachmentPreviewUrlsRef.current) URL.revokeObjectURL(url);
+    attachmentPreviewUrlsRef.current.clear();
+  }
+
+  function setAgentComposerFocused(focused: boolean) {
+    const bridge = (window as {
+      electron?: {
+        setAgentComposerFocused?: (value: boolean) => void;
+        markCurrentClipboardImageHandled?: () => void;
+      };
+    }).electron;
+    bridge?.setAgentComposerFocused?.(focused);
+  }
+
+  function pasteImages(files: File[]) {
+    const bridge = (window as {
+      electron?: { markCurrentClipboardImageHandled?: () => void };
+    }).electron;
+    // The native watcher independently observes screenshots. Mark this
+    // explicit composer paste first so it cannot surface later as a library
+    // import prompt once focus leaves the input.
+    bridge?.markCurrentClipboardImageHandled?.();
+    void uploadFiles(files);
+  }
 
   // A launcher can be clicked before the chrome's initial discovery request
   // settles. Keep that tab out of the WebSocket path until its runtime has a
@@ -198,6 +233,7 @@ export function AgentView({
   /** Tear down and start a fresh session (Retry button / after the user
    *  reopens a folder). */
   function reconnect() {
+    releaseAllAttachmentPreviews();
     setBlocks([]);
     setEditableUserMessageIds(new Set());
     setFatal(null);
@@ -237,6 +273,7 @@ export function AgentView({
       actions.toast('Could not load that session.', { level: 'error' });
       return;
     }
+    releaseAllAttachmentPreviews();
     setBlocks(hist);
     setEditableUserMessageIds(new Set());
     setFatal(null);
@@ -505,7 +542,7 @@ export function AgentView({
         text: wire,
         ...(titleHint ? { titleHint } : {}),
       }));
-      if (clearAttachments) setAttachments([]);
+      if (clearAttachments) clearComposerAttachments();
     } catch (err) {
       setTurnBusy(false);
       setBlocks((bs) => [...bs, { kind: 'error', id: nextId(), text: `Could not send message: ${errorText(err)}` }]);
@@ -560,8 +597,9 @@ export function AgentView({
     try {
       const result = await api.attachFiles(eligible, { signal: controller.signal });
       if (!mountedRef.current) return;
-      // `result.files` is 1:1 with `files` (server preserves order); pull
-      // image dimensions off the original File for the chip label.
+      // `result.files` is 1:1 with `files` (server preserves order). Keep a
+      // renderer-local preview URL for image thumbnails; only the returned
+      // temp path becomes Agent context.
       const entries = result.files ?? [];
       const added: Attachment[] = [];
       let failed = 0;
@@ -569,10 +607,17 @@ export function AgentView({
         const r = entries[i];
         if (r.error || !r.path) { failed++; continue; }
         const orig = eligible[i];
+        const previewUrl = orig && orig.type.startsWith('image/') ? URL.createObjectURL(orig) : undefined;
+        if (previewUrl) attachmentPreviewUrlsRef.current.add(previewUrl);
         const dims = orig && orig.type.startsWith('image/') ? await readImageDims(orig) : undefined;
-        added.push({ path: r.path, name: r.name, dims });
+        added.push({ path: r.path, name: r.name, dims, previewUrl });
       }
-      if (!mountedRef.current) return;
+      if (!mountedRef.current) {
+        for (const attachment of added) {
+          if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+        }
+        return;
+      }
       if (added.length) setAttachments((a) => mergeAttachments(a, added));
       if (failed) actions.toast(`${failed} file(s) failed to attach.`, { level: 'error' });
     } catch (err: unknown) {
@@ -597,7 +642,20 @@ export function AgentView({
   }
 
   function removeAttachment(path: string) {
-    setAttachments((a) => a.filter((x) => x.path !== path));
+    setAttachments((current) => {
+      const removed = current.find((attachment) => attachment.path === path);
+      if (removed?.previewUrl) {
+        URL.revokeObjectURL(removed.previewUrl);
+        attachmentPreviewUrlsRef.current.delete(removed.previewUrl);
+      }
+      return current.filter((attachment) => attachment.path !== path);
+    });
+  }
+
+  function clearComposerAttachments() {
+    // Sent and queued turns retain their image thumbnail in the transcript.
+    // The URL remains owned by the panel until its transcript is replaced.
+    setAttachments([]);
   }
 
   function stop() {
@@ -801,6 +859,8 @@ export function AgentView({
         attachments={attachments}
         uploading={uploading}
         onPickFiles={uploadFiles}
+        onPasteImages={pasteImages}
+        onFocusChange={setAgentComposerFocused}
         onRemoveAttachment={removeAttachment}
         onSend={send}
         onStop={stop}

--- a/web-src/src/components/ImageLightbox.tsx
+++ b/web-src/src/components/ImageLightbox.tsx
@@ -63,9 +63,12 @@ export function ImageLightbox({ src, alt = '', onClose }: ImageLightboxProps) {
     });
   }
 
-  function reset() {
-    setScale(1);
-    setOffset({ x: 0, y: 0 });
+  function download() {
+    const link = document.createElement('a');
+    link.href = src;
+    link.download = safeDownloadName(alt);
+    link.click();
+    link.remove();
   }
 
   function onPointerDown(e: PointerEvent<HTMLDivElement>) {
@@ -89,14 +92,6 @@ export function ImageLightbox({ src, alt = '', onClose }: ImageLightboxProps) {
 
   return (
     <div className="image-lightbox quick-open-blocking" role="dialog" aria-modal="true" aria-label="Image preview">
-      <div className="image-lightbox-toolbar">
-        <div className="image-lightbox-title">{alt || 'Image preview'}</div>
-        <button type="button" onClick={() => zoomBy(1 / 1.2)}>Zoom out</button>
-        <span className="image-lightbox-scale">{Math.round(scale * 100)}%</span>
-        <button type="button" onClick={() => zoomBy(1.2)}>Zoom in</button>
-        <button type="button" onClick={reset}>Reset</button>
-        <button type="button" onClick={onClose}>Close</button>
-      </div>
       <div
         ref={stageRef}
         className={'image-lightbox-stage' + (scale > 1 ? ' pannable' : '')}
@@ -114,8 +109,46 @@ export function ImageLightbox({ src, alt = '', onClose }: ImageLightboxProps) {
           }}
         />
       </div>
+      <div className="image-lightbox-actions">
+        <button type="button" className="image-lightbox-floating-btn" aria-label="Download image" title="Download" onClick={download}>
+          <LightboxIcon kind="download" />
+        </button>
+        <button type="button" className="image-lightbox-floating-btn" aria-label="Close image preview" title="Close" onClick={onClose}>
+          <LightboxIcon kind="close" />
+        </button>
+      </div>
+      <div className="image-lightbox-zoom-controls">
+        <button type="button" aria-label="Zoom out" title="Zoom out" onClick={() => zoomBy(1 / 1.2)}>
+          <ZoomGlyph />
+        </button>
+        <span className="image-lightbox-scale">{Math.round(scale * 100)}%</span>
+        <button type="button" aria-label="Zoom in" title="Zoom in" onClick={() => zoomBy(1.2)}>
+          <ZoomGlyph plus />
+        </button>
+      </div>
     </div>
   );
+}
+
+function LightboxIcon({ kind }: { kind: 'download' | 'close' }) {
+  if (kind === 'download') return (
+    <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 2.25v7.5m0 0 2.7-2.7M8 9.75 5.3 7.05M3 10.75v2h10v-2" /></svg>
+  );
+  return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="m3.5 3.5 9 9m0-9-9 9" /></svg>;
+}
+
+function ZoomGlyph({ plus = false }: { plus?: boolean }) {
+  return (
+    <svg className="image-lightbox-zoom-glyph" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M3.5 8h9" />
+      {plus && <path d="M8 3.5v9" />}
+    </svg>
+  );
+}
+
+function safeDownloadName(name: string): string {
+  const trimmed = name.trim();
+  return trimmed && !/[\\/:*?"<>|]/.test(trimmed) ? trimmed : 'image';
 }
 
 function clamp(value: number): number {

--- a/web-src/src/components/agent/AgentComposer.tsx
+++ b/web-src/src/components/agent/AgentComposer.tsx
@@ -5,6 +5,7 @@ import {
   FileGenericIcon, FolderIcon, HandIcon, PlusIcon, StopIcon,
 } from '../../icons';
 import { useApp } from '../../store/AppContext';
+import { ImageLightbox } from '../ImageLightbox';
 import { baseName } from './attachments';
 import { MentionComposer, type MentionComposerHandle, type MentionQuery } from './MentionComposer';
 import { rankMentionSuggestions } from './mentionRanking';
@@ -135,7 +136,7 @@ function EffortMenu({
 
 export function AgentComposer({
   phase, disabled, turnActive, active, mode, onSetMode, effort, onSetEffort,
-  effortLocked, attachments, uploading, agentShortName, showModeMenu, showEffortMenu, onPickFiles, onRemoveAttachment, onSend, onStop,
+  effortLocked, attachments, uploading, agentShortName, showModeMenu, showEffortMenu, onPickFiles, onPasteImages, onFocusChange, onRemoveAttachment, onSend, onStop,
 }: {
   phase: 'connecting' | 'live' | 'closed';
   disabled: boolean;
@@ -152,6 +153,8 @@ export function AgentComposer({
   showModeMenu: boolean;
   showEffortMenu: boolean;
   onPickFiles: (files: File[]) => void;
+  onPasteImages: (files: File[]) => void;
+  onFocusChange: (focused: boolean) => void;
   onRemoveAttachment: (path: string) => void;
   onSend: (text: string) => void;
   onStop: () => void;
@@ -164,6 +167,7 @@ export function AgentComposer({
   const [activeMentionIndex, setActiveMentionIndex] = useState(0);
   const [modeOpen, setModeOpen] = useState(false);
   const [effortOpen, setEffortOpen] = useState(false);
+  const [previewAttachment, setPreviewAttachment] = useState<Attachment | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const activeMentionRef = useRef<HTMLDivElement>(null);
 
@@ -260,19 +264,34 @@ export function AgentComposer({
       <div className="agent-composer-box">
         {(attachments.length > 0 || uploading) && (
           <div className="agent-attachments">
-            {attachments.map((a) => (
-              <span key={a.path} className="agent-attach-chip" title={a.path}>
-                <FileGenericIcon className="agent-attach-icon" />
-                <span className="agent-attach-text">
-                  <span className="agent-attach-name">{a.name}</span>
-                  <span className="agent-attach-path">{a.path}</span>
-                </span>
-                {a.dims && <span className="agent-attach-dims">{a.dims}</span>}
+            {attachments.map((a) => a.previewUrl ? (
+              <span key={a.path} className="agent-attach-image-chip">
+                <button
+                  type="button"
+                  className="agent-attach-image-preview"
+                  aria-label={`Preview ${a.name}`}
+                  onClick={() => setPreviewAttachment(a)}
+                >
+                  <img src={a.previewUrl} alt="" />
+                </button>
                 <Button
                   className="agent-attach-x"
                   aria-label={`Remove ${a.name}`}
-                  onPress={() => onRemoveAttachment(a.path)}
-                >×</Button>
+                  onPress={() => {
+                    if (previewAttachment?.path === a.path) setPreviewAttachment(null);
+                    onRemoveAttachment(a.path);
+                  }}
+                >
+                  <svg viewBox="0 0 12 12" aria-hidden="true" focusable="false">
+                    <path d="m2.25 2.25 7.5 7.5M9.75 2.25l-7.5 7.5" />
+                  </svg>
+                </Button>
+              </span>
+            ) : (
+              <span key={a.path} className="agent-attach-chip" title={a.path}>
+                <FileGenericIcon className="agent-attach-icon" />
+                <span className="agent-attach-name">{a.name}</span>
+                <Button className="agent-attach-x" aria-label={`Remove ${a.name}`} onPress={() => onRemoveAttachment(a.path)}>×</Button>
               </span>
             ))}
             {uploading && <span className="agent-attach-loading">Uploading…</span>}
@@ -300,6 +319,8 @@ export function AgentComposer({
             return true;
           }}
           onSubmit={submit}
+          onPasteImages={onPasteImages}
+          onFocusChange={onFocusChange}
           mentionOpen={Boolean(mention && suggestions.length)}
           mentionListboxId={mention && suggestions.length ? mentionListboxId : undefined}
         />
@@ -358,6 +379,13 @@ export function AgentComposer({
           )}
         </div>
       </div>
+      {previewAttachment?.previewUrl && (
+        <ImageLightbox
+          src={previewAttachment.previewUrl}
+          alt={previewAttachment.name}
+          onClose={() => setPreviewAttachment(null)}
+        />
+      )}
     </div>
   );
 }

--- a/web-src/src/components/agent/AgentMessages.tsx
+++ b/web-src/src/components/agent/AgentMessages.tsx
@@ -3,6 +3,7 @@ import { Button } from 'react-aria-components';
 import { VIEWABLE_FILE_EXTENSION_ALTERNATION } from '../../../../shared/file-formats.ts';
 import { AgentMarkdown } from './AgentMarkdown';
 import { ChevronDownIcon, CopyIcon, EditIcon, FileGenericIcon } from '../../icons';
+import { ImageLightbox } from '../ImageLightbox';
 import type { Attachment, Block, ToolBlock, ToolStatus } from './types';
 
 export interface QueuedTurnPreview {
@@ -194,17 +195,7 @@ function UserTurnHead({
     <>
       {sticky && <span ref={sentinelRef} className="agent-turn-sentinel" aria-hidden="true" />}
       <div className={'agent-turn-head' + (block.text && !editing ? ' has-actions' : '') + (sticky ? '' : ' static') + (stuck ? ' stuck' : '')}>
-        {block.attachments && block.attachments.length > 0 && (
-          <div className="agent-turn-attach">
-            {block.attachments.map((a) => (
-              <span key={a.path} className="agent-attach-chip" title={a.path}>
-                <FileGenericIcon className="agent-attach-icon" />
-                <span className="agent-attach-name">{a.name}</span>
-                {a.dims && <span className="agent-attach-dims">{a.dims}</span>}
-              </span>
-            ))}
-          </div>
-        )}
+        {block.attachments && block.attachments.length > 0 && <MessageAttachments attachments={block.attachments} />}
         {editing ? (
           <InlineUserMessageEditor
             text={draft}
@@ -249,17 +240,7 @@ function QueuedTurn({
   return (
     <div className="agent-turn queued">
       <div className="agent-turn-head queued">
-        {turn.attachments && turn.attachments.length > 0 && (
-          <div className="agent-turn-attach">
-            {turn.attachments.map((a) => (
-              <span key={a.path} className="agent-attach-chip" title={a.path}>
-                <FileGenericIcon className="agent-attach-icon" />
-                <span className="agent-attach-name">{a.name}</span>
-                {a.dims && <span className="agent-attach-dims">{a.dims}</span>}
-              </span>
-            ))}
-          </div>
-        )}
+        {turn.attachments && turn.attachments.length > 0 && <MessageAttachments attachments={turn.attachments} />}
         <div className="agent-turn-line">
           {turn.text && <UserMessageText text={turn.text} />}
           <span className="agent-turn-actions">
@@ -276,6 +257,42 @@ function QueuedTurn({
         </div>
       </div>
     </div>
+  );
+}
+
+/** Sent image attachments intentionally mirror the composer thumbnail, but
+ * are transcript content rather than removable composer state. */
+function MessageAttachments({ attachments }: { attachments: Attachment[] }) {
+  const [previewAttachment, setPreviewAttachment] = useState<Attachment | null>(null);
+  return (
+    <>
+      <div className="agent-turn-attach">
+        {attachments.map((attachment) => attachment.previewUrl ? (
+          <button
+            key={attachment.path}
+            type="button"
+            className="agent-attach-image-chip agent-attach-image-static"
+            aria-label={`Preview ${attachment.name}`}
+            onClick={() => setPreviewAttachment(attachment)}
+          >
+            <img src={attachment.previewUrl} alt="" />
+          </button>
+        ) : (
+          <span key={attachment.path} className="agent-attach-chip" title={attachment.path}>
+            <FileGenericIcon className="agent-attach-icon" />
+            <span className="agent-attach-name">{attachment.name}</span>
+            {attachment.dims && <span className="agent-attach-dims">{attachment.dims}</span>}
+          </span>
+        ))}
+      </div>
+      {previewAttachment?.previewUrl && (
+        <ImageLightbox
+          src={previewAttachment.previewUrl}
+          alt={previewAttachment.name}
+          onClose={() => setPreviewAttachment(null)}
+        />
+      )}
+    </>
   );
 }
 

--- a/web-src/src/components/agent/MentionComposer.tsx
+++ b/web-src/src/components/agent/MentionComposer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useImperativeHandle, useRef } from 'react';
 import { Compartment, EditorState, RangeSet, RangeValue, StateEffect, StateField } from '@codemirror/state';
 import { defaultKeymap, history, historyKeymap, invertedEffects } from '@codemirror/commands';
 import { Decoration, type DecorationSet, EditorView, keymap, placeholder, WidgetType } from '@codemirror/view';
+import { handleComposerPaste } from './clipboardAttachments';
 
 const MENTION = '\uFFFC';
 
@@ -148,6 +149,8 @@ export function MentionComposer({
   onMentionDismiss,
   onShiftTab,
   onSubmit,
+  onPasteImages,
+  onFocusChange,
   mentionListboxId,
   mentionOpen,
   ref,
@@ -161,6 +164,8 @@ export function MentionComposer({
   onMentionDismiss: () => void;
   onShiftTab: () => boolean;
   onSubmit: (text: string) => boolean;
+  onPasteImages: (files: File[]) => void;
+  onFocusChange: (focused: boolean) => void;
   mentionListboxId?: string;
   mentionOpen: boolean;
   ref: React.Ref<MentionComposerHandle>;
@@ -175,6 +180,8 @@ export function MentionComposer({
   const onMentionDismissRef = useRef(onMentionDismiss);
   const onShiftTabRef = useRef(onShiftTab);
   const onSubmitRef = useRef(onSubmit);
+  const onPasteImagesRef = useRef(onPasteImages);
+  const onFocusChangeRef = useRef(onFocusChange);
   const mentionOpenRef = useRef(mentionOpen);
   const mentionDismissedRef = useRef(false);
   const editableCompartmentRef = useRef(new Compartment());
@@ -188,6 +195,8 @@ export function MentionComposer({
   onMentionDismissRef.current = onMentionDismiss;
   onShiftTabRef.current = onShiftTab;
   onSubmitRef.current = onSubmit;
+  onPasteImagesRef.current = onPasteImages;
+  onFocusChangeRef.current = onFocusChange;
   mentionOpenRef.current = mentionOpen;
 
   function submit() {
@@ -230,6 +239,19 @@ export function MentionComposer({
           })),
           mentionField,
           EditorView.lineWrapping,
+          EditorView.domEventHandlers({
+            paste: (event) => {
+              return handleComposerPaste(event.clipboardData, disabledRef.current, onPasteImagesRef.current);
+            },
+            focus: () => {
+              onFocusChangeRef.current(true);
+              return false;
+            },
+            blur: () => {
+              onFocusChangeRef.current(false);
+              return false;
+            },
+          }),
           placeholderCompartmentRef.current.of(placeholder(placeholderText)),
           editableCompartmentRef.current.of(EditorView.editable.of(!disabledRef.current)),
           keymap.of([
@@ -300,6 +322,7 @@ export function MentionComposer({
     });
     viewRef.current = view;
     return () => {
+      onFocusChangeRef.current(false);
       view.destroy();
       viewRef.current = null;
     };

--- a/web-src/src/components/agent/clipboardAttachments.ts
+++ b/web-src/src/components/agent/clipboardAttachments.ts
@@ -1,0 +1,54 @@
+const IMAGE_EXTENSIONS: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/avif': 'avif',
+};
+
+function generatedClipboardName(type: string, now: Date): string {
+  const stamp = now.toISOString().replace(/[:.]/g, '-');
+  return `clipboard-${stamp}.${IMAGE_EXTENSIONS[type] ?? 'png'}`;
+}
+
+/**
+ * Select image representations from a browser paste payload. Clipboard
+ * images generally arrive without a useful filename, so copy them into a
+ * File with a stable, human-readable name before sending them through the
+ * normal transient-attachment upload path. Text is intentionally untouched:
+ * CodeMirror's native paste continues after this function returns.
+ */
+export function clipboardImageFiles(clipboard: DataTransfer, now = new Date()): File[] {
+  const files = Array.from(clipboard.files);
+  const candidates = files.length
+    ? files
+    : Array.from(clipboard.items)
+      .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => file !== null);
+  return candidates
+    .filter((file) => file.type.startsWith('image/'))
+    .map((file) => {
+      const name = file.name || generatedClipboardName(file.type, now);
+      return new File([file], name, { type: file.type, lastModified: file.lastModified });
+    });
+}
+
+/**
+ * Handle the attachment half of a composer paste without cancelling the DOM
+ * event. Returning false is part of the contract: it lets CodeMirror insert
+ * any simultaneous plain text, so mixed clipboard payloads never duplicate
+ * or discard text.
+ */
+export function handleComposerPaste(
+  clipboard: DataTransfer | null,
+  disabled: boolean,
+  onPasteImages: (files: File[]) => void,
+  now = new Date(),
+): false {
+  if (!disabled && clipboard) {
+    const files = clipboardImageFiles(clipboard, now);
+    if (files.length) onPasteImages(files);
+  }
+  return false;
+}

--- a/web-src/src/components/agent/types.ts
+++ b/web-src/src/components/agent/types.ts
@@ -4,10 +4,10 @@ export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export type ToolStatus = 'running' | 'awaiting' | 'done' | 'error' | 'denied';
 
-/** A context file attached to the composer, shown as a removable chip.
- *  `path` is the folder-relative path (sent to the agent); `dims` is the
- *  pixel size for images (chip label only). */
-export interface Attachment { path: string; name: string; dims?: string }
+/** A context file attached to the composer. Image uploads use a renderer-local
+ * object URL while composing; restored sessions use a constrained local
+ * preview URL. The agent only receives `path`, never either preview URL. */
+export interface Attachment { path: string; name: string; dims?: string; previewUrl?: string }
 
 export interface ToolBlock {
   kind: 'tool';

--- a/web-src/src/styles/chat.css
+++ b/web-src/src/styles/chat.css
@@ -1034,6 +1034,63 @@
       font-size: calc(11.5px * var(--ui-scale));
       color: var(--fg);
     }
+    .agent-attach-image-chip {
+      position: relative;
+      width: 64px;
+      height: 64px;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 9px;
+      background: var(--hover);
+      box-shadow: 0 1px 2px color-mix(in srgb, #000 28%, transparent);
+    }
+    .agent-attach-image-preview {
+      display: block;
+      width: 100%;
+      height: 100%;
+      padding: 0;
+      border: 0;
+      background: transparent;
+      cursor: zoom-in;
+    }
+    .agent-attach-image-preview img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    .agent-attach-image-static {
+      display: block;
+      padding: 0;
+      cursor: zoom-in;
+    }
+    .agent-attach-image-static img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    .agent-attach-image-chip .agent-attach-x {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      width: 16px;
+      height: 16px;
+      padding: 0;
+      color: var(--fg);
+      background: color-mix(in srgb, var(--bg) 76%, transparent);
+      border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+      border-radius: 50%;
+    }
+    .agent-attach-image-chip .agent-attach-x svg {
+      display: block;
+      width: 9px;
+      height: 9px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.7;
+      stroke-linecap: round;
+    }
     .agent-attach-icon { width: 13px; height: 13px; flex-shrink: 0; color: var(--muted); }
     .agent-attach-text { display: flex; min-width: 0; flex-direction: column; }
     .agent-attach-name {

--- a/web-src/src/styles/mainpane.css
+++ b/web-src/src/styles/mainpane.css
@@ -1359,50 +1359,76 @@
       color: #fff;
     }
 
-    .image-lightbox-toolbar {
-      height: 44px;
-      flex: 0 0 auto;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 7px 12px 7px 78px;
-      background: rgba(18, 18, 20, 0.96);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-      -webkit-app-region: drag;
-    }
-
-    .image-lightbox-title {
-      min-width: 0;
-      flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      font-size: calc(12.5px * var(--ui-scale));
-      color: rgba(255, 255, 255, 0.82);
-    }
-
-    .image-lightbox-toolbar button {
-      height: 28px;
-      padding: 0 10px;
-      border: 1px solid rgba(255, 255, 255, 0.16);
-      border-radius: 6px;
+    .image-lightbox-floating-btn,
+    .image-lightbox-zoom-controls button {
+      display: grid;
+      width: 38px;
+      height: 38px;
+      padding: 0;
+      place-items: center;
+      border: 0;
+      border-radius: 50%;
       background: rgba(255, 255, 255, 0.08);
       color: #fff;
       font: inherit;
-      font-size: calc(12.5px * var(--ui-scale));
       cursor: pointer;
       -webkit-app-region: no-drag;
     }
 
-    .image-lightbox-toolbar button:hover {
+    .image-lightbox-floating-btn:hover,
+    .image-lightbox-zoom-controls button:hover {
       background: rgba(255, 255, 255, 0.14);
     }
 
+    .image-lightbox-actions {
+      position: absolute;
+      top: 16px;
+      right: 16px;
+      z-index: 1;
+      display: flex;
+      gap: 8px;
+    }
+
+    .image-lightbox-floating-btn svg {
+      width: 15px;
+      height: 15px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.5;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+
+    .image-lightbox-zoom-glyph {
+      width: 18px;
+      height: 18px;
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1.8;
+      stroke-linecap: round;
+    }
+
+    .image-lightbox-zoom-controls {
+      position: absolute;
+      bottom: 20px;
+      left: 50%;
+      z-index: 1;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px;
+      transform: translateX(-50%);
+      border: 0;
+      border-radius: 22px;
+      background: rgba(31, 32, 42, 0.96);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.34);
+    }
+
     .image-lightbox-scale {
-      min-width: 44px;
+      min-width: 66px;
       text-align: center;
-      color: rgba(255, 255, 255, 0.72);
-      font-size: calc(12px * var(--ui-scale));
+      color: rgba(255, 255, 255, 0.82);
+      font-size: calc(13px * var(--ui-scale));
       font-variant-numeric: tabular-nums;
     }
 


### PR DESCRIPTION
## Summary

- paste clipboard screenshots into the focused shared Agent composer as transient Claude/Codex context
- preserve accompanying plain text, normalize generated image filenames, and retain existing attachment limits, upload progress, and removal behavior
- suppress the competing library-import clipboard offer for an explicitly handled composer paste
- render image thumbnails in the composer, sent transcript, and safely restored histories with an accessible preview lightbox
- constrain restored image previews to real files under StashBase's private transient attachment root

## Why

The Agent composer previously supported picker and drag-and-drop attachments only. Pasting a screenshot could instead trigger the global library-import flow, which is a different intent and could put temporary chat context into the visible library.

## User impact

With the Agent input focused, Cmd+V on macOS and Ctrl+V on Windows attach a clipboard image to the current chat without importing it into the library. Mixed text continues to paste normally, and the same behavior is shared by Claude and Codex tabs.

## Documentation

Updated the Agent Panel design guide and maintainer review contract for image-paste context, thumbnail lifecycle, preview controls, and the restored-preview trust boundary.

## Validation

- `git diff --check`
- `node --import tsx --test server/routes/attach.test.ts server/codex-history.test.ts`
- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`

Closes #70
