### PR TITLE
feat(mcp): add file-type filters to library search

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ While the StashBase app is running, a local MCP server makes the same library av
 Core tools:
 
 - `library_info` - return the default folder home, opened folders, optional folder descriptions, and embedder status.
-- `search_library` - search the library, optionally scoped by folder or path prefix.
+- `search_library` - search the library, optionally scoped by folder, path prefix, or file-type categories.
 - `reindex` - reconcile disk changes and make updated files searchable.
 
 StashBase also exposes bounded file helpers for opened folders:

--- a/code-review/architecture.md
+++ b/code-review/architecture.md
@@ -109,7 +109,11 @@ daemon adapters cross these modules. Identity, containment, migration, and proto
 
 One installation has **one library**: the set of opened folders indexed into one collection and exposed by one MCP server.
 
-MCP search defaults to the whole library. Calls can narrow scope by folder root or path prefix. The in-app search UI is scoped to the current window's folder and can narrow further to one subfolder and to file-type categories.
+MCP search defaults to the whole library. Calls can narrow scope by folder root,
+path prefix, or source file-type categories; the detailed filtering contract
+lives in [§6.2](#62-scope). The in-app search UI is scoped to the current
+window's folder and can narrow further to one subfolder and to file-type
+categories.
 
 On server boot, StashBase binds every library folder into the daemon and then reconciles them in the background. The Welcome screen also reconciles library folders with a short cooldown and polls folder status when it is idle. While a folder is actively opening, Welcome status polling and reconcile are deferred so navigation does not compete with preparation work.
 
@@ -373,9 +377,11 @@ StashBase supports two retrieval paths:
 
 ## 6.2 Scope
 
-Search defaults to the whole library for MCP callers. It can be narrowed by folder root or path prefix.
+Search defaults to the whole library for MCP callers. It can be narrowed by
+folder root, path prefix, and the same source file-type categories as app
+search.
 
-The desktop UI search is scoped to the current folder because the UI is showing one folder at a time. The Search panel can narrow further: a subfolder scope (folder-relative, resolved escape-safe against the active folder) and file-type category chips (`shared/search-types.ts` defines the `notes` / `pdf` / `image` / `docx` / `audio` vocabulary; `server/format.ts` maps categories to source extensions). Both narrowing knobs apply to semantic and keyword modes and compose. The semantic path passes the extension filter to the daemon, which over-fetches from MFS (bounded), filters hits by source suffix, and truncates back to `top_k` before returning, so filtering happens before the caller-visible top-k cut; a very sparse type can still return fewer than `top_k` hits. The keyword path restricts the ripgrep target and the derived-text walk to the scoped subtree and enabled categories. Display-path remapping is unchanged: filters act on source paths, and derived notes never surface.
+The desktop UI search is scoped to the current folder because the UI is showing one folder at a time. The Search panel can narrow further: a subfolder scope (folder-relative, resolved escape-safe against the active folder) and file-type category chips (`shared/search-types.ts` defines and validates the `notes` / `pdf` / `image` / `docx` / `audio` vocabulary; `server/format.ts` maps categories to source extensions). MCP `search_library` accepts the same categories. The app and library HTTP routes plus the shared MCP handler normalize raw values through that validator; Library Operations accepts only validated categories before reaching Retrieval. Scope and type narrowing compose. The semantic path passes the extension filter to the daemon, which over-fetches from MFS (bounded), resolves any legacy sibling-derived row to its live visible source identity, filters by that source suffix, and truncates back to `top_k` before returning. Node pushes the note and legacy-source extension vocabularies with the daemon indexing rules so this compatibility logic cannot drift from the shared format catalog. A very sparse type can still return fewer than `top_k` hits. The keyword path restricts the ripgrep target and the derived-text walk to the scoped subtree and enabled categories. Display-path remapping is unchanged: filters act on source paths, and derived notes never surface.
 
 `server/retrieval/` returns one flat list of visible-source evidence for an explicit `keyword` or `semantic` query. The source path is absolute at this seam; renderer adapters make it folder-relative while MCP retains the absolute path. A result reports `ready`, `partial`, or `unavailable` availability so an embedding-key absence is not confused with preparation or indexing work. `server/index-status.ts` owns the folder-scoped readiness snapshot behind `/api/index-status`, including semantic pending work, conversion state, durable attention records, tree versions, and index warnings. `web-src/src/store/useSearchActions.ts` mirrors that snapshot for file rows and the Search view. The readiness, caching, failure, and cancellation rules belong to [data-layer §8.2](data-layer.md#82-conversion-scheduler-and-renderer-notification).
 
@@ -402,7 +408,7 @@ StashBase does not embed an LLM. It gives AI clients retrieval tools, explicit r
 The core MCP tools are:
 
 - **`library_info()`**: returns the default folder home, opened folders, optional folder descriptions, and embedder information so a client can orient itself.
-- **`search_library(query, folder?, path_prefix?, top_k?)`**: searches the library and returns source paths, chunks, line ranges, and scores.
+- **`search_library(query, folder?, path_prefix?, types?, top_k?)`**: searches the library and returns source paths, chunks, line ranges, and scores; `types` accepts the shared source categories and is echoed in the response.
 - **`reindex(folder?)`**: reconciles disk state with the index after local files change.
 
 StashBase also exposes bounded file helpers:

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -37,7 +37,7 @@ user-visible source file.
   show different folders at the same time; those are independent UI scopes,
   not separate libraries or indexing runtimes.
 - In-app search defaults to that current folder. MCP can search the library and
-  narrow to an authorized folder or path prefix.
+  narrow to an authorized folder, path prefix, or source file-type category.
 - MCP file operations are deliberately bounded to authorized library folders;
   they are never a general filesystem interface.
 - One local runtime owns indexing state. Other processes communicate through

--- a/design-docs/design/search.md
+++ b/design-docs/design/search.md
@@ -13,8 +13,8 @@ as the result identity.
   or page/timestamp hint.
 - Prepared PDF, image, DOCX, and media transcript text can be evidence, but
   opening a result returns to the original source file.
-- MCP offers orientation, search, read, reindex, and bounded file operations
-  to authorized Agent clients.
+- MCP offers orientation, search with the same file-type categories as the
+  app, read, reindex, and bounded file operations to authorized Agent clients.
 
 ## Experience Contract
 

--- a/mcp/library-operations-http.ts
+++ b/mcp/library-operations-http.ts
@@ -28,9 +28,15 @@ export function createHttpLibraryOperations(webBase: string, windowId?: string):
   const pathQuery = (path: unknown) => `path=${encodeURIComponent(typeof path === 'string' ? path : '')}`;
   return {
     info: () => json(`${webBase}/api/library/info`, { headers: headers() }),
-    search: ({ query, topK, folder, pathPrefix }) => json(`${webBase}/api/library/search`, {
+    search: ({ query, topK, folder, pathPrefix, types }) => json(`${webBase}/api/library/search`, {
       method: 'POST', headers: headers({ 'content-type': 'application/json' }),
-      body: JSON.stringify({ query, top_k: topK, ...(folder ? { folder } : {}), ...(pathPrefix ? { path_prefix: pathPrefix } : {}) }),
+      body: JSON.stringify({
+        query,
+        top_k: topK,
+        ...(folder ? { folder } : {}),
+        ...(pathPrefix ? { path_prefix: pathPrefix } : {}),
+        ...(types !== undefined ? { types } : {}),
+      }),
     }),
     reindex: ({ folder } = {}) => json(`${webBase}/api/library/reindex`, {
       method: 'POST', headers: headers({ 'content-type': 'application/json' }), body: JSON.stringify(folder ? { folder } : {}),

--- a/mcp/library-server.ts
+++ b/mcp/library-server.ts
@@ -18,6 +18,11 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import type { LibraryOperations } from '../server/library-operations/index.ts';
 import { createHttpLibraryOperations } from './library-operations-http.ts';
+import {
+  parseSearchTypes,
+  SEARCH_TYPE_CATEGORIES,
+  SEARCH_TYPES_VALIDATION_ERROR,
+} from '../shared/search-types.ts';
 
 export interface LibraryMcpServerOptions {
   /** App server base URL, e.g. `http://127.0.0.1:8090`. */
@@ -87,14 +92,32 @@ export function createLibraryMcpServer(opts: LibraryMcpServerOptions): Server {
       if (!query) throw new Error('`query` is required');
       const pathPrefix = typeof args.path_prefix === 'string' && args.path_prefix.trim()
         ? args.path_prefix.trim() : undefined;
+      const parsedTypes = parseSearchTypes(args.types);
+      if (parsedTypes == null) {
+        return {
+          content: [{ type: 'text', text: SEARCH_TYPES_VALIDATION_ERROR }],
+          isError: true,
+        };
+      }
+      const types = args.types == null ? undefined : parsedTypes;
       const k = Math.max(
         1,
         Math.min(MAX_TOP_K, Math.floor(typeof args.top_k === 'number' ? args.top_k : DEFAULT_TOP_K)),
       );
-      const searchResult = await operations.search({ query, topK: k, folder, pathPrefix });
+      const searchResult = await operations.search({ query, topK: k, folder, pathPrefix, types });
       const hits = annotateSearchHitsForMcp(searchResult.hits);
       return {
-        content: [{ type: 'text', text: JSON.stringify({ query, folder: folder ?? null, path_prefix: pathPrefix ?? null, top_k: k, hits }, null, 2) }],
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            query,
+            folder: folder ?? null,
+            path_prefix: pathPrefix ?? null,
+            types: types ?? null,
+            top_k: k,
+            hits,
+          }, null, 2),
+        }],
       };
     }
 
@@ -316,6 +339,14 @@ const BUILTIN_TOOLS = [
               'Optional absolute path prefix (e.g. "/Users/me/notes/transcripts/"). Overrides ' +
               '`folder` when present — pass either, not both. Matches any chunk whose source ' +
               'starts with the prefix.',
+          },
+          types: {
+            type: 'array',
+            description:
+              'Optional source file categories. Omit for all types; combine categories to ' +
+              'search notes, PDFs, images, DOCX files, or audio/video transcripts.',
+            items: { type: 'string', enum: [...SEARCH_TYPE_CATEGORIES] },
+            uniqueItems: true,
           },
           top_k: {
             type: 'integer',

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:electron:smoke": "node electron/multi-window-smoke-runner.cjs",
     "test:renderer-chunks": "node scripts/check-renderer-chunks.mjs",
     "test:conversion-scheduler": "node --import tsx --test server/filesystem-path.test.ts server/folder-relative-path.test.ts server/folder-window.test.ts server/window-context-route.test.ts server/internal-shutdown-route.test.ts server/files.test.ts server/file-hash.test.ts server/http.test.ts server/markdown-source-format.test.ts server/keyword-search.test.ts server/index-status.test.ts server/indexer-mfs-path.test.ts server/session-path.test.ts server/conversion-scheduler.test.ts server/conversion-auxiliary.test.ts server/conversion-status.test.ts server/conversion.test.ts server/extractor-process.test.ts server/audio-transcription.test.ts server/transcription-models.test.ts server/transcription-provider.test.ts server/transcription-runtime.test.ts server/transcription-tools.test.ts server/upload.test.ts",
-    "test:library-files": "node --import tsx --test server/library-file-mutations.test.ts server/library-operations/index.test.ts",
+    "test:library-files": "node --import tsx --test server/library-file-mutations.test.ts server/library-operations/index.test.ts server/routes/library-files.test.ts",
     "test:retrieval": "node --import tsx --test server/retrieval/index.test.ts",
     "test:agent": "node --import tsx --test server/__tests__/agent.test.ts server/__tests__/agent-contract.test.ts server/__tests__/codex-agent.test.ts",
     "test:agent:native": "node --import tsx --test server/__tests__/agent-native-smoke.test.ts",

--- a/python/stashbase_daemon.py
+++ b/python/stashbase_daemon.py
@@ -65,7 +65,9 @@ name to keep the protocol surface small).
                           Scoped by root prefix when given.
 - ``close_store``       — release Milvus Lite's flock so the server can
                           delete or move the DB file.
-- ``set_rules {excluded_dirs?, max_indexable_bytes?, include_extensions?}``
+- ``set_rules {excluded_dirs?, max_indexable_bytes?, include_extensions?,
+  note_extensions?, legacy_derived_source_extensions?,
+  legacy_extensionless_derived_source_extensions?}``
                         — receive indexing rules from Node (single source
                           of truth there); built-in constants are only the
                           fallback for an old Node. Echoes effective rules.
@@ -527,6 +529,13 @@ _RULES = {
     "excluded_dirs": set(INDEX_EXCLUDED_DIRS),
     "max_indexable_bytes": MAX_INDEXABLE_BYTES,
     "include_extensions": [".html", ".htm"],
+    "note_extensions": [".md", ".markdown", ".html", ".htm"],
+    "legacy_derived_source_extensions": [
+        ".pdf", ".png", ".jpg", ".jpeg", ".webp", ".docx",
+    ],
+    "legacy_extensionless_derived_source_extensions": [
+        ".pdf", ".png", ".jpg", ".jpeg", ".webp",
+    ],
 }
 
 
@@ -544,10 +553,31 @@ def op_set_rules(svc: StashbaseStore, args: dict) -> dict:
         _RULES["include_extensions"] = [
             str(e) for e in args["include_extensions"] if str(e).startswith(".")
         ]
+    if isinstance(args.get("note_extensions"), list):
+        _RULES["note_extensions"] = [
+            str(e).lower() for e in args["note_extensions"]
+            if str(e).startswith(".")
+        ]
+    if isinstance(args.get("legacy_derived_source_extensions"), list):
+        _RULES["legacy_derived_source_extensions"] = [
+            str(e).lower() for e in args["legacy_derived_source_extensions"]
+            if str(e).startswith(".")
+        ]
+    if isinstance(args.get("legacy_extensionless_derived_source_extensions"), list):
+        _RULES["legacy_extensionless_derived_source_extensions"] = [
+            str(e).lower()
+            for e in args["legacy_extensionless_derived_source_extensions"]
+            if str(e).startswith(".")
+        ]
     return {
         "excluded_dirs": sorted(_RULES["excluded_dirs"]),
         "max_indexable_bytes": _RULES["max_indexable_bytes"],
         "include_extensions": _RULES["include_extensions"],
+        "note_extensions": _RULES["note_extensions"],
+        "legacy_derived_source_extensions":
+            _RULES["legacy_derived_source_extensions"],
+        "legacy_extensionless_derived_source_extensions":
+            _RULES["legacy_extensionless_derived_source_extensions"],
     }
 
 
@@ -1198,6 +1228,45 @@ def _search_extension_filter(raw) -> tuple | None:
     return exts or None
 
 
+def _visible_source_for_extension_filter(source: str) -> str | None:
+    """Resolve a legacy hidden derived-note row to its live visible source.
+
+    Current derived text is indexed directly under the source path. Older
+    indexes may still contain sibling rows such as ``.paper.pdf.md`` or
+    ``.paper.md``. Extension filtering must classify those rows as the source
+    PDF/image/DOCX before the top-k cut; an orphaned extension-bearing row is
+    dropped just as the Node display remapper drops it later.
+    """
+    normalized = source.replace("\\", "/")
+    slash = normalized.rfind("/")
+    parent = normalized[:slash + 1] if slash >= 0 else ""
+    basename = normalized[slash + 1:]
+    if not basename.startswith("."):
+        return source
+
+    lower = basename.lower()
+    note_extension = next(
+        (ext for ext in _RULES["note_extensions"] if lower.endswith(ext)),
+        None,
+    )
+    if note_extension is None:
+        return source
+
+    stem = basename[1:-len(note_extension)]
+    if not stem:
+        return source
+    legacy_extensions = tuple(_RULES["legacy_derived_source_extensions"])
+    if stem.lower().endswith(legacy_extensions):
+        candidate = f"{parent}{stem}"
+        return candidate if Path(candidate).is_file() else None
+
+    for extension in _RULES["legacy_extensionless_derived_source_extensions"]:
+        candidate = f"{parent}{stem}{extension}"
+        if Path(candidate).is_file():
+            return candidate
+    return source
+
+
 def op_search(svc: StashbaseStore, args: dict) -> dict:
     """Hybrid search in the single collection, optionally scoped to one
     ``folder``. MFS's ``hybrid_search`` already does dense + BM25 + RRF
@@ -1249,8 +1318,13 @@ def op_search(svc: StashbaseStore, args: dict) -> dict:
     for h in hits:
         if h.is_dir:
             continue
-        if extensions is not None and not h.source.lower().endswith(extensions):
-            continue
+        if extensions is not None:
+            visible_source = _visible_source_for_extension_filter(h.source)
+            if (
+                visible_source is None
+                or not visible_source.lower().endswith(extensions)
+            ):
+                continue
         out.append({
             "path": h.source,
             "chunk_index": h.chunk_index,

--- a/python/stashbase_daemon_test.py
+++ b/python/stashbase_daemon_test.py
@@ -383,6 +383,78 @@ class StashbaseDaemonTests(unittest.TestCase):
             # Filtered call over-fetches; unfiltered keeps the caller's k.
             self.assertEqual(requested, [50, 2])
 
+    def test_search_filters_legacy_derived_rows_by_visible_source_type(self) -> None:
+        hit = lambda source: types.SimpleNamespace(
+            is_dir=False, source=source, chunk_index=0, chunk_text="t",
+            start_line=1, end_line=2, content_type="text", score=1.0, metadata={},
+        )
+
+        class FakeStore:
+            def __init__(self, hits) -> None:  # noqa: ANN001
+                self.hits = hits
+
+            def is_empty(self):
+                return False
+
+            def hybrid_search(self, _qvec, _query, path_filter, top_k):  # noqa: ANN001
+                return self.hits[:top_k]
+
+        class FakeEmbedder:
+            def embed(self, texts):  # noqa: ANN001
+                return [[0.0] for _ in texts]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "paper.pdf"
+            legacy = root / ".paper.pdf.md"
+            image_source = root / "scan.png"
+            extensionless_legacy = root / ".scan.md"
+            docx_source = root / "report.docx"
+            hidden_note = root / ".report.md"
+            note = root / "note.md"
+            source.write_text("pdf", encoding="utf-8")
+            legacy.write_text("legacy derived text", encoding="utf-8")
+            image_source.write_text("image", encoding="utf-8")
+            extensionless_legacy.write_text(
+                "extensionless legacy text", encoding="utf-8",
+            )
+            docx_source.write_text("docx", encoding="utf-8")
+            hidden_note.write_text("user hidden note", encoding="utf-8")
+            note.write_text("ordinary note", encoding="utf-8")
+
+            svc = stashbase_daemon.StashbaseStore(tmp)
+            svc.stores = lambda: [(
+                None,
+                FakeEmbedder(),
+                FakeStore([
+                    hit(legacy.as_posix()),
+                    hit(extensionless_legacy.as_posix()),
+                    hit(hidden_note.as_posix()),
+                    hit(note.as_posix()),
+                ]),
+            )]
+
+            pdf = stashbase_daemon.op_search(svc, {
+                "query": "q", "top_k": 10, "extensions": [".pdf"],
+            })
+            self.assertEqual([h["path"] for h in pdf["hits"]], [legacy.as_posix()])
+
+            images = stashbase_daemon.op_search(svc, {
+                "query": "q", "top_k": 10, "extensions": [".png"],
+            })
+            self.assertEqual(
+                [h["path"] for h in images["hits"]],
+                [extensionless_legacy.as_posix()],
+            )
+
+            notes = stashbase_daemon.op_search(svc, {
+                "query": "q", "top_k": 10, "extensions": [".md"],
+            })
+            self.assertEqual(
+                [h["path"] for h in notes["hits"]],
+                [hidden_note.as_posix(), note.as_posix()],
+            )
+
     def test_search_extension_filter_normalizes_suffixes(self) -> None:
         f = stashbase_daemon._search_extension_filter
         self.assertEqual(f([".md", ".PDF"]), (".md", ".pdf"))

--- a/server/__tests__/mcp-http-transport.test.ts
+++ b/server/__tests__/mcp-http-transport.test.ts
@@ -29,10 +29,16 @@ const callRequest = {
 
 test('HTTP transport enforces the live Settings token and preserves the shared tool surface', async () => {
   let token = 'a'.repeat(64);
+  let searchInput: Record<string, unknown> | undefined;
+  let stdioSearchBody: Record<string, unknown> | undefined;
   const app = express();
   app.use(express.json());
   app.get('/api/library/info', (_req, res) => {
     res.json({ folder_home: '/tmp', folders: [] });
+  });
+  app.post('/api/library/search', (req, res) => {
+    stdioSearchBody = req.body as Record<string, unknown>;
+    res.json({ hits: [] });
   });
 
   const server = app.listen(0, '127.0.0.1');
@@ -46,7 +52,17 @@ test('HTTP transport enforces the live Settings token and preserves the shared t
   mount(app, {
     webBase: base,
     getToken: () => token,
-    operations: createLibraryOperations({ getLibraryInfo: () => ({ folder_home: '/tmp', folders: [] }) }),
+    operations: createLibraryOperations({
+      getLibraryInfo: () => ({ folder_home: '/tmp', folders: [] }),
+      retrieval: { search: async (input) => {
+        searchInput = input as unknown as Record<string, unknown>;
+        return {
+          evidence: [],
+          availability: { state: 'ready' as const },
+          truncated: false,
+        };
+      } },
+    }),
   });
 
   try {
@@ -60,14 +76,53 @@ test('HTTP transport enforces the live Settings token and preserves the shared t
     const listed = await post(base, listRequest, token);
     assert.equal(listed.status, 200);
     assert.equal(listed.body.result.tools.length, 9);
+    const searchTool = listed.body.result.tools.find((tool: any) => tool.name === 'search_library');
+    assert.deepEqual(
+      searchTool.inputSchema.properties.types.items.enum,
+      ['notes', 'pdf', 'image', 'docx', 'audio'],
+    );
 
     const called = await post(base, callRequest, token);
     assert.equal(called.status, 200);
+
+    const searched = await post(base, {
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'search_library',
+        arguments: { query: 'paper', types: ['pdf', 'docx'] },
+      },
+    }, token);
+    assert.equal(searched.status, 200);
+    assert.deepEqual(searchInput?.types, ['pdf', 'docx']);
+    assert.deepEqual(
+      JSON.parse(searched.body.result.content[0].text).types,
+      ['pdf', 'docx'],
+    );
+
+    const invalidSearch = await post(base, {
+      jsonrpc: '2.0',
+      id: 5,
+      method: 'tools/call',
+      params: {
+        name: 'search_library',
+        arguments: { query: 'paper', types: ['spreadsheet'] },
+      },
+    }, token);
+    assert.equal(invalidSearch.status, 200);
+    assert.equal(invalidSearch.body.result.isError, true);
+    assert.match(invalidSearch.body.result.content[0].text, /unknown search type/i);
 
     const stdio = await runStdio(address.port);
     assert.equal(stdio.initialized.result.serverInfo.name, 'stashbase');
     assert.deepEqual(stdio.listed.result.tools, listed.body.result.tools);
     assert.deepEqual(stdio.called.result, called.body.result);
+    assert.deepEqual(stdioSearchBody?.types, ['image']);
+    assert.deepEqual(
+      JSON.parse(stdio.searched.result.content[0].text).types,
+      ['image'],
+    );
 
     token = 'b'.repeat(64);
     assert.equal((await post(base, initRequest, 'a'.repeat(64))).status, 401);
@@ -146,7 +201,12 @@ async function waitForJsonLines(read: () => string, count: number): Promise<any[
   throw new Error(`timed out waiting for ${count} JSON lines: ${read()}`);
 }
 
-async function runStdio(port: number): Promise<{ initialized: any; listed: any; called: any }> {
+async function runStdio(port: number): Promise<{
+  initialized: any;
+  listed: any;
+  called: any;
+  searched: any;
+}> {
   const { spawn } = await import('node:child_process');
   const entry = fileURLToPath(new URL('../../mcp/server.ts', import.meta.url));
   const child = spawn(process.execPath, ['--import', 'tsx', entry, '--port', String(port)], {
@@ -160,10 +220,24 @@ async function runStdio(port: number): Promise<{ initialized: any; listed: any; 
   child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`);
   child.stdin.write(`${JSON.stringify(listRequest)}\n`);
   child.stdin.write(`${JSON.stringify(callRequest)}\n`);
+  child.stdin.write(`${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 4,
+    method: 'tools/call',
+    params: {
+      name: 'search_library',
+      arguments: { query: 'diagram', types: ['image'] },
+    },
+  })}\n`);
 
   try {
-    const lines = await waitForJsonLines(() => stdout, 3);
-    return { initialized: lines[0], listed: lines[1], called: lines[2] };
+    const lines = await waitForJsonLines(() => stdout, 4);
+    return {
+      initialized: lines[0],
+      listed: lines[1],
+      called: lines[2],
+      searched: lines[3],
+    };
   } catch (err) {
     throw new Error(`${err instanceof Error ? err.message : String(err)}\nstderr: ${stderr}`);
   } finally {

--- a/server/library-operations/index.test.ts
+++ b/server/library-operations/index.test.ts
@@ -33,6 +33,28 @@ test('Library Operations keeps search result identity at the visible source path
   );
 });
 
+test('Library Operations forwards file-type filters to Retrieval', async () => {
+  let searchInput: Record<string, unknown> | undefined;
+  const operations = createLibraryOperations({
+    getLibraryInfo: () => ({ folder_home: '/library', folders: [] }),
+    retrieval: { search: async (input) => {
+      searchInput = input as unknown as Record<string, unknown>;
+      return {
+        evidence: [],
+        availability: { state: 'ready' as const },
+        truncated: false,
+      };
+    } },
+  });
+
+  await operations.search({
+    query: 'paper',
+    types: ['pdf', 'docx'],
+  });
+
+  assert.deepEqual(searchInput?.types, ['pdf', 'docx']);
+});
+
 test('Library Operations validates mutation fields before an adapter can write', async () => {
   const operations = createLibraryOperations({
     getLibraryInfo: () => ({ folder_home: '/library', folders: [] }),

--- a/server/library-operations/index.ts
+++ b/server/library-operations/index.ts
@@ -26,6 +26,7 @@ import { createRetrieval, semanticHitsFromEvidence, type Retrieval } from '../re
 import type { IndexStatus, SearchHit } from '../indexer.ts';
 import type { SyncResult } from '../sync.ts';
 import { LibraryOperationError } from './errors.ts';
+import type { SearchTypeCategory } from '../../shared/search-types.ts';
 
 export { LibraryOperationError } from './errors.ts';
 
@@ -33,7 +34,13 @@ const log = logger('library-operations');
 
 export interface LibraryOperations {
   info(): Promise<LibraryInfo>;
-  search(input: { query: string; topK?: number; folder?: string; pathPrefix?: string }): Promise<{ hits: SearchHit[] }>;
+  search(input: {
+    query: string;
+    topK?: number;
+    folder?: string;
+    pathPrefix?: string;
+    types?: readonly SearchTypeCategory[];
+  }): Promise<{ hits: SearchHit[] }>;
   reindex(input?: { folder?: string }): Promise<unknown>;
   listDirectory(path?: unknown): Promise<unknown>;
   read(path: unknown): Promise<unknown>;
@@ -79,12 +86,17 @@ export function createLibraryOperations(
   return {
     info: async () => deps.getLibraryInfo(),
 
-    async search({ query, topK = 8, folder, pathPrefix }) {
+    async search({ query, topK = 8, folder, pathPrefix, types }) {
       const trimmedQuery = query.trim();
       if (!trimmedQuery) throw routeError('query required', 400);
       const scope = normalizeLibrarySearchScope(folder, pathPrefix);
       const result = await deps.retrieval.search({
-        mode: 'semantic', query: trimmedQuery, topK, folderRoot: scope.folderRoot, pathPrefix: scope.pathPrefix,
+        mode: 'semantic',
+        query: trimmedQuery,
+        topK,
+        folderRoot: scope.folderRoot,
+        pathPrefix: scope.pathPrefix,
+        types,
       });
       if (result.availability.state === 'unavailable') {
         throw routeError(

--- a/server/mfs-daemon.ts
+++ b/server/mfs-daemon.ts
@@ -21,7 +21,11 @@ import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from 'node:chil
 import { INDEX_EXCLUDED_DIRS, MAX_INDEXABLE_BYTES } from './indexable.ts';
 import { NOTE_EXTS } from './format.ts';
 import { EventEmitter } from 'node:events';
-import { CONVERTIBLE_SOURCE_EXTENSIONS } from '../shared/file-formats.ts';
+import {
+  CONVERTIBLE_SOURCE_EXTENSIONS,
+  LEGACY_DERIVED_SOURCE_EXTENSIONS,
+  LEGACY_EXTENSIONLESS_DERIVED_SOURCE_EXTENSIONS,
+} from '../shared/file-formats.ts';
 import { existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
@@ -251,6 +255,11 @@ class MfsDaemon extends EventEmitter {
             // them; the markdown content is pushed by the conversion path.
             ...CONVERTIBLE_SOURCE_EXTENSIONS.map((extension) => `.${extension}`),
           ],
+          note_extensions: NOTE_EXTS.map((extension) => `.${extension}`),
+          legacy_derived_source_extensions:
+            LEGACY_DERIVED_SOURCE_EXTENSIONS.map((extension) => `.${extension}`),
+          legacy_extensionless_derived_source_extensions:
+            LEGACY_EXTENSIONLESS_DERIVED_SOURCE_EXTENSIONS.map((extension) => `.${extension}`),
         }).catch((err) => log.warn(
           `set_rules failed — daemon binary may predate rule push, indexing rules can drift ` +
             `(rebuild with: pnpm build:python-sidecar): ${(err as Error).message}`,

--- a/server/pdf.ts
+++ b/server/pdf.ts
@@ -28,6 +28,10 @@ import {
 import { lowerExtractorPriority, spawnOptionsForExtractor, terminateExtractorTree } from './extractor-process.ts';
 import type { ConversionProgress } from './conversion-status.ts';
 import { logger } from './log.ts';
+import {
+  LEGACY_DERIVED_SOURCE_EXTENSIONS,
+  LEGACY_EXTENSIONLESS_DERIVED_SOURCE_EXTENSIONS,
+} from '../shared/file-formats.ts';
 
 const log = logger('pdf');
 const STDERR_TAIL_BYTES = 64 * 1024;
@@ -183,8 +187,10 @@ function originalForLegacyDerivedNote(noteRel: string, baseAbs: string): string 
   // source with the same stem exists next to them; this keeps ordinary
   // user-authored hidden notes visible unless they collide with a legacy
   // converter artifact.
-  if (/\.(pdf|png|jpe?g|webp)$/i.test(stem)) return null;
-  for (const ext of ['pdf', 'png', 'jpg', 'jpeg', 'webp']) {
+  if (LEGACY_DERIVED_SOURCE_EXTENSIONS.some(
+    (extension) => stem.toLowerCase().endsWith(`.${extension}`),
+  )) return null;
+  for (const ext of LEGACY_EXTENSIONLESS_DERIVED_SOURCE_EXTENSIONS) {
     const sourceBase = `${stem}.${ext}`;
     const source = dir === '.' ? sourceBase : `${dir}/${sourceBase}`;
     if (existsSync(path.join(baseAbs, source))) return source;

--- a/server/retrieval/index.test.ts
+++ b/server/retrieval/index.test.ts
@@ -65,6 +65,25 @@ test('Retrieval preserves semantic source identity and source-safe locators', as
   }]);
 });
 
+test('Retrieval maps source categories to semantic index extension filters', async () => {
+  let extensions: string[] | undefined;
+  const retrieval = createRetrieval({
+    hasEmbeddingKey: () => true,
+    semanticSearch: async (_query, _topK, _folderRoot, _pathPrefix, requestedExtensions) => {
+      extensions = requestedExtensions;
+      return [];
+    },
+  });
+
+  await retrieval.search({
+    mode: 'semantic',
+    query: 'evidence',
+    types: ['pdf', 'docx'],
+  });
+
+  assert.deepEqual(extensions, ['.pdf', '.docx']);
+});
+
 test('Retrieval remaps scoped semantic legacy-derived hits to their visible source', async () => {
   const folderRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-retrieval-'));
   const sourcePath = path.join(folderRoot, 'paper.pdf');

--- a/server/routes/indexing.ts
+++ b/server/routes/indexing.ts
@@ -30,7 +30,10 @@ import { clearIndexWarning, syncFolderNow } from '../state.ts';
 import { noteTreeChanged } from '../watcher.ts';
 import { sendError } from '../http.ts';
 import { filesystemPath } from '../filesystem-path.ts';
-import { isSearchTypeCategory, type SearchTypeCategory } from '../../shared/search-types.ts';
+import {
+  parseSearchTypes,
+  SEARCH_TYPES_VALIDATION_ERROR,
+} from '../../shared/search-types.ts';
 import { buildIndexStatus } from '../index-status.ts';
 import { createRetrieval, keywordFilesFromEvidence, semanticHitsFromEvidence } from '../retrieval/index.ts';
 import {
@@ -253,7 +256,7 @@ export function mount(app: express.Express): void {
       const explicit = parseFolderParam(req.body?.folder);
       const { folderRoot } = requireRequestFolder(explicit);
       const types = parseSearchTypes(req.body?.types);
-      if (types == null) return res.status(400).json({ error: 'unknown types value' });
+      if (types == null) return res.status(400).json({ error: SEARCH_TYPES_VALIDATION_ERROR });
       const prefixAbs = resolveScopePrefix(folderRoot, req.body?.path_prefix);
       if (prefixAbs === false) return res.status(400).json({ error: 'path_prefix must be a folder-relative subfolder' });
       const result = await retrieval.search({
@@ -294,7 +297,7 @@ export function mount(app: express.Express): void {
           ? req.query.types.split(',')
           : undefined,
       );
-      if (types == null) return res.status(400).json({ error: 'unknown types value' });
+      if (types == null) return res.status(400).json({ error: SEARCH_TYPES_VALIDATION_ERROR });
       const rawPrefix = typeof req.query.path_prefix === 'string' ? req.query.path_prefix : undefined;
       const prefixAbs = resolveScopePrefix(folderDir, rawPrefix);
       if (prefixAbs === false) return res.status(400).json({ error: 'path_prefix must be a folder-relative subfolder' });
@@ -382,20 +385,6 @@ export function mount(app: express.Express): void {
       sendError(res, err);
     }
   });
-}
-
-/** Validates a `types` request value into search categories. Absent →
- *  empty list (no filter); any unknown entry → null (caller 400s). */
-function parseSearchTypes(raw: unknown): SearchTypeCategory[] | null {
-  if (raw == null) return [];
-  if (!Array.isArray(raw)) return null;
-  const out: SearchTypeCategory[] = [];
-  for (const entry of raw) {
-    const value = typeof entry === 'string' ? entry.trim() : entry;
-    if (!isSearchTypeCategory(value)) return null;
-    out.push(value);
-  }
-  return out;
 }
 
 /** Resolves a folder-relative subfolder scope to an absolute directory

--- a/server/routes/library-files.test.ts
+++ b/server/routes/library-files.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import express from 'express';
+import { createLibraryOperations } from '../library-operations/index.ts';
+import { mount } from './library-files.ts';
+
+test('library search validates and forwards file-type filters', async () => {
+  let searchInput: Record<string, unknown> | undefined;
+  const operations = createLibraryOperations({
+    retrieval: { search: async (input) => {
+      searchInput = input as unknown as Record<string, unknown>;
+      return {
+        evidence: [],
+        availability: { state: 'ready' as const },
+        truncated: false,
+      };
+    } },
+  });
+  const app = express();
+  app.use(express.json());
+  mount(app, operations);
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', reject);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const url = `http://127.0.0.1:${address.port}/api/library/search`;
+
+  try {
+    const filtered = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: 'paper', types: ['pdf', 'docx'] }),
+    });
+    assert.equal(filtered.status, 200);
+    assert.deepEqual(searchInput?.types, ['pdf', 'docx']);
+
+    searchInput = undefined;
+    const invalid = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: 'paper', types: ['spreadsheet'] }),
+    });
+    assert.equal(invalid.status, 400);
+    assert.match((await invalid.json() as { error: string }).error, /unknown search type/i);
+    assert.equal(searchInput, undefined);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});

--- a/server/routes/library-files.ts
+++ b/server/routes/library-files.ts
@@ -14,6 +14,10 @@ import {
 } from '../library-file-access.ts';
 import { agentContextFile } from '../library-file-reader.ts';
 import { createLibraryOperations, type LibraryOperations } from '../library-operations/index.ts';
+import {
+  parseSearchTypes,
+  SEARCH_TYPES_VALIDATION_ERROR,
+} from '../../shared/search-types.ts';
 
 export {
   normalizeLibraryFilePath,
@@ -35,15 +39,28 @@ const log = logger('routes/library-files');
 
 
 export function mount(app: express.Express, operations: LibraryOperations = createLibraryOperations()): void {
-  // Hybrid search over the whole library (optional `folder` / `path_prefix`
-  // filter). Powers MCP's `search_library`. Hidden `.md` files are remapped or
-  // dropped (same rule as /api/search) so an external client never sees
-  // an internal path.
+  // Hybrid search over the whole library (optional `folder`, `path_prefix`,
+  // and source `types` filters). Powers MCP's `search_library`. Hidden `.md`
+  // files are remapped or dropped (same rule as /api/search) so an external
+  // client never sees an internal path.
   app.post('/api/library/search', async (req, res) => {
     try {
       const query = typeof req.body?.query === 'string' ? req.body.query : '';
       const topK = Number.isFinite(req.body?.top_k) ? Number(req.body.top_k) : 8;
-      res.json(await operations.search({ query, topK, folder: req.body?.folder, pathPrefix: req.body?.path_prefix }));
+      const types = parseSearchTypes(req.body?.types);
+      if (types == null) {
+        return res.status(400).json({
+          error: SEARCH_TYPES_VALIDATION_ERROR,
+          code: 'INVALID_SEARCH_TYPES',
+        });
+      }
+      res.json(await operations.search({
+        query,
+        topK,
+        folder: req.body?.folder,
+        pathPrefix: req.body?.path_prefix,
+        types,
+      }));
     } catch (err: unknown) {
       sendError(res, err);
     }

--- a/shared/file-formats.ts
+++ b/shared/file-formats.ts
@@ -38,6 +38,13 @@ export const LEGACY_DERIVED_SOURCE_EXTENSIONS = [
   ...DOCX_EXTENSIONS,
 ] as const;
 
+/** Older converters also emitted extension-less sibling names such as
+ * `.paper.md`, but only for PDF and image sources. */
+export const LEGACY_EXTENSIONLESS_DERIVED_SOURCE_EXTENSIONS = [
+  ...PDF_EXTENSIONS,
+  ...IMAGE_SOURCE_EXTENSIONS,
+] as const;
+
 export const VIEWABLE_FILE_EXTENSIONS = [
   ...NOTE_EXTENSIONS,
   ...CONVERTIBLE_SOURCE_EXTENSIONS,

--- a/shared/search-types.ts
+++ b/shared/search-types.ts
@@ -9,3 +9,21 @@ export type SearchTypeCategory = (typeof SEARCH_TYPE_CATEGORIES)[number];
 export function isSearchTypeCategory(value: unknown): value is SearchTypeCategory {
   return typeof value === 'string' && (SEARCH_TYPE_CATEGORIES as readonly string[]).includes(value);
 }
+
+export const SEARCH_TYPES_VALIDATION_ERROR =
+  `unknown search type; types must be an array containing only: ${SEARCH_TYPE_CATEGORIES.join(', ')}`;
+
+/** Normalizes an optional transport value into the shared search vocabulary.
+ *  Absent → empty list (no filter); malformed input or any unknown entry →
+ *  null so each transport can return its native validation error envelope. */
+export function parseSearchTypes(raw: unknown): SearchTypeCategory[] | null {
+  if (raw == null) return [];
+  if (!Array.isArray(raw)) return null;
+  const out: SearchTypeCategory[] = [];
+  for (const entry of raw) {
+    const value = typeof entry === 'string' ? entry.trim() : entry;
+    if (!isSearchTypeCategory(value)) return null;
+    if (!out.includes(value)) out.push(value);
+  }
+  return out;
+}


### PR DESCRIPTION
## What changed

- expose the shared file-type filter through Library Operations, `/api/library/search`, and both MCP transports
- validate raw values only at HTTP/MCP boundaries and keep the internal search seam strongly typed
- apply extension filtering before caller-visible `top_k`, using visible source identity for legacy derived rows
- share Node-owned extension vocabularies with the Python daemon and document the contract

## Validation

- `pnpm test:python` (23 passed)
- `pnpm test:conversion-scheduler` (101 passed)
- `pnpm test:library-files` (6 passed)
- `pnpm test:retrieval` (5 passed)
- `pnpm test:mcp` (16 passed)
- `pnpm typecheck`
- `pnpm build:mcp`
- `pnpm build:server`

Closes #84