### PR TITLE
feat(library): add Command Palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Use **File → New Window** or Cmd/Ctrl+Shift+N to keep different folders and
 tools side by side. Window close follows VS Code's platform shortcuts;
 Cmd/Ctrl+W continues to close the active document tab.
 
+Use Cmd/Ctrl+O to open a source file in the active folder. The Command Palette
+opens with Cmd/Ctrl+Shift+P or F1 (or by typing `>` in Quick Open) and exposes
+safe application actions with their existing safeguards.
+
 ---
 
 ## What It Does

--- a/code-review/architecture.md
+++ b/code-review/architecture.md
@@ -127,8 +127,11 @@ its separate local blocking state to the picker, while reducer-backed confirms,
 cascade prompts, context menus, inline rename, modal veils, and explicitly
 marked local dialogs prevent invocation. Open-file recency is folder-local and
 separate from tab-strip order. Dismissal restores the element that invoked the
-picker. Do not turn it into a retrieval, cross-library, or Agent-permission
-surface.
+picker. Its `>` provider is Command Palette, also entered directly with
+Cmd/Ctrl+Shift+P or F1. Command definitions have stable identities and
+availability predicates, call established renderer actions, and keep command
+recency in picker-local session memory only. Do not turn either provider into a
+retrieval, cross-library, Agent-permission, or destructive-operation surface.
 
 The renderer's local HTTP boundary keeps `web-src/src/api.ts` as the stable endpoint facade. `shared/conversion.ts` and `shared/transcription.ts` own the preparation and transcription contracts consumed on both sides of that boundary; `apiTypes.ts` re-exports them and owns the remaining renderer-only request/response shapes. `apiTransport.ts` owns per-window request identity, JSON/error normalization, retry policy, and folder-relative path encoding. `web-src/src/preparation-copy.ts` translates queued and yielded preparation waits into shared user-facing copy without exposing scheduler lanes or positions. `web-src/src/audio-transcript.ts` maps semantic text or an explicit keyword-result millisecond timestamp back to the exact structured transcript segment and owns the remaining transcription-specific status copy, while `web-src/src/audio-playback.ts` retains logical playback position across direct-to-fallback source replacement.
 

--- a/design-docs/design/library.md
+++ b/design-docs/design/library.md
@@ -22,7 +22,8 @@ to migrate them into a StashBase-specific storage model.
 - Cmd/Ctrl+O opens a focused Quick Open for visible source files in the active
   folder. It starts with recently used editors, then ranks basename and
   relative-path matches; accepting a result retains normal preview-tab and
-  unsaved-work protections.
+  unsaved-work protections. Typing `>` switches that same picker to safe app
+  commands; Cmd/Ctrl+Shift+P and F1 open that command mode directly.
 - Search results and agent file links return users to those source files.
 - Root-level `AGENTS.md` and optional `CLAUDE.md` bridge files are visible,
   editable user files. StashBase only creates missing defaults.
@@ -47,6 +48,9 @@ to migrate them into a StashBase-specific storage model.
   project-management surface.
 - Quick Open is file navigation, not content retrieval: it stays scoped to the
   active folder and does not surface generated artifacts or search evidence.
+- Command Palette exposes only safe, context-available actions the app already
+  supports. Its recency ordering lasts for the current session only; destructive
+  and target-dependent operations keep their explicit flows and confirmations.
 
 ## Contribution Map
 

