### PR TITLE
fix(agent): make effort picker selection reliable

### DIFF
--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -88,7 +88,9 @@ The accepted baseline includes:
   Restored Claude and Codex sessions may recreate thumbnails only for live
   transient image files through the scoped local preview route; never expose
   an arbitrary path found in a transcript. The route resolves the real target
-  under a non-symlinked private attachment root before it reads it. When a
+  under a non-symlinked private attachment root before it reads it. Effort
+  selection remains open across the session reconnect caused by a level change
+  and is dismissed only by its trigger or an outside interaction. When a
   permission action removes its own controls, restore focus to the persistent
   tool-card trigger.
 - Image-preview controls float over the image: Download and Close at the top

--- a/design-docs/design/agent-panel.md
+++ b/design-docs/design/agent-panel.md
@@ -42,6 +42,8 @@ context, not a separate AI workspace.
   history while their transient files are available, open the existing image
   preview with floating image actions and bottom-centered zoom controls, and clear
   Send/Stop states rather than editor UI.
+- Choosing an Agent effort level keeps the picker open for further adjustment;
+  the trigger or an outside interaction dismisses it.
 - The panel complements external MCP clients; it does not replace the
   bring-your-own-agent direction.
 

--- a/web-src/src/components/agent/AgentComposer.tsx
+++ b/web-src/src/components/agent/AgentComposer.tsx
@@ -83,7 +83,14 @@ function EffortBar({ effort, onSet }: { effort: EffortLevel; onSet: (l: EffortLe
         aria-label="Effort"
         selectionMode="single"
         selectedKeys={[effort]}
-        onAction={(key) => onSet(key as EffortLevel)}
+        disallowEmptySelection
+        onSelectionChange={(keys) => {
+          if (keys === 'all') return;
+          const next = keys.values().next().value;
+          if (typeof next === 'string' && next !== effort && EFFORTS.includes(next as EffortLevel)) {
+            onSet(next as EffortLevel);
+          }
+        }}
       >
         {EFFORTS.map((lv, i) => (
           <ListBoxItem
@@ -116,7 +123,7 @@ function EffortMenu({
 }) {
   const unavailable = disabled || locked;
   return (
-    <MenuTrigger isOpen={open && !unavailable} onOpenChange={onOpenChange}>
+    <MenuTrigger isOpen={open && !locked} onOpenChange={onOpenChange}>
       <Button
         className={'agent-mode-btn agent-effort-btn' + (locked ? ' is-locked' : '')}
         isDisabled={unavailable}
@@ -360,7 +367,7 @@ export function AgentComposer({
               disabled={disabled}
               locked={effortLocked}
               onOpenChange={(open) => { setEffortOpen(open); if (open) setModeOpen(false); }}
-              onSetEffort={(level) => { onSetEffort(level); setEffortOpen(false); }}
+              onSetEffort={onSetEffort}
             />
           )}
           {turnActive ? (


### PR DESCRIPTION
## Summary

- handle React Aria effort changes through `onSelectionChange` so a single dot click updates the controlled selection
- prevent an empty effort selection
- keep the effort picker open while the Agent reconnects with the new fixed effort
- dismiss the picker only through its trigger or an outside interaction
- document the Agent panel interaction contract

## Root cause

The controlled `ListBox` listened to `onAction`, but React Aria routes a single click through selection behavior. The attempted internal selection was therefore replaced by the unchanged external `selectedKeys`. The composer also explicitly closed the picker after selection and treated the reconnecting state as a reason to unmount it.

## Validation

- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`
- headless interaction check: a single click changes the effort, the picker remains open through reconnect, and trigger/outside interaction dismisses it

Closes #118
