### PR TITLE
feat(library): add Editor History

### DIFF
--- a/code-review/architecture.md
+++ b/code-review/architecture.md
@@ -133,6 +133,35 @@ availability predicates, call established renderer actions, and keep command
 recency in picker-local session memory only. Do not turn either provider into a
 retrieval, cross-library, Agent-permission, or destructive-operation surface.
 
+Editor History (`state.editorHistory`, `web-src/src/editorHistory.ts`,
+`EditorHistoryNavigator.tsx`) is `state.tabs`' id-level most-recently-activated
+order, separate from `recentFilePaths` (Quick Open's folder-local file recency,
+which can outlive a closed tab) and from tab-strip order (`TABS_REORDER` never
+touches it). Every tab-creating or tab-activating action records itself;
+`CLOSE_TAB` / `PRUNE_MISSING_FILE_TABS` / `TABS_RESET` drop entries so the
+navigator never offers a tab that no longer exists. The Ctrl+Tab chord binds
+the literal Control key on every platform, including macOS, matching VS
+Code's own default — Cmd+Tab is the OS application switcher and never reaches
+an Electron window.
+
+Hotkeys owns the raw keydown for the chord (mirroring how it dispatches
+Quick Open's Cmd+O) and dispatches `stashbase-open-editor-history` on every
+qualifying Tab press while Ctrl is held, not just the first. The navigator
+tells opening from cycling apart by an internal `closed`/`pending`/`open`
+phase: the first press arms a pending switch (list computed, index picked)
+without rendering anything; releasing Control within `REVEAL_DELAY_MS`
+(150ms) commits that pending switch directly, so a quick tap never paints
+the overlay. Only a hold past that window, or a second Tab tap arriving
+first, reveals the overlay and enters cycling mode. While pending, nothing
+owns keyboard focus yet, so a `document`-level listener handles release-to-
+commit and Escape-to-cancel; once open, the navigator's focused root owns
+Tab/Shift+Tab (cycle)/Enter/Escape/Control-release through React's synthetic
+handlers and stops propagation, the same topmost-owns-input contract Quick
+Open follows. It carries Quick Open's `quick-open-blocking` marker class for
+mutual exclusion and reuses `activateTab` to commit, preserving that
+action's dirty-buffer save guard. There are no editor groups, so this is one
+navigator over one list, not a per-group picker.
+
 The renderer's local HTTP boundary keeps `web-src/src/api.ts` as the stable endpoint facade. `shared/conversion.ts` and `shared/transcription.ts` own the preparation and transcription contracts consumed on both sides of that boundary; `apiTypes.ts` re-exports them and owns the remaining renderer-only request/response shapes. `apiTransport.ts` owns per-window request identity, JSON/error normalization, retry policy, and folder-relative path encoding. `web-src/src/preparation-copy.ts` translates queued and yielded preparation waits into shared user-facing copy without exposing scheduler lanes or positions. `web-src/src/audio-transcript.ts` maps semantic text or an explicit keyword-result millisecond timestamp back to the exact structured transcript segment and owns the remaining transcription-specific status copy, while `web-src/src/audio-playback.ts` retains logical playback position across direct-to-fallback source replacement.
 
 Electron assigns each `BrowserWindow` a stable identity through its preload

--- a/design-docs/design/library.md
+++ b/design-docs/design/library.md
@@ -19,11 +19,22 @@ to migrate them into a StashBase-specific storage model.
   file operations.
 - The main pane opens the source file the user selected; generated artifacts
   stay hidden.
+- Cmd/Ctrl+T opens a new blank tab, the keyboard equivalent of the tab
+  strip's `+` button — distinct from Cmd/Ctrl+N, which creates a note file.
 - Cmd/Ctrl+O opens a focused Quick Open for visible source files in the active
   folder. It starts with recently used editors, then ranks basename and
   relative-path matches; accepting a result retains normal preview-tab and
   unsaved-work protections. Typing `>` switches that same picker to safe app
   commands; Cmd/Ctrl+Shift+P and F1 open that command mode directly.
+- Holding Ctrl and tapping Tab opens Editor History, a VS Code-style
+  Alt-Tab switcher over open tabs ordered by most-recent use, independent of
+  tab-strip order. A quick tap-release switches straight to the previous
+  editor without ever showing the picker; only a deliberate hold (or a
+  second Tab tap) reveals it. Once revealed, tapping Tab while Ctrl stays
+  down cycles the highlighted entry (Shift reverses); releasing Ctrl
+  activates it. Escape cancels. Deliberately the literal Control key on
+  every platform, including macOS, since Cmd+Tab is the OS application
+  switcher.
 - Search results and agent file links return users to those source files.
 - Root-level `AGENTS.md` and optional `CLAUDE.md` bridge files are visible,
   editable user files. StashBase only creates missing defaults.

--- a/web-src/src/App.tsx
+++ b/web-src/src/App.tsx
@@ -28,6 +28,7 @@ import { Toasts } from './components/Toasts';
 import { ChatLaunchButtons } from './components/ChatLaunchButtons';
 import { SettingsPortal, openSettings } from './components/SettingsModal';
 import { QuickOpen } from './components/QuickOpen';
+import { EditorHistoryNavigator } from './components/EditorHistoryNavigator';
 import { HomeIcon } from './icons';
 import { useHoverTip } from './hooks/useHoverTip';
 import { ErrorBoundary, LazyLoadBoundary, lazyWithRetry } from './components/ErrorBoundary';
@@ -273,6 +274,7 @@ function AppBody() {
       <ContextMenu />
       <Hotkeys />
       <QuickOpen />
+      <EditorHistoryNavigator />
       {previewImage && (
         <ImageLightbox
           src={previewImage.src}

--- a/web-src/src/__tests__/editorHistory.test.ts
+++ b/web-src/src/__tests__/editorHistory.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  cycleEditorHistoryIndex,
+  initialEditorHistoryIndex,
+  isEditorHistoryChord,
+  orderEditorHistory,
+} from '../editorHistory';
+import type { Tab } from '../store/state';
+
+function tab(id: string, name: string | null, preview = false): Tab {
+  return {
+    id,
+    file: name ? { name, format: 'md', content: '' } : null,
+    editMode: false,
+    dirty: false,
+    preview,
+    pendingAnchor: null,
+    pendingHighlight: null,
+    saveStatus: { text: '', cls: '' },
+  };
+}
+
+test('Editor History orders open tabs by MRU, not tab-strip order', () => {
+  const tabs = [tab('a', 'a.md'), tab('b', 'b.md'), tab('c', 'c.md')];
+  const entries = orderEditorHistory(tabs, ['c', 'a', 'b']);
+  assert.deepEqual(entries.map((entry) => entry.id), ['c', 'a', 'b']);
+  assert.deepEqual(entries.map((entry) => entry.label), ['c.md', 'a.md', 'b.md']);
+});
+
+test('Editor History appends open tabs missing from recorded history defensively', () => {
+  const tabs = [tab('a', 'a.md'), tab('b', 'b.md')];
+  const entries = orderEditorHistory(tabs, ['a']);
+  assert.deepEqual(entries.map((entry) => entry.id), ['a', 'b']);
+});
+
+test('Editor History drops history entries whose tab already closed', () => {
+  const tabs = [tab('a', 'a.md')];
+  const entries = orderEditorHistory(tabs, ['b', 'a', 'c']);
+  assert.deepEqual(entries.map((entry) => entry.id), ['a']);
+});
+
+test('Editor History labels a blank tab and flags preview tabs', () => {
+  const tabs = [tab('a', null), tab('b', 'b.md', true)];
+  const entries = orderEditorHistory(tabs, ['a', 'b']);
+  assert.equal(entries[0].label, 'Untitled');
+  assert.equal(entries[1].preview, true);
+});
+
+test('the chord is the literal Control key, never Cmd/Meta', () => {
+  assert.equal(isEditorHistoryChord({ key: 'Tab', ctrlKey: true, metaKey: false, altKey: false }), true);
+  assert.equal(isEditorHistoryChord({ key: 'Tab', ctrlKey: false, metaKey: true, altKey: false }), false);
+  assert.equal(isEditorHistoryChord({ key: 'Tab', ctrlKey: true, metaKey: false, altKey: true }), false);
+  assert.equal(isEditorHistoryChord({ key: 'q', ctrlKey: true, metaKey: false, altKey: false }), false);
+});
+
+test('forward opens on the previous editor; backward opens on the oldest', () => {
+  assert.equal(initialEditorHistoryIndex(4, false), 1);
+  assert.equal(initialEditorHistoryIndex(4, true), 3);
+  assert.equal(initialEditorHistoryIndex(1, false), 0);
+});
+
+test('cycling wraps in both directions', () => {
+  assert.equal(cycleEditorHistoryIndex(2, 3, false), 0);
+  assert.equal(cycleEditorHistoryIndex(0, 3, true), 2);
+  assert.equal(cycleEditorHistoryIndex(1, 3, false), 2);
+});

--- a/web-src/src/components/EditorHistoryNavigator.tsx
+++ b/web-src/src/components/EditorHistoryNavigator.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  cycleEditorHistoryIndex,
+  initialEditorHistoryIndex,
+  orderEditorHistory,
+  type EditorHistoryEntry,
+} from '../editorHistory';
+import { useSettingsBlocking } from '../hooks/useSettingsBlocking';
+import { useApp } from '../store/AppContext';
+
+/** How long Control must stay down before the overlay actually renders. A
+ *  quick tap-release resolves inside this window and never paints — only a
+ *  deliberate hold (or a second Tab tap, which reveals immediately) shows
+ *  the picker. Keeps a fast "switch to the last editor" tap flicker-free. */
+const REVEAL_DELAY_MS = 150;
+
+type Phase = 'closed' | 'pending' | 'open';
+
+interface PendingListeners {
+  keyup: (e: KeyboardEvent) => void;
+  keydown: (e: KeyboardEvent) => void;
+  blur: () => void;
+}
+
+/**
+ * Ctrl+Tab / Ctrl+Shift+Tab Editor History navigator — a VS Code-style
+ * Alt-Tab switcher over Editor History's tab-id MRU order (`state.editorHistory`),
+ * not tab-strip order. There are no editor groups here, so this is the whole
+ * feature: one navigator, one list.
+ *
+ * Chord lifecycle: the first Ctrl+Tab arms a pending switch to the previous
+ * editor (Ctrl+Shift+Tab arms the oldest one) without rendering anything.
+ * Releasing Control within `REVEAL_DELAY_MS` commits that pending switch
+ * directly — a quick tap never shows the overlay. Only a hold past that
+ * window, or a second Tab tap arriving first, reveals the overlay and
+ * enters cycling mode; from there further Tab taps cycle, releasing Control
+ * commits the highlighted entry through the same dirty-buffer-safe
+ * `activateTab` used by the tab strip, and Escape cancels without changing
+ * the active editor.
+ *
+ * Hotkeys owns the raw keydown for the chord (same as Quick Open's Cmd+O)
+ * and dispatches `stashbase-open-editor-history` on every qualifying Tab
+ * press while Ctrl is held — both the opening one and any cycling repeats;
+ * this component tells them apart by phase. Once open, the veil itself
+ * takes focus and owns Tab/Escape/Enter/keyup via React's synthetic
+ * handlers so `stopPropagation` keeps those keystrokes from also reaching
+ * Hotkeys' global listener — same topmost-owns-input contract Quick Open
+ * already follows.
+ *
+ * While pending, nothing owns DOM focus yet, so release-to-commit and
+ * Escape-to-cancel need their own `document`-level listeners — attached
+ * *imperatively*, synchronously inside the chord handler, and closing
+ * directly over the just-computed pending entry rather than reading
+ * component state/refs. A `useEffect`, or a ref that only mirrors state
+ * via the render-body assignment pattern, would only be current *after*
+ * React commits and re-renders — exactly the window a fast tap-release
+ * races. A commit landing before that point would either miss entirely
+ * (unattached listener) or read a stale selection (unmirrored ref).
+ * Closing over plain values computed in the same synchronous handler that
+ * arms `pending` closes both races at once.
+ */
+export function EditorHistoryNavigator() {
+  const { state, actions } = useApp();
+  const [phase, setPhase] = useState<Phase>('closed');
+  const [entries, setEntries] = useState<EditorHistoryEntry[]>([]);
+  const [active, setActive] = useState(0);
+  const settingsBlocking = useSettingsBlocking();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const restoreRef = useRef<HTMLElement | null>(null);
+  const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingListenersRef = useRef<PendingListeners | null>(null);
+  // Mutated synchronously alongside `setEntries` — unlike `entries` itself,
+  // this is readable immediately within the same handler, before React has
+  // re-rendered. Only the cycle-on-second-tap path needs it (the pending
+  // commit path below closes over its own selection instead).
+  const listRef = useRef<EditorHistoryEntry[]>([]);
+
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const settingsBlockingRef = useRef(settingsBlocking);
+  settingsBlockingRef.current = settingsBlocking;
+  const phaseRef = useRef(phase);
+  phaseRef.current = phase;
+
+  function clearRevealTimer() {
+    if (revealTimerRef.current) {
+      clearTimeout(revealTimerRef.current);
+      revealTimerRef.current = null;
+    }
+  }
+
+  function detachPendingListeners() {
+    const listeners = pendingListenersRef.current;
+    if (!listeners) return;
+    document.removeEventListener('keyup', listeners.keyup);
+    document.removeEventListener('keydown', listeners.keydown);
+    window.removeEventListener('blur', listeners.blur);
+    pendingListenersRef.current = null;
+  }
+
+  // Cancel: nothing ever rendered (pending never revealed), so there's
+  // nothing to restore focus to — it never left.
+  const cancel = () => {
+    clearRevealTimer();
+    detachPendingListeners();
+    setPhase('closed');
+  };
+  // Close: the overlay was visible and focus moved to it; restore it.
+  const close = () => {
+    clearRevealTimer();
+    detachPendingListeners();
+    setPhase('closed');
+    requestAnimationFrame(() => restoreRef.current?.focus());
+  };
+  const commit = (id: string) => {
+    clearRevealTimer();
+    detachPendingListeners();
+    setPhase('closed');
+    requestAnimationFrame(() => restoreRef.current?.focus());
+    void actions.activateTab(id);
+  };
+
+  function attachPendingListeners(pendingEntry: EditorHistoryEntry) {
+    detachPendingListeners();
+    const keyup = (e: KeyboardEvent) => {
+      if (e.key !== 'Control') return;
+      e.preventDefault();
+      commit(pendingEntry.id);
+    };
+    const keydown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      cancel();
+    };
+    const blur = () => cancel();
+    document.addEventListener('keyup', keyup);
+    document.addEventListener('keydown', keydown);
+    window.addEventListener('blur', blur);
+    pendingListenersRef.current = { keyup, keydown, blur };
+  }
+
+  useEffect(() => {
+    function onChord(event: Event) {
+      const backward = (event as CustomEvent<{ backward?: boolean }>).detail?.backward === true;
+      if (phaseRef.current === 'closed') {
+        const s = stateRef.current;
+        const blocked = settingsBlockingRef.current
+          || Boolean(s.modal || s.cascadePrompt || s.ctxMenu || s.renaming)
+          || s.welcomeVisible || !s.folder
+          || document.querySelector('.modal-veil, .quick-open-blocking, .quick-open-veil');
+        if (blocked) return;
+        const list = orderEditorHistory(s.tabs, s.editorHistory);
+        if (list.length < 2) return;
+        const initialIndex = initialEditorHistoryIndex(list.length, backward);
+        listRef.current = list;
+        restoreRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        setEntries(list);
+        setActive(initialIndex);
+        setPhase('pending');
+        attachPendingListeners(list[initialIndex]);
+        revealTimerRef.current = setTimeout(() => {
+          revealTimerRef.current = null;
+          setPhase((p) => (p === 'pending' ? 'open' : p));
+        }, REVEAL_DELAY_MS);
+        return;
+      }
+      // A second Tab tap arrived before the reveal timer — the hold is
+      // deliberate, so reveal now already cycled. (If phase is already
+      // 'open' this is a defensive no-op path: the focused container
+      // should have consumed the keystroke itself via stopPropagation
+      // before Hotkeys ever saw it to redispatch.)
+      clearRevealTimer();
+      detachPendingListeners();
+      setActive((index) => cycleEditorHistoryIndex(index, listRef.current.length, backward));
+      setPhase('open');
+    }
+    window.addEventListener('stashbase-open-editor-history', onChord);
+    return () => window.removeEventListener('stashbase-open-editor-history', onChord);
+  }, []);
+
+  // Unmount safety net — this component is always mounted at App level, but
+  // don't leak a dangling timer/listener pair if that ever changes.
+  useEffect(() => () => { clearRevealTimer(); detachPendingListeners(); }, []);
+
+  useEffect(() => {
+    if (phase !== 'open') return;
+    containerRef.current?.focus();
+    // Window losing OS-level focus (e.g. actually alt-tabbing to another
+    // app) doesn't reliably blur the focused container, so watch for it
+    // separately — otherwise a held Control released outside the window
+    // never reaches our keyup handler and the navigator is stuck open.
+    window.addEventListener('blur', close);
+    return () => window.removeEventListener('blur', close);
+  }, [phase]);
+
+  // Defensive close if the folder switches (or a tab closes some other way)
+  // out from under an open navigator — TABS_RESET already clears
+  // tabs/editorHistory on folder change, so a stale entry means our list is
+  // no longer valid rather than that we should keep cycling it.
+  useEffect(() => {
+    if (phase === 'open' && entries.some((entry) => !state.tabs.some((tab) => tab.id === entry.id))) {
+      close();
+    }
+  }, [phase, entries, state.tabs]);
+
+  if (phase !== 'open') return null;
+
+  return (
+    <div
+      className="editor-history-veil quick-open-blocking"
+      role="presentation"
+      onMouseDown={(event) => { if (event.target === event.currentTarget) close(); }}
+    >
+      <div
+        ref={containerRef}
+        className="editor-history"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Editor History"
+        tabIndex={-1}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            event.preventDefault(); event.stopPropagation(); close();
+          } else if (event.key === 'Enter') {
+            event.preventDefault(); event.stopPropagation();
+            const entry = entries[active];
+            if (entry) commit(entry.id);
+          } else if (event.key === 'Tab' || event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault(); event.stopPropagation();
+            const backward = event.key === 'ArrowUp' || (event.key === 'Tab' && event.shiftKey);
+            setActive((index) => cycleEditorHistoryIndex(index, entries.length, backward));
+          }
+        }}
+        onKeyUp={(event) => {
+          if (event.key !== 'Control') return;
+          event.preventDefault(); event.stopPropagation();
+          const entry = entries[active];
+          if (entry) commit(entry.id); else close();
+        }}
+        onBlur={() => close()}
+      >
+        <div className="quick-open-label">Editor History</div>
+        <ul
+          className="editor-history-results"
+          role="listbox"
+          aria-label="Recently used editors"
+          aria-activedescendant={entries[active] ? `editor-history-${active}` : undefined}
+        >
+          {entries.map((entry, index) => (
+            <li
+              key={entry.id}
+              id={`editor-history-${index}`}
+              role="option"
+              aria-selected={index === active}
+              className={index === active ? 'active' : ''}
+              onMouseMove={() => setActive(index)}
+              onMouseDown={(event) => { event.preventDefault(); commit(entry.id); }}
+            >
+              <span>{entry.label}</span>
+              {entry.preview && <small>preview</small>}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/web-src/src/components/Hotkeys.tsx
+++ b/web-src/src/components/Hotkeys.tsx
@@ -25,6 +25,7 @@ export function isCommandPaletteShortcut(input: WindowShortcutInput): boolean {
  * on document and dispatches into the store.
  *
  *   Cmd/Ctrl + N        → new note
+ *   Cmd/Ctrl + T        → new blank tab (Obsidian-style `+`)
  *   Cmd/Ctrl + S        → flush autosave immediately
  *   Cmd/Ctrl + O        → Quick Open for the active library
  *   Cmd/Ctrl + Shift + P / F1 → Command Palette
@@ -93,6 +94,9 @@ export function Hotkeys() {
       if (k === 'n') {
         e.preventDefault();
         void actions.newNote();
+      } else if (k === 't') {
+        e.preventDefault();
+        void actions.newTab();
       } else if (k === 's') {
         e.preventDefault();
         void actions.flushSave();

--- a/web-src/src/components/Hotkeys.tsx
+++ b/web-src/src/components/Hotkeys.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { isEditorHistoryChord } from '../editorHistory';
 import { useApp } from '../store/AppContext';
 
 type WindowShortcutInput = Pick<
@@ -27,6 +28,9 @@ export function isCommandPaletteShortcut(input: WindowShortcutInput): boolean {
  *   Cmd/Ctrl + S        → flush autosave immediately
  *   Cmd/Ctrl + O        → Quick Open for the active library
  *   Cmd/Ctrl + Shift + P / F1 → Command Palette
+ *   Ctrl + Tab (Shift = reverse) → open/cycle Editor History (literal
+ *                         Control on every platform, including macOS —
+ *                         Cmd+Tab is the OS app switcher)
  *   Cmd/Ctrl + W        → close the active tab
  *   Cmd/Ctrl + F        → open in-document find bar
  *   Cmd/Ctrl + G        → next find match (Shift = prev). No-op when bar is closed.
@@ -56,6 +60,11 @@ export function Hotkeys() {
       if (isCommandPaletteShortcut(e)) {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent('stashbase-open-quick-open', { detail: { mode: 'commands' } }));
+        return;
+      }
+      if (isEditorHistoryChord(e)) {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent('stashbase-open-editor-history', { detail: { backward: e.shiftKey } }));
         return;
       }
       if (!(e.metaKey || e.ctrlKey)) return;

--- a/web-src/src/components/QuickOpen.tsx
+++ b/web-src/src/components/QuickOpen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { commandDefinitions, rankCommandPalette, routeQuickAccess } from '../commandPalette';
 import { rankQuickOpen } from '../quickOpen';
+import { useSettingsBlocking } from '../hooks/useSettingsBlocking';
 import { openSettings } from './SettingsModal';
 import { useApp } from '../store/AppContext';
 
@@ -11,7 +12,7 @@ export function QuickOpen() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [active, setActive] = useState(0);
-  const [settingsBlocking, setSettingsBlocking] = useState(false);
+  const settingsBlocking = useSettingsBlocking();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const restoreRef = useRef<HTMLElement | null>(null);
   const blocked = Boolean(settingsBlocking || state.modal || state.cascadePrompt || state.ctxMenu || state.renaming);
@@ -66,11 +67,6 @@ export function QuickOpen() {
     window.addEventListener('stashbase-open-quick-open', onOpen);
     return () => window.removeEventListener('stashbase-open-quick-open', onOpen);
   }, [blocked, state.folder, state.welcomeVisible]);
-  useEffect(() => {
-    const onBlocking = (event: Event) => setSettingsBlocking((event as CustomEvent<boolean>).detail === true);
-    window.addEventListener('stashbase-overlay-blocking', onBlocking);
-    return () => window.removeEventListener('stashbase-overlay-blocking', onBlocking);
-  }, []);
   useEffect(() => { if (open) inputRef.current?.focus(); }, [open]);
   useEffect(() => { if (active >= itemCount) setActive(Math.max(0, itemCount - 1)); }, [active, itemCount]);
   if (!open) return null;

--- a/web-src/src/editorHistory.ts
+++ b/web-src/src/editorHistory.ts
@@ -1,0 +1,50 @@
+import { basename } from './quickOpen';
+import type { Tab } from './store/state';
+
+export interface EditorHistoryEntry {
+  id: string;
+  label: string;
+  preview: boolean;
+}
+
+/** Order currently-open tabs by Editor History (most-recent-first). Any
+ *  open tab missing from `history` — defensively, should never happen since
+ *  every tab-creating action records itself — is appended in strip order so
+ *  no open editor is ever silently excluded from the navigator. */
+export function orderEditorHistory(tabs: Tab[], history: string[]): EditorHistoryEntry[] {
+  const known = new Set(history);
+  const orderedIds = history.filter((id) => tabs.some((tab) => tab.id === id));
+  const missingIds = tabs.filter((tab) => !known.has(tab.id)).map((tab) => tab.id);
+  return [...orderedIds, ...missingIds].map((id) => {
+    const tab = tabs.find((candidate) => candidate.id === id)!;
+    return { id, label: tab.file ? basename(tab.file.name) : 'Untitled', preview: tab.preview };
+  });
+}
+
+type ChordInput = Pick<KeyboardEvent, 'key' | 'ctrlKey' | 'metaKey' | 'altKey'>;
+
+/** The literal Control key + Tab, on every platform — never Cmd/Meta.
+ *  Cmd+Tab is the macOS application switcher and is intercepted by the OS
+ *  before it ever reaches an Electron window; VS Code's own default
+ *  keybinding for this exact feature binds Control on macOS too, so this
+ *  mirrors established precedent rather than the issue title's literal
+ *  "Ctrl/Cmd+Tab" wording. */
+export function isEditorHistoryChord(input: ChordInput): boolean {
+  return input.ctrlKey && !input.metaKey && !input.altKey && input.key === 'Tab';
+}
+
+/** Highlighted index when the chord is first pressed. Forward starts on the
+ *  previous editor (index 1); Shift (backward) starts on the oldest one —
+ *  mirroring VS Code's two distinct entry actions (`...PreviousRecentlyUsedEditorInGroup`
+ *  vs `...LeastRecentlyUsedEditorInGroup`). */
+export function initialEditorHistoryIndex(length: number, backward: boolean): number {
+  if (length <= 1) return 0;
+  return backward ? length - 1 : 1;
+}
+
+/** Cycle the highlighted index while the chord is held. Wraps in both directions. */
+export function cycleEditorHistoryIndex(current: number, length: number, backward: boolean): number {
+  if (length === 0) return 0;
+  const step = backward ? -1 : 1;
+  return (current + step + length) % length;
+}

--- a/web-src/src/hooks/useSettingsBlocking.ts
+++ b/web-src/src/hooks/useSettingsBlocking.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+/** Tracks Settings' local `stashbase-overlay-blocking` announcement — the
+ *  one blocking surface that lives outside the reducer, so topmost pickers
+ *  (Quick Open, Editor History) can't open over it. */
+export function useSettingsBlocking(): boolean {
+  const [blocking, setBlocking] = useState(false);
+  useEffect(() => {
+    const onBlocking = (event: Event) => setBlocking((event as CustomEvent<boolean>).detail === true);
+    window.addEventListener('stashbase-overlay-blocking', onBlocking);
+    return () => window.removeEventListener('stashbase-overlay-blocking', onBlocking);
+  }, []);
+  return blocking;
+}

--- a/web-src/src/quickOpen.ts
+++ b/web-src/src/quickOpen.ts
@@ -5,7 +5,7 @@ export interface QuickOpenItem {
   score: number;
 }
 
-const basename = (path: string) => path.split('/').pop() ?? path;
+export const basename = (path: string) => path.split('/').pop() ?? path;
 
 /** A small deterministic fuzzy ranker. Basename matches win over path-only
  * matches; contiguous and early matches win within either field. */

--- a/web-src/src/store/__tests__/state.test.ts
+++ b/web-src/src/store/__tests__/state.test.ts
@@ -92,6 +92,57 @@ test('document activation maintains folder-local file recency separately from ta
   assert.deepEqual(state.recentFilePaths, []);
 });
 
+test('Editor History tracks tab-id MRU order independent of tab-strip order and prunes closed tabs', () => {
+  let state = reducer(freshState(), {
+    type: 'FILE_OPEN',
+    body: { name: 'one.md', format: 'md', content: '' },
+  });
+  const oneId = state.activeTabId!;
+  state = reducer(state, { type: 'NEW_TAB' });
+  const blankId = state.activeTabId!;
+  state = reducer(state, {
+    type: 'FILE_OPEN',
+    body: { name: 'two.md', format: 'md', content: '' },
+  });
+  // FILE_OPEN without newTab replaces the active (blank) tab's file — the
+  // MRU entry is the blank tab's id, not a fresh id.
+  assert.deepEqual(state.editorHistory, [blankId, oneId]);
+
+  // Reordering the tab strip must not perturb Editor History.
+  state = reducer(state, { type: 'TABS_REORDER', id: oneId, beforeId: null });
+  assert.deepEqual(state.editorHistory, [blankId, oneId]);
+
+  state = reducer(state, { type: 'ACTIVATE_TAB', id: oneId });
+  assert.deepEqual(state.editorHistory, [oneId, blankId]);
+
+  // Closing a tab drops it from history even though it isn't the most
+  // recent entry.
+  state = reducer(state, { type: 'CLOSE_TAB', id: blankId });
+  assert.deepEqual(state.editorHistory, [oneId]);
+
+  state = reducer(state, {
+    type: 'FILES_LOADED', files: [], folders: [], folder: 'other', folderPath: '/other',
+  });
+  assert.deepEqual(state.editorHistory, []);
+});
+
+test('Editor History survives sidebar pruning of missing file tabs', () => {
+  let state = reducer(freshState(), {
+    type: 'FILE_OPEN',
+    body: { name: 'keep.md', format: 'md', content: '' },
+  });
+  const keepId = state.activeTabId!;
+  state = reducer(state, { type: 'NEW_TAB' });
+  state = reducer(state, {
+    type: 'FILE_OPEN',
+    body: { name: 'gone.md', format: 'md', content: '' },
+  });
+  assert.equal(state.editorHistory.length, 2);
+
+  state = reducer(state, { type: 'PRUNE_MISSING_FILE_TABS', names: ['keep.md'] });
+  assert.deepEqual(state.editorHistory, [keepId]);
+});
+
 test('a save acknowledgement advances the version without replacing the live document source', () => {
   const state = reducer(freshState(), {
     type: 'FILE_OPEN',

--- a/web-src/src/store/state.ts
+++ b/web-src/src/store/state.ts
@@ -205,6 +205,13 @@ export interface State {
   /** Most recently activated source-file paths for the active folder.
    *  This is intentionally independent of tab-strip order. */
   recentFilePaths: string[];
+  /** Editor History: most-recently-activated tab ids, current tab first.
+   *  Independent of tab-strip order — the Ctrl+Tab navigator's ordering
+   *  source. Entries are dropped when their tab closes; unlike
+   *  `recentFilePaths` (which can outlive a closed tab for Quick Open's
+   *  "recent editors" list) this never references a tab that isn't
+   *  currently open. Reset with `tabs` on `TABS_RESET` / folder switch. */
+  editorHistory: string[];
   activeTabId: string | null;
 
   expanded: Set<string>;
@@ -362,6 +369,7 @@ export const initialState: State = {
   fileOrder: {},
   tabs: [],
   recentFilePaths: [],
+  editorHistory: [],
   activeTabId: null,
   expanded: new Set(),
   activeFolder: '',

--- a/web-src/src/store/stateHelpers.ts
+++ b/web-src/src/store/stateHelpers.ts
@@ -87,6 +87,17 @@ export function rememberRecentFile(paths: string[], path: string): string[] {
   return [path, ...paths.filter((candidate) => candidate !== path)];
 }
 
+/** Put a tab id first in Editor History's most-recently-activated list. */
+export function rememberActivatedTab(history: string[], id: string): string[] {
+  return [id, ...history.filter((candidate) => candidate !== id)];
+}
+
+/** Drop closed tab ids from Editor History so the Ctrl+Tab navigator never
+ *  offers a tab that no longer exists. */
+export function forgetClosedTabs(history: string[], openIds: Set<string>): string[] {
+  return history.filter((id) => openIds.has(id));
+}
+
 /** Visible files to mark as pending immediately after the user adds the
  *  first embedding key. The server may already be embedding by the time
  *  `/api/index-status` is polled, and the daemon serialises status behind

--- a/web-src/src/store/stateReducer.ts
+++ b/web-src/src/store/stateReducer.ts
@@ -8,10 +8,12 @@ import {
   SIDEBAR_MIN_WIDTH,
   clampChatWidth,
   forgetChatTab,
+  forgetClosedTabs,
   getActiveTab,
   makeTab,
   mostRecentChatTab,
   patchActiveTab,
+  rememberActivatedTab,
   rememberRecentFile,
   remapFileOrder,
   remapOnePath,
@@ -75,6 +77,7 @@ export function reducer(s: State, a: Action): State {
               keywordResult: null,
               searchError: null,
               recentFilePaths: [],
+              editorHistory: [],
               // Scope names a subfolder of the previous folder; type
               // filters are per-folder session state too.
               searchScope: null,
@@ -113,6 +116,7 @@ export function reducer(s: State, a: Action): State {
           ...s,
           tabs: [...s.tabs, tab],
           recentFilePaths: rememberRecentFile(s.recentFilePaths, file.name),
+          editorHistory: rememberActivatedTab(s.editorHistory, tab.id),
           activeTabId: tab.id,
           selectedPath: file.name,
         };
@@ -131,6 +135,8 @@ export function reducer(s: State, a: Action): State {
           ...(a.preview != null ? { preview: a.preview } : {}),
         }),
         recentFilePaths: rememberRecentFile(s.recentFilePaths, file.name),
+        // The branch above already returned unless `s.activeTabId` is set.
+        editorHistory: rememberActivatedTab(s.editorHistory, s.activeTabId!),
         selectedPath: file.name,
       };
     }
@@ -168,6 +174,7 @@ export function reducer(s: State, a: Action): State {
       return {
         ...s,
         tabs: nextTabs,
+        editorHistory: forgetClosedTabs(s.editorHistory, new Set(nextTabs.map((t) => t.id))),
         activeTabId: activeId,
         selectedPath: activeWasStale ? active?.file?.name ?? '' : s.selectedPath,
       };
@@ -205,6 +212,7 @@ export function reducer(s: State, a: Action): State {
       return {
         ...s,
         tabs: [...s.tabs, tab],
+        editorHistory: rememberActivatedTab(s.editorHistory, tab.id),
         activeTabId: tab.id,
         selectedPath: '',
       };
@@ -223,6 +231,7 @@ export function reducer(s: State, a: Action): State {
       return {
         ...s,
         tabs: next,
+        editorHistory: forgetClosedTabs(s.editorHistory, new Set(next.map((t) => t.id))),
         activeTabId: activeId,
         selectedPath: active?.file?.name ?? '',
       };
@@ -237,11 +246,12 @@ export function reducer(s: State, a: Action): State {
         recentFilePaths: target.file
           ? rememberRecentFile(s.recentFilePaths, target.file.name)
           : s.recentFilePaths,
+        editorHistory: rememberActivatedTab(s.editorHistory, a.id),
         selectedPath: target.file?.name ?? '',
       };
     }
     case 'TABS_RESET':
-      return { ...s, tabs: [], recentFilePaths: [], activeTabId: null, selectedPath: '' };
+      return { ...s, tabs: [], recentFilePaths: [], editorHistory: [], activeTabId: null, selectedPath: '' };
     case 'EDIT_MODE': {
       const tab = getActiveTab(s);
       if (!tab) return s;

--- a/web-src/src/styles/mainpane.css
+++ b/web-src/src/styles/mainpane.css
@@ -2926,10 +2926,11 @@
     .toast-close:hover {
       color: var(--fg);
     }
-/* Quick Open is a lightweight topmost picker. It intentionally shares the
- * restrained modal palette while keeping the result list compact enough for
- * keyboard-first file switching. */
-.quick-open-veil {
+/* Quick Open and Editor History are lightweight topmost pickers that share
+ * one restrained modal palette — Editor History is just narrower and skips
+ * the input row (no query, just a hold-to-cycle list). */
+.quick-open-veil,
+.editor-history-veil {
   position: fixed;
   inset: 0;
   z-index: 1200;
@@ -2939,15 +2940,16 @@
   padding-top: min(18vh, 150px);
   background: rgba(0, 0, 0, 0.18);
 }
-.quick-open {
-  width: min(680px, calc(100vw - 32px));
-  max-height: min(480px, calc(100vh - 64px));
+.quick-open,
+.editor-history {
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 9px;
   background: var(--card);
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.24);
 }
+.quick-open { width: min(680px, calc(100vw - 32px)); max-height: min(480px, calc(100vh - 64px)); }
+.editor-history { width: min(420px, calc(100vw - 32px)); max-height: min(420px, calc(100vh - 64px)); outline: none; }
 .quick-open-input {
   width: 100%;
   border: 0;
@@ -2960,11 +2962,17 @@
   background: transparent;
 }
 .quick-open-label { padding: 7px 15px 3px; color: var(--muted); font-size: calc(12px * var(--ui-scale)); }
-.quick-open-results { list-style: none; margin: 0; padding: 5px; overflow: auto; max-height: 380px; }
-.quick-open-results li { display: flex; justify-content: space-between; gap: 20px; padding: 7px 10px; border-radius: 5px; cursor: default; }
-.quick-open-results li.active { color: #fff; background: var(--accent); }
-.quick-open-results small { overflow: hidden; color: var(--muted); text-overflow: ellipsis; white-space: nowrap; }
-.quick-open-results li.active small { color: inherit; opacity: .82; }
+.quick-open-results,
+.editor-history-results { list-style: none; margin: 0; padding: 5px; overflow: auto; max-height: 380px; }
+.quick-open-results li,
+.editor-history-results li { display: flex; justify-content: space-between; gap: 20px; padding: 7px 10px; border-radius: 5px; cursor: default; }
+.quick-open-results li.active,
+.editor-history-results li.active { color: #fff; background: var(--accent); }
+.quick-open-results small,
+.editor-history-results small { overflow: hidden; color: var(--muted); text-overflow: ellipsis; white-space: nowrap; }
+.quick-open-results li.active small,
+.editor-history-results li.active small { color: inherit; opacity: .82; }
 .quick-open-results .quick-open-empty { color: var(--muted); justify-content: center; padding: 18px; }
 .quick-open-help { display: block !important; color: var(--muted); line-height: 1.5; padding: 14px 10px !important; }
 .quick-open-help kbd { color: var(--fg); font: inherit; font-weight: 600; }
+.editor-history-results small { font-style: italic; }


### PR DESCRIPTION
## Summary

- add a Ctrl+Tab / Ctrl+Shift+Tab Editor History navigator: a VS Code-style Alt-Tab switcher over open tabs ordered by most-recent use (`state.editorHistory`), independent of tab-strip order
- bind the literal Control key on every platform, including macOS, matching VS Code's own default — Cmd+Tab is the OS application switcher and never reaches an Electron window
- debounce the overlay's reveal: a quick tap-release commits straight to the previous editor without ever painting the picker; only a deliberate hold past 150ms, or a second Tab tap, reveals it and enters cycling mode
- reuse the existing dirty-buffer-safe `activateTab` to commit, and extract `useSettingsBlocking()` / `basename()` as shared helpers so Quick Open and Editor History don't duplicate overlay-blocking and path-formatting logic
- add Cmd/Ctrl+T as the keyboard equivalent of the tab strip's `+` button (new blank tab), distinct from Cmd/Ctrl+N's "new note"

## Why

Closes #80. Also closes #76, the parent Quick Access epic — Quick Open (#77), Command Palette (#79), and Appearance presets (#78) are already merged, and Editor History was the last piece.

## User impact

Users can hold Ctrl and tap Tab to cycle through recently used editors like VS Code/most desktop apps, or just tap-release for an instant flicker-free swap to the last editor — without disturbing preview-tab semantics or bypassing unsaved-work protection. Cmd/Ctrl+T gives blank-tab creation a keyboard shortcut for the first time.

## Documentation

Updated the Local File Workspace design guide and the maintainer architecture contract with Editor History's chord lifecycle (Control-only binding, debounced reveal, phase state machine) and the new-tab shortcut.

## Validation

- `pnpm test:renderer` (82 passing)
- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`
- live-verified in a running instance: open/cycle/commit/Escape/single-tab no-op, the quick-tap-vs-hold debounce split, window-blur focus restoration, and the Cmd/Ctrl+T shortcut

Closes #80 and #76