--- a/web-src/src/__tests__/commandPalette.test.ts
+++ b/web-src/src/__tests__/commandPalette.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  commandDefinitions,
+  rankCommandPalette,
+  routeQuickAccess,
+} from '../commandPalette';
+
+test('Quick Access routes explicit command input without mixing it with files', () => {
+  assert.deepEqual(routeQuickAccess('>new note'), { provider: 'commands', query: 'new note' });
+  assert.deepEqual(routeQuickAccess('notes/plan'), { provider: 'files', query: 'notes/plan' });
+  assert.deepEqual(routeQuickAccess('?'), { provider: 'help', query: '' });
+});
+
+test('Command Palette filters unavailable commands and promotes session recency', () => {
+  const available = commandDefinitions.filter((command) => command.available({
+    hasFolder: true,
+    hasActiveTab: true,
+    activeFileIsMarkdown: true,
+  }));
+  const ranked = rankCommandPalette(available, '', ['agent.show-codex']);
+
+  assert.equal(ranked[0]?.id, 'agent.show-codex');
+  assert.ok(ranked.some((command) => command.id === 'document.new-note'));
+  assert.ok(ranked.some((command) => command.id === 'document.find'));
+  assert.ok(!commandDefinitions.some((command) => command.id === 'document.new-note' && command.available({
+    hasFolder: false,
+    hasActiveTab: false,
+    activeFileIsMarkdown: false,
+  })));
+});
+
+test('Command Palette matches labels, categories, and stable identities', () => {
+  const commands = commandDefinitions.filter((command) => command.available({
+    hasFolder: true,
+    hasActiveTab: false,
+    activeFileIsMarkdown: false,
+  }));
+
+  assert.deepEqual(rankCommandPalette(commands, 'settings', []).map((command) => command.id), ['settings.open']);
+  assert.deepEqual(rankCommandPalette(commands, 'agent.show-codex', []).map((command) => command.id), ['agent.show-codex']);
+});

