### PR TITLE
fix(welcome): keep folder opens safe from stale index status

### DIFF
--- a/code-review/data-layer.md
+++ b/code-review/data-layer.md
@@ -433,7 +433,7 @@ Representative failure:
 Current contract:
 
 - Opening a folder establishes renderer folder identity and hides Welcome before `/api/files`, file order, or `/api/index-status` finish.
-- Active-folder index polling starts only after that renderer identity is committed. Every poll response, including `NO_FOLDER`, is fenced by both the committed folder path and the navigation generation, so a Welcome-era or superseded response cannot cancel a newer successful open.
+- Active-folder index polling starts only after that renderer identity is committed. Every poll response, including `NO_FOLDER`, is fenced by both the committed folder path and the navigation generation, so a Welcome-era or superseded response cannot cancel a newer successful open. Rebind recovery rechecks that fence after every await and shares the window's folder-mutation queue with user navigation, so an old recovery cannot restore an obsolete server binding.
 - Folder-switch side effects such as index sync and Agent-session cleanup are scheduled after the open-folder response, so they cannot turn navigation into a failed request.
 - Folder-sync queue cleanup consumes rejected promises; an indexer or daemon startup failure records an index warning but must not exit the Node server.
 - Going Home resets renderer folder state and shows Welcome before the server-side close request returns.

--- a/code-review/data-layer.md
+++ b/code-review/data-layer.md
@@ -433,6 +433,7 @@ Representative failure:
 Current contract:
 
 - Opening a folder establishes renderer folder identity and hides Welcome before `/api/files`, file order, or `/api/index-status` finish.
+- Active-folder index polling starts only after that renderer identity is committed. Every poll response, including `NO_FOLDER`, is fenced by both the committed folder path and the navigation generation, so a Welcome-era or superseded response cannot cancel a newer successful open.
 - Folder-switch side effects such as index sync and Agent-session cleanup are scheduled after the open-folder response, so they cannot turn navigation into a failed request.
 - Folder-sync queue cleanup consumes rejected promises; an indexer or daemon startup failure records an index warning but must not exit the Node server.
 - Going Home resets renderer folder state and shows Welcome before the server-side close request returns.

--- a/web-src/src/__tests__/folder-path.test.ts
+++ b/web-src/src/__tests__/folder-path.test.ts
@@ -46,3 +46,21 @@ test('context recovery never reopens a folder removed by another window', async 
   assert.equal(opens, 0);
   assert.equal(result.opened, null);
 });
+
+test('context recovery does not issue an old folder open after navigation changes during its library read', async () => {
+  let resolveLibrary!: (library: { recent: { path: string }[] }) => void;
+  const library = new Promise<{ recent: { path: string }[] }>((resolve) => { resolveLibrary = resolve; });
+  let opens = 0;
+  const recovery = rebindFolderIfStillInLibrary('/notes', {
+    getLibrary: async () => library,
+    shouldContinue: () => false,
+    openFolder: async () => {
+      opens += 1;
+      return { current: { path: '/notes' } };
+    },
+  });
+  resolveLibrary({ recent: [{ path: '/notes' }] });
+  const result = await recovery;
+  assert.equal(opens, 0);
+  assert.equal(result.opened, null);
+});

--- a/web-src/src/folderPath.ts
+++ b/web-src/src/folderPath.ts
@@ -35,9 +35,14 @@ export async function rebindFolderIfStillInLibrary<
   operations: {
     getLibrary: () => Promise<Library>;
     openFolder: (path: string) => Promise<Opened>;
+    /** Re-check ownership after the library read and before issuing a
+     * recovery mutation. A newer navigation may have started while the read
+     * was in flight. */
+    shouldContinue?: () => boolean;
   },
 ): Promise<{ library: Library; opened: Opened | null }> {
   const library = await operations.getLibrary();
   if (!isFolderStillInLibrary(folder, library)) return { library, opened: null };
+  if (operations.shouldContinue && !operations.shouldContinue()) return { library, opened: null };
   return { library, opened: await operations.openFolder(folder) };
 }

