### PR TITLE
fix(agent): normalize mention search

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ The panel is a convenient client of the same MCP server, not a separate knowledg
 - Sessions run in the current folder, next to the files they work on.
 - Tool calls and file edits can be reviewed in the app.
 - Session history stays in the Agent CLI's normal storage.
+- `@` mentions find files and folders with forgiving workspace-path search;
+  selecting one inserts only its workspace-relative path.
 
 ---
 

--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -38,7 +38,11 @@ Community contributions can land as useful first iterations, but the long-term d
 The accepted baseline includes:
 
 - per-agent chat tab selection and toggle behavior
-- keyboard navigation for `@` file and folder mentions
+- keyboard navigation for `@` file and folder mentions. Ranking normalizes
+  Unicode accents and ignores case, punctuation, whitespace, and path
+  separators; basename matches precede path-only matches, ties use a
+  locale-independent order, and raw workspace-relative paths remain the
+  stable item IDs and inserted tokens.
 - smooth chat-side resize without drag-frequency global state updates
 - compact activity grouping for non-actionable tool calls, with inspectable
   command/read/search labels rather than lifecycle-only summaries

--- a/design-docs/design/agent-panel.md
+++ b/design-docs/design/agent-panel.md
@@ -35,7 +35,9 @@ context, not a separate AI workspace.
   indexing, or MCP model.
 - Popup controls use maintained accessible primitives while the CodeMirror
   composer remains responsible for typed content and mention keystrokes. The
-  composer presents as a capped-height chat input, with ranked file and folder mentions,
+  composer presents as a capped-height chat input, with ranked file and folder
+  mentions that search workspace paths without case, punctuation, whitespace,
+  or separator sensitivity,
   image attachment thumbnails that remain visible in sent messages and restored
   history while their transient files are available, open the existing image
   preview with floating image actions and bottom-centered zoom controls, and clear

--- a/web-src/src/__tests__/agent-mention-keys.test.ts
+++ b/web-src/src/__tests__/agent-mention-keys.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mentionKeyAction } from '../components/agent/mentionKeys';
+
+test('mention keys stay owned by the composer only while suggestions are open', () => {
+  assert.equal(mentionKeyAction('ArrowDown', true), 'next');
+  assert.equal(mentionKeyAction('ArrowUp', true), 'previous');
+  assert.equal(mentionKeyAction('Enter', true), 'accept');
+  assert.equal(mentionKeyAction('Tab', true), 'accept');
+  assert.equal(mentionKeyAction('Escape', true), 'dismiss');
+
+  assert.equal(mentionKeyAction('ArrowDown', false), null);
+  assert.equal(mentionKeyAction('Enter', false), null);
+  assert.equal(mentionKeyAction('a', true), null);
+});