--- a/web-src/src/__tests__/hotkeys.test.ts
+++ b/web-src/src/__tests__/hotkeys.test.ts
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { isWindowLifecycleShortcut } from '../components/Hotkeys';
+import { isCommandPaletteShortcut, isWindowLifecycleShortcut } from '../components/Hotkeys';
+
+test('Command Palette owns F1 and Cmd/Ctrl+Shift+P only', () => {
+  assert.equal(isCommandPaletteShortcut({ key: 'F1', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false }), true);
+  assert.equal(isCommandPaletteShortcut({ key: 'p', metaKey: true, ctrlKey: false, shiftKey: true, altKey: false }), true);
+  assert.equal(isCommandPaletteShortcut({ key: 'p', metaKey: false, ctrlKey: true, shiftKey: false, altKey: false }), false);
+  assert.equal(isCommandPaletteShortcut({ key: 'F1', metaKey: false, ctrlKey: false, shiftKey: true, altKey: false }), false);
+});
 
 test('renderer yields shifted new-window and close-window chords to Electron', () => {
   assert.equal(

--- a/web-src/src/commandPalette.ts
+++ b/web-src/src/commandPalette.ts
@@ -1,0 +1,74 @@
+export type QuickAccessProvider = 'files' | 'commands' | 'help';
+
+export interface CommandContext {
+  hasFolder: boolean;
+  hasActiveTab: boolean;
+  activeFileIsMarkdown: boolean;
+}
+
+export interface CommandDefinition {
+  id: string;
+  label: string;
+  category: string;
+  shortcut?: string;
+  available: (context: CommandContext) => boolean;
+}
+
+export function routeQuickAccess(value: string): { provider: QuickAccessProvider; query: string } {
+  const trimmed = value.trimStart();
+  if (trimmed.startsWith('>')) return { provider: 'commands', query: trimmed.slice(1).trimStart() };
+  if (trimmed.startsWith('?')) return { provider: 'help', query: trimmed.slice(1).trimStart() };
+  return { provider: 'files', query: value };
+}
+
+export const commandDefinitions: readonly CommandDefinition[] = [
+  { id: 'navigation.go-home', label: 'Go to Welcome', category: 'Navigation', available: ({ hasFolder }) => hasFolder },
+  { id: 'document.new-note', label: 'New Note', category: 'Document', shortcut: 'Cmd/Ctrl+N', available: ({ hasFolder }) => hasFolder },
+  { id: 'document.save', label: 'Save', category: 'Document', shortcut: 'Cmd/Ctrl+S', available: ({ hasActiveTab }) => hasActiveTab },
+  { id: 'document.close-editor', label: 'Close Editor', category: 'Document', shortcut: 'Cmd/Ctrl+W', available: ({ hasActiveTab }) => hasActiveTab },
+  { id: 'document.toggle-editing', label: 'Toggle Editing Mode', category: 'Document', available: ({ activeFileIsMarkdown }) => activeFileIsMarkdown },
+  { id: 'document.find', label: 'Find in Document', category: 'Document', shortcut: 'Cmd/Ctrl+F', available: ({ hasActiveTab }) => hasActiveTab },
+  { id: 'search.focus', label: 'Focus Search', category: 'Search', shortcut: 'Cmd/Ctrl+Shift+F', available: ({ hasFolder }) => hasFolder },
+  { id: 'agent.show-claude', label: 'Show Claude Code', category: 'Agent Panel', available: ({ hasFolder }) => hasFolder },
+  { id: 'agent.show-codex', label: 'Show Codex', category: 'Agent Panel', available: ({ hasFolder }) => hasFolder },
+  { id: 'settings.open', label: 'Open Settings', category: 'Settings', available: () => true },
+];
+
+function fuzzyMatch(value: string, query: string): number | null {
+  let cursor = 0;
+  let score = 0;
+  for (const char of query.toLocaleLowerCase()) {
+    const index = value.toLocaleLowerCase().indexOf(char, cursor);
+    if (index < 0) return null;
+    score += 10 - Math.min(index, 8);
+    cursor = index + 1;
+  }
+  return score;
+}
+
+/** Ranks only supplied, already-available commands. Recency is deliberately
+ * owned by the picker component so it never becomes persisted activity data. */
+export function rankCommandPalette(
+  commands: readonly CommandDefinition[],
+  query: string,
+  recentIds: readonly string[],
+): CommandDefinition[] {
+  const normalized = query.trim();
+  const recentRank = new Map(recentIds.map((id, index) => [id, index]));
+  return commands
+    .map((command) => {
+      const haystack = `${command.label} ${command.category} ${command.id}`;
+      const score = normalized ? fuzzyMatch(haystack, normalized) : 0;
+      return score == null ? null : { command, score, recent: recentRank.get(command.id) };
+    })
+    .filter((candidate): candidate is { command: CommandDefinition; score: number; recent: number | undefined } => candidate !== null)
+    .sort((a, b) => {
+      if (a.recent !== undefined || b.recent !== undefined) {
+        if (a.recent === undefined) return 1;
+        if (b.recent === undefined) return -1;
+        return a.recent - b.recent;
+      }
+      return b.score - a.score || a.command.label.localeCompare(b.command.label);
+    })
+    .map(({ command }) => command);
+}

--- a/web-src/src/components/Hotkeys.tsx
+++ b/web-src/src/components/Hotkeys.tsx
@@ -13,6 +13,12 @@ export function isWindowLifecycleShortcut(input: WindowShortcutInput): boolean {
     && ['n', 'w'].includes(input.key.toLowerCase());
 }
 
+export function isCommandPaletteShortcut(input: WindowShortcutInput): boolean {
+  const key = input.key.toLowerCase();
+  return (key === 'f1' && !input.metaKey && !input.ctrlKey && !input.altKey && !input.shiftKey)
+    || ((input.metaKey || input.ctrlKey) && input.shiftKey && !input.altKey && key === 'p');
+}
+
 /**
  * Global keyboard shortcuts. Renderless — mounts a `keydown` listener
  * on document and dispatches into the store.
@@ -20,6 +26,7 @@ export function isWindowLifecycleShortcut(input: WindowShortcutInput): boolean {
  *   Cmd/Ctrl + N        → new note
  *   Cmd/Ctrl + S        → flush autosave immediately
  *   Cmd/Ctrl + O        → Quick Open for the active library
+ *   Cmd/Ctrl + Shift + P / F1 → Command Palette
  *   Cmd/Ctrl + W        → close the active tab
  *   Cmd/Ctrl + F        → open in-document find bar
  *   Cmd/Ctrl + G        → next find match (Shift = prev). No-op when bar is closed.
@@ -44,6 +51,11 @@ export function Hotkeys() {
       if (e.key === 'Escape' && findOpenRef.current) {
         e.preventDefault();
         actions.closeFind();
+        return;
+      }
+      if (isCommandPaletteShortcut(e)) {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent('stashbase-open-quick-open', { detail: { mode: 'commands' } }));
         return;
       }
       if (!(e.metaKey || e.ctrlKey)) return;

--- a/web-src/src/components/QuickOpen.tsx
+++ b/web-src/src/components/QuickOpen.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { commandDefinitions, rankCommandPalette, routeQuickAccess } from '../commandPalette';
 import { rankQuickOpen } from '../quickOpen';
+import { openSettings } from './SettingsModal';
 import { useApp } from '../store/AppContext';
 
 /** Quick Open calls the sidebar's document-selection action, preserving its
  * save guards, folder-generation checks, and preview-tab replacement. */
 export function QuickOpen() {
-  const { state, actions } = useApp();
+  const { state, actions, activeTab } = useApp();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [active, setActive] = useState(0);
@@ -15,18 +17,51 @@ export function QuickOpen() {
   const blocked = Boolean(settingsBlocking || state.modal || state.cascadePrompt || state.ctxMenu || state.renaming);
   const paths = useMemo(() => state.files.map((file) => file.name), [state.files]);
   const recentPaths = state.recentFilePaths;
-  const items = useMemo(() => rankQuickOpen(paths, query, recentPaths), [paths, query, recentPaths]);
+  const [recentCommandIds, setRecentCommandIds] = useState<string[]>([]);
+  const route = routeQuickAccess(query);
+  const commandContext = {
+    hasFolder: Boolean(state.folder && !state.welcomeVisible),
+    hasActiveTab: Boolean(state.activeTabId),
+    activeFileIsMarkdown: activeTab?.file?.format === 'md',
+  };
+  const fileItems = useMemo(
+    () => rankQuickOpen(paths, route.provider === 'files' ? route.query : '', recentPaths),
+    [paths, recentPaths, route.provider, route.query],
+  );
+  const commands = useMemo(
+    () => rankCommandPalette(commandDefinitions.filter((command) => command.available(commandContext)), route.query, recentCommandIds),
+    [commandContext.activeFileIsMarkdown, commandContext.hasActiveTab, commandContext.hasFolder, recentCommandIds, route.query],
+  );
+  const itemCount = route.provider === 'files' ? fileItems.length : route.provider === 'commands' ? commands.length : 0;
   const close = () => { setOpen(false); setQuery(''); setActive(0); requestAnimationFrame(() => restoreRef.current?.focus()); };
   const accept = (path: string) => { close(); void actions.selectFile(path); };
+  const runCommand = (id: string) => {
+    setRecentCommandIds((recent) => [id, ...recent.filter((candidate) => candidate !== id)]);
+    close();
+    switch (id) {
+      case 'navigation.go-home': void actions.goHome(); break;
+      case 'document.new-note': void actions.newNote(); break;
+      case 'document.save': void actions.flushSave(); break;
+      case 'document.close-editor': void actions.closeActiveTab(); break;
+      case 'document.toggle-editing': void actions.toggleEditMode(); break;
+      case 'document.find': actions.openFind(); break;
+      case 'search.focus': actions.focusSearch(); break;
+      case 'agent.show-claude': actions.openAgent('claude'); break;
+      case 'agent.show-codex': actions.openAgent('codex'); break;
+      case 'settings.open': openSettings(); break;
+    }
+  };
 
   useEffect(() => {
-    const onOpen = () => {
+    const onOpen = (event: Event) => {
       // Some blocking UI (notably Agent permission cards) owns local state
       // outside this reducer. Every blocking surface uses the shared modal
       // veil, so this final topmost check keeps the shortcut from escaping it.
-      if (blocked || document.querySelector('.modal-veil, .quick-open-blocking') || state.welcomeVisible || !state.folder) return;
+      const mode = (event as CustomEvent<{ mode?: string }>).detail?.mode;
+      const commandsOnly = mode === 'commands';
+      if (blocked || document.querySelector('.modal-veil, .quick-open-blocking') || (!commandsOnly && (state.welcomeVisible || !state.folder))) return;
       restoreRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
-      setQuery(''); setActive(0); setOpen(true);
+      setQuery(commandsOnly ? '>' : ''); setActive(0); setOpen(true);
     };
     window.addEventListener('stashbase-open-quick-open', onOpen);
     return () => window.removeEventListener('stashbase-open-quick-open', onOpen);
@@ -37,25 +72,29 @@ export function QuickOpen() {
     return () => window.removeEventListener('stashbase-overlay-blocking', onBlocking);
   }, []);
   useEffect(() => { if (open) inputRef.current?.focus(); }, [open]);
-  useEffect(() => { if (active >= items.length) setActive(Math.max(0, items.length - 1)); }, [active, items.length]);
+  useEffect(() => { if (active >= itemCount) setActive(Math.max(0, itemCount - 1)); }, [active, itemCount]);
   if (!open) return null;
   return <div className="quick-open-veil" role="presentation" onMouseDown={(event) => { if (event.target === event.currentTarget) close(); }}>
-    <div className="quick-open" role="dialog" aria-label="Quick Open">
-      <input ref={inputRef} className="quick-open-input" role="combobox" aria-autocomplete="list" aria-controls="quick-open-results" aria-expanded="true" aria-activedescendant={items[active] ? `quick-open-${active}` : undefined} placeholder="Search files by name or path" value={query}
+    <div className="quick-open" role="dialog" aria-label={route.provider === 'commands' ? 'Command Palette' : 'Quick Open'}>
+      <input ref={inputRef} className="quick-open-input" role="combobox" aria-autocomplete="list" aria-controls="quick-open-results" aria-expanded="true" aria-activedescendant={itemCount ? `quick-open-${active}` : undefined} placeholder={route.provider === 'commands' ? 'Type a command' : 'Search files by name or path'} value={query}
         onChange={(event) => { setQuery(event.target.value); setActive(0); }}
         onKeyDown={(event) => {
           if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); close(); }
-          else if (event.key === 'ArrowDown') { event.preventDefault(); setActive((index) => Math.min(index + 1, items.length - 1)); }
+          else if (event.key === 'ArrowDown') { event.preventDefault(); setActive((index) => Math.min(index + 1, itemCount - 1)); }
           else if (event.key === 'ArrowUp') { event.preventDefault(); setActive((index) => Math.max(index - 1, 0)); }
           else if (event.key === 'Home') { event.preventDefault(); setActive(0); }
-          else if (event.key === 'End') { event.preventDefault(); setActive(Math.max(0, items.length - 1)); }
-          else if (event.key === 'Enter' && items[active]) { event.preventDefault(); accept(items[active].path); }
+          else if (event.key === 'End') { event.preventDefault(); setActive(Math.max(0, itemCount - 1)); }
+          else if (event.key === 'Enter' && route.provider === 'files' && fileItems[active]) { event.preventDefault(); accept(fileItems[active].path); }
+          else if (event.key === 'Enter' && route.provider === 'commands' && commands[active]) { event.preventDefault(); runCommand(commands[active].id); }
         }} />
-      <div className="quick-open-label">{query.trim() ? 'Files' : 'Recent editors'}</div>
+      <div className="quick-open-label">{route.provider === 'files' ? (route.query.trim() ? 'Files' : 'Recent editors') : route.provider === 'commands' ? 'Commands' : 'Quick Access'}</div>
       <ul id="quick-open-results" className="quick-open-results" role="listbox" aria-label="Quick Open results">
-        {items.map((item, index) => <li key={item.path} id={`quick-open-${index}`} role="option" aria-selected={index === active} className={index === active ? 'active' : ''} onMouseMove={() => setActive(index)} onMouseDown={(event) => { event.preventDefault(); accept(item.path); }}><span>{item.basename}</span><small>{item.path.includes('/') ? item.path.slice(0, item.path.lastIndexOf('/')) : 'Active Library'}</small></li>)}
-        {items.length === 0 && <li className="quick-open-empty" role="option" aria-disabled="true">{query.trim() ? 'No matching source files' : 'No recently used editors'}</li>}
+        {route.provider === 'files' && fileItems.map((item, index) => <li key={item.path} id={`quick-open-${index}`} role="option" aria-selected={index === active} className={index === active ? 'active' : ''} onMouseMove={() => setActive(index)} onMouseDown={(event) => { event.preventDefault(); accept(item.path); }}><span>{item.basename}</span><small>{item.path.includes('/') ? item.path.slice(0, item.path.lastIndexOf('/')) : 'Active Library'}</small></li>)}
+        {route.provider === 'files' && fileItems.length === 0 && <li className="quick-open-empty" role="option" aria-disabled="true">{route.query.trim() ? 'No matching source files' : 'No recently used editors'}</li>}
+        {route.provider === 'commands' && commands.map((command, index) => <li key={command.id} id={`quick-open-${index}`} role="option" aria-selected={index === active} className={index === active ? 'active' : ''} onMouseMove={() => setActive(index)} onMouseDown={(event) => { event.preventDefault(); runCommand(command.id); }}><span>{command.label}</span><small>{command.shortcut ?? command.category}</small></li>)}
+        {route.provider === 'commands' && commands.length === 0 && <li className="quick-open-empty" role="option" aria-disabled="true">No matching available commands</li>}
       </ul>
+      {route.provider === 'help' && <div className="quick-open-help" role="note">Type a file name to open a source file, or <kbd>&gt;</kbd> to run a command. Cmd/Ctrl+Shift+P and F1 open commands directly.</div>}
     </div>
   </div>;
 }

--- a/web-src/src/store/AppContext.tsx
+++ b/web-src/src/store/AppContext.tsx
@@ -23,6 +23,7 @@ import {
 import {
   getActiveTab,
   initialState,
+  makeChatTab,
   reducer,
   type Action,
   type CascadeDecision,
@@ -30,6 +31,7 @@ import {
   type State,
 } from './state';
 import type { SearchTypeCategory } from '../../../shared/search-types.ts';
+import type { AgentKind } from '../agentCatalog';
 import type { EditorHandle, FindController } from './actionTypes';
 import { useDocumentActions } from './useDocumentActions';
 import { useFeedbackActions } from './useFeedbackActions';
@@ -168,6 +170,9 @@ export interface AppActions {
    *  toasts otherwise have to be dismissed one by one). */
   clearToasts: () => void;
   toggleEditMode: () => Promise<void>;
+  /** Reveal an existing Agent Panel session or create its first tab. This only
+   * changes renderer layout; permissions and Agent context remain unchanged. */
+  openAgent: (agent: AgentKind) => void;
 
   newNote: () => Promise<void>;
   newFolder: (path: string) => Promise<void>;
@@ -568,6 +573,15 @@ export function AppProvider({ children }: { children: ReactNode }) {
     alert: showAlert, confirm: askConfirm, resolveModal,
     toast, dismissToast, clearToasts,
     toggleEditMode,
+    openAgent: (agent) => {
+      const current = stateRef.current;
+      const hasOpenTab = current.chatTabs.some((tab) => tab.agent === agent);
+      dispatch({
+        type: 'CHAT_AGENT_OPEN',
+        agent,
+        tab: hasOpenTab ? undefined : makeChatTab(agent, current.chatTabs),
+      });
+    },
     newNote, newFolder, deleteFile, deleteFolder,
     renameFile, renameFolder, moveFile, upload,
     scheduleSave, flushSave,

--- a/web-src/src/store/state.ts
+++ b/web-src/src/store/state.ts
@@ -453,6 +453,8 @@ export type Action =
   /** Select or toggle an agent from a chrome icon. `tab` is supplied only
    *  when that agent has no open tabs. */
   | { type: 'CHAT_AGENT_TOGGLE'; agent: string; tab?: ChatTab }
+  /** Reveal an Agent Panel session without toggling an already-visible panel. */
+  | { type: 'CHAT_AGENT_OPEN'; agent: string; tab?: ChatTab }
   | { type: 'CHAT_TAB_NEW'; tab: ChatTab }
   | { type: 'CHAT_TAB_CLOSE'; id: string }
   | { type: 'CHAT_TAB_ACTIVATE'; id: string }

--- a/web-src/src/store/stateReducer.ts
+++ b/web-src/src/store/stateReducer.ts
@@ -311,6 +311,25 @@ export function reducer(s: State, a: Action): State {
         chatTabRecencyByAgent: rememberChatTab(s.chatTabRecencyByAgent, a.tab),
       };
     }
+    case 'CHAT_AGENT_OPEN': {
+      const existingTab = mostRecentChatTab(s, a.agent);
+      if (existingTab) {
+        return {
+          ...s,
+          chatOpen: true,
+          activeChatTabId: existingTab.id,
+          chatTabRecencyByAgent: rememberChatTab(s.chatTabRecencyByAgent, existingTab),
+        };
+      }
+      if (!a.tab) return s;
+      return {
+        ...s,
+        chatOpen: true,
+        chatTabs: [...s.chatTabs, a.tab],
+        activeChatTabId: a.tab.id,
+        chatTabRecencyByAgent: rememberChatTab(s.chatTabRecencyByAgent, a.tab),
+      };
+    }
     case 'CHAT_TAB_NEW':
       return {
         ...s,

--- a/web-src/src/styles/mainpane.css
+++ b/web-src/src/styles/mainpane.css
@@ -2966,3 +2966,5 @@
 .quick-open-results small { overflow: hidden; color: var(--muted); text-overflow: ellipsis; white-space: nowrap; }
 .quick-open-results li.active small { color: inherit; opacity: .82; }
 .quick-open-results .quick-open-empty { color: var(--muted); justify-content: center; padding: 18px; }
+.quick-open-help { display: block !important; color: var(--muted); line-height: 1.5; padding: 14px 10px !important; }
+.quick-open-help kbd { color: var(--fg); font: inherit; font-weight: 600; }


### PR DESCRIPTION
## Summary

- add a VS Code-like Command Palette to the existing Quick Open shell, with Cmd/Ctrl+Shift+P, F1, and `>` provider routing
- register safe navigation, document, search, Agent Panel, and Settings commands with stable IDs, availability rules, categories, and shortcut hints
- rank session-only command recency before the general list without persisting activity history
- preserve existing document, search, Agent, and Settings action paths rather than duplicating their behavior

## Why

StashBase already has useful keyboard actions, but they were scattered and difficult to discover. Quick Open also needed a command-only provider without mixing commands and source files.

## User impact

Users can invoke safe application actions from a keyboard-first picker, see only commands that apply in the current context, and return to common actions faster during a session. Quick Open remains source-file navigation only; destructive and target-dependent operations remain outside the palette.

## Documentation

Updated the README, Local File Workspace design guide, and maintainer architecture contract with Command Palette routing, safety, session-recent behavior, and overlay ownership.

## Validation

- `git diff --check`
- `pnpm test:renderer` (73 passing)
- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`

Closes #79