--- a/web-src/src/store/AppContext.tsx
+++ b/web-src/src/store/AppContext.tsx
@@ -39,6 +39,7 @@ import { useFileActions } from './useFileActions';
 import { useFindActions } from './useFindActions';
 import { useFolderActions } from './useFolderActions';
 import { useSearchActions } from './useSearchActions';
+import { createFolderMutationQueue } from '../folderTransition';
 
 interface ElectronLifecycleBridge {
   onPrepareContextRelease?: (
@@ -229,6 +230,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveInFlight = useRef<Promise<boolean> | null>(null);
   const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Both user navigation and stale-binding recovery mutate the server-side
+  // folder context for this window. One queue preserves their ordering.
+  const folderMutations = useRef(createFolderMutationQueue());
   const editorRef = useRef<EditorHandle | null>(null);
   // Race protection for `runSearch`: every call bumps this counter and
   // remembers its own value; an older request's response is dropped
@@ -457,6 +461,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       importConversionGrace,
       importIndexGrace,
       keyBackfillGrace,
+      folderMutations,
     },
     {
       loadFiles,
@@ -533,6 +538,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       importConversionGrace,
       importIndexGrace,
       keyBackfillGrace,
+      folderMutations,
     },
     {
       flushSave,

--- a/web-src/src/store/__tests__/folder-open-status-race.test.ts
+++ b/web-src/src/store/__tests__/folder-open-status-race.test.ts
@@ -1,12 +1,95 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { isCurrentIndexStatusPoll } from '../useSearchActions.ts';
-import { initialState, reducer } from '../state.ts';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { api, ApiError } from '../../api.ts';
+import { createFolderMutationQueue } from '../../folderTransition.ts';
+import { useFolderActions } from '../useFolderActions.ts';
+import { isCurrentIndexStatusPoll, useSearchActions } from '../useSearchActions.ts';
+import { initialState, reducer, type Action, type State } from '../state.ts';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((done) => { resolve = done; });
-  return { promise, resolve };
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((done, fail) => { resolve = done; reject = fail; });
+  return { promise, resolve, reject };
+}
+
+function freshState(overrides: Partial<State> = {}): State {
+  return {
+    ...initialState,
+    tabs: [],
+    chatTabs: [],
+    chatTabRecencyByAgent: {},
+    expanded: new Set(),
+    pendingSemanticNames: new Set(),
+    fileOrder: {},
+    ...overrides,
+  };
+}
+
+function createActionHarness(initial: State) {
+  let current = initial;
+  const stateRef = { current };
+  const pollTimer = { current: null as ReturnType<typeof setTimeout> | null };
+  const openGeneration = { current: 0 };
+  const folderMutations = { current: createFolderMutationQueue() };
+  const dispatch = (action: Action) => {
+    current = reducer(current, action);
+    stateRef.current = current;
+  };
+  let searchActions!: ReturnType<typeof useSearchActions>;
+  let folderActions!: ReturnType<typeof useFolderActions>;
+
+  function Harness() {
+    searchActions = useSearchActions({
+      stateRef,
+      pollTimer,
+      searchGeneration: { current: 0 },
+      syncGeneration: { current: 0 },
+      openGeneration,
+      lastTreeVersion: { current: -1 },
+      importConversionGrace: { current: new Map() },
+      importIndexGrace: { current: new Map() },
+      keyBackfillGrace: { current: new Map() },
+      folderMutations,
+    }, {
+      loadFiles: async () => [],
+      loadFilesFromServer: async () => [],
+      refreshActiveTabFromDisk: async () => {},
+      toast: () => '',
+    }, dispatch);
+    folderActions = useFolderActions({
+      state: stateRef,
+      editor: { current: null },
+      openGeneration,
+      syncGeneration: { current: 0 },
+      searchGeneration: { current: 0 },
+      lastTreeVersion: { current: -1 },
+      importConversionGrace: { current: new Map() },
+      importIndexGrace: { current: new Map() },
+      keyBackfillGrace: { current: new Map() },
+      // The real provider shares this queue across both hooks. The harness
+      // does too so it exercises the same recovery/open ordering.
+      folderMutations,
+    }, {
+      flushSave: async () => true,
+      loadFiles: async () => [],
+      loadFileOrder: async () => {},
+      markVisibleFilesPendingForSearch: async () => {},
+      refreshIndexState: (...args) => searchActions.refreshIndexState(...args),
+      toast: () => '',
+    }, dispatch);
+    return null;
+  }
+
+  renderToStaticMarkup(createElement(Harness));
+  return {
+    get state() { return current; },
+    searchActions,
+    folderActions,
+    clearTimer: () => { if (pollTimer.current) clearTimeout(pollTimer.current); },
+  };
 }
 
 test('a stale Welcome index-status 412 cannot discard a successful folder open', async () => {
@@ -67,4 +150,109 @@ test('index-status polling only accepts a committed folder from the same navigat
     openGenerationAtStart: 4,
     currentOpenGeneration: 4,
   }), false);
+});
+
+test('the real status and folder-open actions ignore a stale 412 and commit the selected folder', async () => {
+  const originalIndexStatus = api.indexStatus;
+  const originalOpenFolder = api.openFolder;
+  const originalGetFolder = api.getFolder;
+  const originalSetTimeout = global.setTimeout;
+  const staleStatus = deferred<never>();
+  const selectedFolder = deferred<{ current: { path: string; name: string }; recent: [] }>();
+  let indexStatusCalls = 0;
+  try {
+    // The tested open schedules a later status refresh. Keep that unrelated
+    // timer out of this deterministic interleaving.
+    global.setTimeout = (() => ({}) as ReturnType<typeof setTimeout>) as unknown as typeof setTimeout;
+    api.indexStatus = (() => {
+      indexStatusCalls += 1;
+      return staleStatus.promise;
+    }) as typeof api.indexStatus;
+    api.openFolder = (() => selectedFolder.promise) as typeof api.openFolder;
+    api.getFolder = (async () => ({ current: null, recent: [] })) as typeof api.getFolder;
+
+    const welcome = createActionHarness(freshState());
+    await welcome.searchActions.refreshIndexState();
+    assert.equal(indexStatusCalls, 0, 'Welcome must not start active-folder polling');
+
+    const harness = createActionHarness(freshState({
+      folder: 'Previous',
+      folderPath: '/previous',
+      welcomeVisible: false,
+    }));
+    const poll = harness.searchActions.refreshIndexState();
+    await Promise.resolve();
+    assert.equal(indexStatusCalls, 1);
+
+    const open = harness.folderActions.openFolder('/selected');
+    await Promise.resolve();
+    staleStatus.reject(new ApiError('no folder', 412, 'NO_FOLDER'));
+    await poll;
+    selectedFolder.resolve({ current: { path: '/selected', name: 'Selected' }, recent: [] });
+    await open;
+
+    assert.equal(harness.state.folderPath, '/selected');
+    assert.equal(harness.state.welcomeVisible, false);
+  } finally {
+    api.indexStatus = originalIndexStatus;
+    api.openFolder = originalOpenFolder;
+    api.getFolder = originalGetFolder;
+    global.setTimeout = originalSetTimeout;
+  }
+});
+
+test('a recovery that becomes stale during its library read cannot rebind over a newer open', async () => {
+  const originalIndexStatus = api.indexStatus;
+  const originalOpenFolder = api.openFolder;
+  const originalGetFolder = api.getFolder;
+  const originalSetTimeout = global.setTimeout;
+  const library = deferred<{ current: null; recent: { path: string; openedAt: string }[] }>();
+  const selectedFolder = deferred<{ current: { path: string; name: string }; recent: [] }>();
+  const opens: string[] = [];
+  let libraryCalls = 0;
+  try {
+    global.setTimeout = (() => ({}) as ReturnType<typeof setTimeout>) as unknown as typeof setTimeout;
+    api.indexStatus = (async () => {
+      throw new ApiError('no folder', 412, 'NO_FOLDER');
+    }) as typeof api.indexStatus;
+    api.getFolder = (() => {
+      libraryCalls += 1;
+      return libraryCalls === 1
+        ? library.promise
+        : Promise.resolve({ current: null, recent: [] });
+    }) as typeof api.getFolder;
+    api.openFolder = ((path: string) => {
+      opens.push(path);
+      if (path === '/selected') return selectedFolder.promise;
+      throw new Error(`unexpected stale recovery open: ${path}`);
+    }) as typeof api.openFolder;
+
+    const harness = createActionHarness(freshState({
+      folder: 'Previous',
+      folderPath: '/previous',
+      welcomeVisible: false,
+    }));
+    const recovery = harness.searchActions.refreshIndexState();
+    await Promise.resolve();
+    assert.equal(libraryCalls, 1);
+
+    const open = harness.folderActions.openFolder('/selected');
+    await Promise.resolve();
+    selectedFolder.resolve({ current: { path: '/selected', name: 'Selected' }, recent: [] });
+    await open;
+    library.resolve({
+      current: null,
+      recent: [{ path: '/previous', openedAt: '2026-08-01T00:00:00.000Z' }],
+    });
+    await recovery;
+
+    assert.deepEqual(opens, ['/selected']);
+    assert.equal(harness.state.folderPath, '/selected');
+    assert.equal(harness.state.welcomeVisible, false);
+  } finally {
+    api.indexStatus = originalIndexStatus;
+    api.openFolder = originalOpenFolder;
+    api.getFolder = originalGetFolder;
+    global.setTimeout = originalSetTimeout;
+  }
 });