--- a/web-src/src/__tests__/agent-mention-ranking.test.ts
+++ b/web-src/src/__tests__/agent-mention-ranking.test.ts
@@ -13,6 +13,7 @@ const files = [
 const folders = [
   { path: 'docs' },
   { path: 'docs/archive' },
+  { path: 'social/x-posts' },
 ];
 
 test('mention ranking prioritizes exact filename and prefix matches', () => {
@@ -33,5 +34,52 @@ test('mention ranking includes matching folders with their path context', () => 
   assert.deepEqual(
     rankMentionSuggestions(files, folders, 'archive').map((suggestion) => [suggestion.path, suggestion.kind]),
     [['docs/archive', 'folder'], ['docs/archive/agent-panel.md', 'file']],
+  );
+});
+
+test('mention ranking ignores punctuation in workspace item names', () => {
+  assert.deepEqual(
+    rankMentionSuggestions(files, folders, 'xpos').map((suggestion) => suggestion.path),
+    ['social/x-posts'],
+  );
+});
+
+test('mention ranking keeps basename matches ahead of path-only matches', () => {
+  const ranked = rankMentionSuggestions(
+    [
+      { name: 'agent-guide.md', format: 'md' as const, heading: '', snippet: '' },
+      { name: 'docs/my-agent.md', format: 'md' as const, heading: '', snippet: '' },
+      { name: 'agent-notes/readme.md', format: 'md' as const, heading: '', snippet: '' },
+      { name: 'docs/agent/readme.md', format: 'md' as const, heading: '', snippet: '' },
+    ],
+    [{ path: 'agent' }],
+    'agent',
+  );
+
+  assert.deepEqual(
+    ranked.map((suggestion) => suggestion.path),
+    [
+      'agent',
+      'agent-guide.md',
+      'docs/my-agent.md',
+      'agent-notes/readme.md',
+      'docs/agent/readme.md',
+    ],
+  );
+});
+
+test('mention ranking normalizes case, separators, spaces, accents, and Unicode text consistently', () => {
+  const internationalFiles = [
+    { name: 'Docs/Résumé 2026/案例-总结.md', format: 'md' as const, heading: '', snippet: '' },
+  ];
+  const internationalFolders = [{ path: '客户/Über Café' }];
+
+  assert.deepEqual(
+    rankMentionSuggestions(internationalFiles, internationalFolders, 'resume/2026案例总结'),
+    [{ path: 'Docs/Résumé 2026/案例-总结.md', kind: 'file' }],
+  );
+  assert.deepEqual(
+    rankMentionSuggestions(internationalFiles, internationalFolders, 'ÜBER-CAFÉ'),
+    [{ path: '客户/Über Café', kind: 'folder' }],
   );
 });

--- a/web-src/src/components/agent/MentionComposer.tsx
+++ b/web-src/src/components/agent/MentionComposer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useImperativeHandle, useRef } from 'react';
 import { Compartment, EditorState, RangeSet, RangeValue, StateEffect, StateField } from '@codemirror/state';
 import { defaultKeymap, history, historyKeymap, invertedEffects } from '@codemirror/commands';
 import { Decoration, type DecorationSet, EditorView, keymap, placeholder, WidgetType } from '@codemirror/view';
+import { mentionKeyAction } from './mentionKeys';
 import { handleComposerPaste } from './clipboardAttachments';
 
 const MENTION = '\uFFFC';
@@ -228,6 +229,24 @@ export function MentionComposer({
       const view = viewRef.current;
       return view && mentionOpenRef.current ? mentionQuery(view.state) : null;
     };
+    const runMentionKey = (key: string) => {
+      const action = mentionKeyAction(key, Boolean(currentMentionQuery()));
+      if (action === 'next') {
+        onMentionNavigateRef.current(1);
+        return true;
+      }
+      if (action === 'previous') {
+        onMentionNavigateRef.current(-1);
+        return true;
+      }
+      if (action === 'accept') return onMentionAcceptRef.current();
+      if (action === 'dismiss') {
+        mentionDismissedRef.current = true;
+        onMentionDismissRef.current();
+        return true;
+      }
+      return false;
+    };
     const view = new EditorView({
       state: EditorState.create({
         extensions: [
@@ -257,24 +276,16 @@ export function MentionComposer({
           keymap.of([
             {
               key: 'ArrowDown',
-              run: () => {
-                if (!currentMentionQuery()) return false;
-                onMentionNavigateRef.current(1);
-                return true;
-              },
+              run: () => runMentionKey('ArrowDown'),
             },
             {
               key: 'ArrowUp',
-              run: () => {
-                if (!currentMentionQuery()) return false;
-                onMentionNavigateRef.current(-1);
-                return true;
-              },
+              run: () => runMentionKey('ArrowUp'),
             },
             {
               key: 'Enter',
               run: () => {
-                if (currentMentionQuery() && onMentionAcceptRef.current()) return true;
+                if (runMentionKey('Enter')) return true;
                 if (disabledRef.current) return true;
                 submit();
                 return true;
@@ -282,17 +293,12 @@ export function MentionComposer({
             },
             {
               key: 'Tab',
-              run: () => currentMentionQuery() ? onMentionAcceptRef.current() : false,
+              run: () => runMentionKey('Tab'),
             },
             { key: 'Shift-Tab', run: () => onShiftTabRef.current() },
             {
               key: 'Escape',
-              run: () => {
-                if (!currentMentionQuery()) return false;
-                mentionDismissedRef.current = true;
-                onMentionDismissRef.current();
-                return true;
-              },
+              run: () => runMentionKey('Escape'),
             },
             { key: 'Backspace', run: (view) => deleteMentionSelection(view, true) },
             { key: 'Delete', run: (view) => deleteMentionSelection(view, false) },

--- a/web-src/src/components/agent/mentionKeys.ts
+++ b/web-src/src/components/agent/mentionKeys.ts
@@ -1,0 +1,10 @@
+export type MentionKeyAction = 'next' | 'previous' | 'accept' | 'dismiss';
+
+export function mentionKeyAction(key: string, suggestionsOpen: boolean): MentionKeyAction | null {
+  if (!suggestionsOpen) return null;
+  if (key === 'ArrowDown') return 'next';
+  if (key === 'ArrowUp') return 'previous';
+  if (key === 'Enter' || key === 'Tab') return 'accept';
+  if (key === 'Escape') return 'dismiss';
+  return null;
+}

--- a/web-src/src/components/agent/mentionRanking.ts
+++ b/web-src/src/components/agent/mentionRanking.ts
@@ -9,7 +9,7 @@ export function rankMentionSuggestions(
   query: string,
   limit = 8,
 ): MentionSuggestion[] {
-  const needle = query.trim().toLowerCase();
+  const needle = normalizeMentionText(query);
   const suggestions = [
     ...files.map((file) => ({ path: file.name, kind: 'file' as const })),
     ...folders.map((folder) => ({ path: folder.path, kind: 'folder' as const })),
@@ -19,23 +19,34 @@ export function rankMentionSuggestions(
     .filter((candidate): candidate is { suggestion: MentionSuggestion; score: number } => candidate.score !== null)
     .sort((a, b) => a.score - b.score
       || baseName(a.suggestion.path).length - baseName(b.suggestion.path).length
-      || a.suggestion.path.localeCompare(b.suggestion.path))
+      || comparePaths(a.suggestion.path, b.suggestion.path))
     .slice(0, limit)
     .map((candidate) => candidate.suggestion);
 }
 
 function mentionScore(path: string, query: string): number | null {
   if (!query) return 5;
-  const fileName = baseName(path).toLowerCase();
-  const lowerPath = path.toLowerCase();
+  const fileName = normalizeMentionText(baseName(path));
+  const lowerPath = normalizeMentionText(path);
   if (fileName === query) return 0;
   if (fileName.startsWith(query)) return 1;
-  if (lowerPath.startsWith(query)) return 2;
-  if (fileName.includes(query)) return 3;
+  if (fileName.includes(query)) return 2;
+  if (lowerPath.startsWith(query)) return 3;
   if (lowerPath.includes(query)) return 4;
   return null;
 }
 
 function baseName(path: string): string {
-  return path.split('/').pop() ?? path;
+  return path.split(/[\\/]/).pop() ?? path;
+}
+
+function comparePaths(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function normalizeMentionText(value: string): string {
+  return value
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[\p{M}\p{P}\p{Z}]+/gu, '');
 }


### PR DESCRIPTION
## What changed
- normalize mention queries and workspace paths across case, punctuation, separators, spaces, accents, and Unicode marks
- rank basename exact/prefix/substring matches before path-only matches with deterministic ties
- preserve raw workspace-relative paths as stable IDs and inserted tokens, while retaining CodeMirror keyboard ownership
- add ranking and interaction regression coverage and update the design/review contracts

## Root cause
The ranker lowercased strings but still compared punctuation and separators literally, so `xpos` could not match `x-posts`; it also ranked path-prefix matches ahead of basename substring matches.

## Validation
- `pnpm test:renderer` — 92 passed
- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`

Closes #71