--- a/web-src/src/store/__tests__/folder-open-status-race.test.ts
+++ b/web-src/src/store/__tests__/folder-open-status-race.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isCurrentIndexStatusPoll } from '../useSearchActions.ts';
+import { initialState, reducer } from '../state.ts';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+test('a stale Welcome index-status 412 cannot discard a successful folder open', async () => {
+  // The initial active-folder poll starts on Welcome, before there is a
+  // renderer folder. Hold that response while a newer open starts.
+  const staleStatus = deferred<void>();
+  const poll = { folderPathAtStart: '', openGenerationAtStart: 0 };
+  let openGeneration = 0;
+  let stale412Handled = false;
+  const staleHandler = staleStatus.promise.then(() => {
+    if (isCurrentIndexStatusPoll({
+      ...poll,
+      currentFolderPath: '',
+      currentOpenGeneration: openGeneration,
+    })) {
+      stale412Handled = true;
+      openGeneration += 1;
+    }
+  });
+
+  // POST /api/folder has begun and received a successful response. Its
+  // continuation is still entitled to commit the selected renderer folder.
+  const openGenerationForSelectedFolder = ++openGeneration;
+  staleStatus.resolve();
+  await staleHandler;
+
+  assert.equal(stale412Handled, false);
+  assert.equal(openGeneration, openGenerationForSelectedFolder);
+
+  let state = reducer(initialState, {
+    type: 'FILES_LOADED',
+    files: [],
+    folders: [],
+    folder: 'Selected',
+    folderPath: '/selected',
+  });
+  state = reducer(state, { type: 'WELCOME_HIDE' });
+  assert.equal(state.folderPath, '/selected');
+  assert.equal(state.welcomeVisible, false);
+});
+
+test('index-status polling only accepts a committed folder from the same navigation generation', () => {
+  assert.equal(isCurrentIndexStatusPoll({
+    folderPathAtStart: '/notes',
+    currentFolderPath: '/notes',
+    openGenerationAtStart: 4,
+    currentOpenGeneration: 4,
+  }), true);
+  assert.equal(isCurrentIndexStatusPoll({
+    folderPathAtStart: '/notes',
+    currentFolderPath: '/notes',
+    openGenerationAtStart: 4,
+    currentOpenGeneration: 5,
+  }), false);
+  assert.equal(isCurrentIndexStatusPoll({
+    folderPathAtStart: '',
+    currentFolderPath: '',
+    openGenerationAtStart: 4,
+    currentOpenGeneration: 4,
+  }), false);
+});

--- a/web-src/src/store/useFolderActions.ts
+++ b/web-src/src/store/useFolderActions.ts
@@ -1,7 +1,7 @@
-import { useCallback, useRef, type MutableRefObject } from 'react';
+import { useCallback, type MutableRefObject } from 'react';
 import { api } from '../api';
 import { folderRefsEqual, isAbsoluteFolderRef } from '../folderPath';
-import { createFolderMutationQueue } from '../folderTransition';
+import type { FolderMutationQueue } from '../folderTransition';
 import type { EditorHandle } from './actionTypes';
 import type { Action, LibraryFolderStatus, State } from './state';
 import type { ToastOptions } from './useFeedbackActions';
@@ -19,6 +19,7 @@ interface FolderActionRefs {
   importConversionGrace: MutableRefObject<Map<string, number>>;
   importIndexGrace: MutableRefObject<Map<string, number>>;
   keyBackfillGrace: MutableRefObject<Map<string, number>>;
+  folderMutations: MutableRefObject<FolderMutationQueue>;
 }
 
 interface FolderActionDependencies {
@@ -63,7 +64,7 @@ export function useFolderActions(
     refreshIndexState,
     toast,
   } = dependencies;
-  const folderMutations = useRef(createFolderMutationQueue()).current;
+  const { folderMutations } = refs;
 
   const resetFolderScopedState = useCallback(() => {
     const previous = state.current;
@@ -162,7 +163,7 @@ export function useFolderActions(
       throw new Error('Current file could not be saved. Resolve the save error before switching folders.');
     }
     const generation = ++openGeneration.current;
-    const opened = await folderMutations.run(() => api.openFolder(path));
+    const opened = await folderMutations.current.run(() => api.openFolder(path));
     const current = opened.current;
     if (!current || generation !== openGeneration.current) return;
     void refreshRecent().catch((err) => {
@@ -179,7 +180,7 @@ export function useFolderActions(
       throw new Error('Current file could not be saved. Resolve the save error before switching folders.');
     }
     const generation = ++openGeneration.current;
-    const opened = await folderMutations.run(() => api.openFolderByName(name, {
+    const opened = await folderMutations.current.run(() => api.openFolderByName(name, {
       create: opts?.create,
       exclusiveCreate: opts?.exclusiveCreate,
     }));
@@ -204,7 +205,7 @@ export function useFolderActions(
       homeDir: state.current.homeDir,
     });
     try {
-      await folderMutations.run(() => api.closeFolder());
+      await folderMutations.current.run(() => api.closeFolder());
     } catch (err: unknown) {
       toast(
         'Could not close the current folder: ' + (err instanceof Error ? err.message : String(err)),

--- a/web-src/src/store/useSearchActions.ts
+++ b/web-src/src/store/useSearchActions.ts
@@ -45,6 +45,29 @@ interface SearchActionDependencies {
   toast: Toast;
 }
 
+/**
+ * Index status belongs to a committed renderer folder, not merely to a server
+ * window context. A folder open has a short interval where the server has
+ * accepted the new folder but the renderer has not committed its identity
+ * yet. Requiring both the path and navigation generation prevents an older
+ * Welcome-era poll from treating that interval as its own and undoing it.
+ */
+export function isCurrentIndexStatusPoll({
+  folderPathAtStart,
+  currentFolderPath,
+  openGenerationAtStart,
+  currentOpenGeneration,
+}: {
+  folderPathAtStart: string;
+  currentFolderPath: string;
+  openGenerationAtStart: number;
+  currentOpenGeneration: number;
+}): boolean {
+  return Boolean(folderPathAtStart)
+    && folderPathAtStart === currentFolderPath
+    && openGenerationAtStart === currentOpenGeneration;
+}
+
 /** Owns search requests, index-status polling, and sync progress state. */
 export function useSearchActions(
   refs: SearchActionRefs,
@@ -93,9 +116,17 @@ export function useSearchActions(
     const explicitFolderPath = folderPathOverride?.trim() || undefined;
     const folderPathAtStart = explicitFolderPath ?? stateRef.current.folderPath;
     const openGenAtStart = openGen.current;
-    const stillTargetFolder = () =>
-      stateRef.current.folderPath === folderPathAtStart
-      || (explicitFolderPath != null && openGenAtStart === openGen.current);
+    // Welcome owns its own per-library-folder status polling. Do not send an
+    // active-folder request until this renderer has committed a folder: a
+    // late NO_FOLDER response from Welcome must never cancel an in-flight
+    // folder open.
+    if (!folderPathAtStart) return;
+    const stillTargetFolder = () => isCurrentIndexStatusPoll({
+      folderPathAtStart,
+      currentFolderPath: stateRef.current.folderPath,
+      openGenerationAtStart: openGenAtStart,
+      currentOpenGeneration: openGen.current,
+    });
     try {
       const s = await api.indexStatus(folderPathAtStart || undefined);
       if (!stillTargetFolder()) {
@@ -300,9 +331,11 @@ export function useSearchActions(
             // Drop through to the hard reset below.
           }
         }
-        // No folder open (e.g. just went home). Clear every folder-scoped
-        // indicator so a stale banner from the previous folder doesn't
-        // bleed into the welcome / next-folder view.
+        // A current committed folder could not be rebound (it was removed,
+        // renamed, or the server is still unavailable). Clear every
+        // folder-scoped indicator before returning this renderer to Welcome.
+        // `stillTargetFolder()` above excludes Welcome-era and superseded
+        // polls, so this invalidation cannot discard a newer folder open.
         syncGen.current += 1;
         openGen.current += 1;
         dispatch({ type: 'PENDING_SEMANTIC_NAMES', names: new Set() });
@@ -314,27 +347,25 @@ export function useSearchActions(
         dispatch({ type: 'PREPARATION_FAILURES', failures: [] });
         dispatch({ type: 'SYNC_RUNNING', running: false });
         lastTreeVersion.current = -1;
-        if (stateRef.current.folderPath) {
-          // Another window may have deleted/closed the folder. The server
-          // has already cleared this window's current-folder context; make
-          // the renderer match instead of leaving a stale tree open.
-          dispatch({ type: 'TABS_RESET' });
-          dispatch({ type: 'CHAT_TABS_RESET' });
-          dispatch({ type: 'FILTER', q: '' });
-          dispatch({ type: 'SEARCH_CLEAR' });
-          dispatch({ type: 'ACTIVE_FOLDER', path: '' });
-          dispatch({ type: 'FILE_ORDER_LOADED', order: {} });
-          dispatch({ type: 'FILES_LOADED', files: [], folders: [], folder: '', folderPath: '' });
-          dispatch({
-            type: 'WELCOME_SHOW',
-            recent: latestLibrary?.recent ?? [],
-            homeDir: latestLibrary?.homeDir,
-          });
-          if (!latestLibrary) {
-            void api.getFolder()
-              .then((j) => dispatch({ type: 'WELCOME_SHOW', recent: j.recent ?? [], homeDir: j.homeDir }))
-              .catch(() => { /* welcome can stay empty until bootstrap/focus */ });
-          }
+        // Another window may have deleted/closed the folder. The server has
+        // already cleared this window's current-folder context; make the
+        // renderer match instead of leaving a stale tree open.
+        dispatch({ type: 'TABS_RESET' });
+        dispatch({ type: 'CHAT_TABS_RESET' });
+        dispatch({ type: 'FILTER', q: '' });
+        dispatch({ type: 'SEARCH_CLEAR' });
+        dispatch({ type: 'ACTIVE_FOLDER', path: '' });
+        dispatch({ type: 'FILE_ORDER_LOADED', order: {} });
+        dispatch({ type: 'FILES_LOADED', files: [], folders: [], folder: '', folderPath: '' });
+        dispatch({
+          type: 'WELCOME_SHOW',
+          recent: latestLibrary?.recent ?? [],
+          homeDir: latestLibrary?.homeDir,
+        });
+        if (!latestLibrary) {
+          void api.getFolder()
+            .then((j) => dispatch({ type: 'WELCOME_SHOW', recent: j.recent ?? [], homeDir: j.homeDir }))
+            .catch(() => { /* welcome can stay empty until bootstrap/focus */ });
         }
       }
     }

--- a/web-src/src/store/useSearchActions.ts
+++ b/web-src/src/store/useSearchActions.ts
@@ -1,6 +1,7 @@
 import { useCallback, type MutableRefObject } from 'react';
 import { api, ApiError } from '../api';
 import { rebindFolderIfStillInLibrary } from '../folderPath';
+import type { FolderMutationQueue } from '../folderTransition';
 import {
   filterGuiSemanticHits,
   shallowEqualConversionProgress,
@@ -34,6 +35,7 @@ interface SearchActionRefs {
   importConversionGrace: MutableRefObject<Map<string, number>>;
   importIndexGrace: MutableRefObject<Map<string, number>>;
   keyBackfillGrace: MutableRefObject<Map<string, number>>;
+  folderMutations: MutableRefObject<FolderMutationQueue>;
 }
 
 interface SearchActionDependencies {
@@ -78,6 +80,7 @@ export function useSearchActions(
     importConversionGrace,
     importIndexGrace,
     keyBackfillGrace,
+    folderMutations,
     lastTreeVersion,
     openGeneration: openGen,
     pollTimer,
@@ -296,7 +299,7 @@ export function useSearchActions(
       }
       if (err instanceof ApiError && err.status === 412) {
         let latestLibrary: Awaited<ReturnType<typeof api.getFolder>> | null = null;
-        if (folderPathAtStart && openGenAtStart === openGen.current) {
+        if (folderPathAtStart && stillTargetFolder()) {
           try {
             // Server restart / dev tsx reload drops the in-memory
             // window → folder binding while the renderer still has the
@@ -305,8 +308,20 @@ export function useSearchActions(
             // removing the folder from the library.
             const recovery = await rebindFolderIfStillInLibrary(folderPathAtStart, {
               getLibrary: api.getFolder,
-              openFolder: api.openFolder,
+              shouldContinue: stillTargetFolder,
+              // Recovery and user navigation mutate the same server-side
+              // window context. Sharing the queue means a newer open either
+              // prevents this stale recovery from starting or is the final
+              // binding after a recovery that was already in flight.
+              openFolder: (path) => folderMutations.current.run(() => {
+                if (!stillTargetFolder()) throw new Error('stale folder recovery');
+                return api.openFolder(path);
+              }),
             });
+            if (!stillTargetFolder()) {
+              scheduleNextPoll(nextDelay);
+              return;
+            }
             latestLibrary = recovery.library;
             if (!recovery.opened) {
               throw new Error('folder was removed from the library');
@@ -327,9 +342,17 @@ export function useSearchActions(
               return;
             }
           } catch {
+            if (!stillTargetFolder()) {
+              scheduleNextPoll(nextDelay);
+              return;
+            }
             // Folder was deleted/renamed, or the server is still not ready.
             // Drop through to the hard reset below.
           }
+        }
+        if (!stillTargetFolder()) {
+          scheduleNextPoll(nextDelay);
+          return;
         }
         // A current committed folder could not be rebound (it was removed,
         // renamed, or the server is still unavailable). Clear every


### PR DESCRIPTION
## Summary

Fixes #89.

Opening a folder from Welcome could complete on the server while the UI remained on Welcome. A late `NO_FOLDER` response from an older index-status poll could invalidate the newer folder-open operation before the renderer committed the selected folder.

This change:

- skips active-folder status polling until the renderer has committed a folder
- fences status responses with both the folder path and navigation generation
- keeps recovery for a genuinely lost active-folder binding
- adds a regression test for the stale Welcome `412` interleaving

## Validation

- `pnpm test:renderer`
- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`
- `pnpm test:electron`
- `pnpm test:electron:smoke`