### PR TITLE
fix(markdown): make outline navigation reliable

### DIFF
--- a/code-review/markdown-rendering.md
+++ b/code-review/markdown-rendering.md
@@ -54,8 +54,10 @@ CodeMirror Markdown editor, HTML preview, or iframe document surface.
 - Document outlines read heading nodes from the retained ProseMirror document.
   Keep live extraction and active-section tracking outside transaction-time DOM
   decoration; outline IDs must share the anchor slug allocation. Outline
-  selection from the Files sidebar scrolls Milkdown's actual document scroller
-  directly rather than using a generic ancestor-scrolling call. The sidebar
+  selection re-resolves the retained heading node against the current
+  ProseMirror document position rather than trusting a stale absolute position
+  or mutable rendered DOM ID, then scrolls Milkdown's actual document scroller
+  directly instead of using a generic ancestor-scrolling call. The sidebar
   consumes transient outline state; it must not parse or retain a second
   document model.
   Collapsing an entry filters only its deeper following heading entries and

--- a/web-src/src/__tests__/document-outline.test.ts
+++ b/web-src/src/__tests__/document-outline.test.ts
@@ -7,8 +7,8 @@ import { DocumentOutline } from '../components/DocumentOutline';
 test('outline entries are keyboard buttons with active and full-label accessibility state', () => {
   const markup = renderToStaticMarkup(createElement(DocumentOutline, {
     headings: [
-      { id: 'overview', level: 1, text: 'Overview' },
-      { id: 'section', level: 3, text: '' },
+      { id: 'overview', level: 1, text: 'Overview', position: 0 },
+      { id: 'section', level: 3, text: '', position: 1 },
     ],
     activeId: 'overview',
     onSelect: () => {},

--- a/web-src/src/__tests__/markdown-headings.test.ts
+++ b/web-src/src/__tests__/markdown-headings.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { Schema } from '@milkdown/kit/prose/model';
 import { activeHeadingId, extractDocumentHeadings, outlineDepth, outlineHasChildren, outlineScrollTop, visibleOutlineHeadings } from '../milkdown/headings';
+import { scrollOutlineToHeading, type HeadingNodeView } from '../milkdown/outlineNavigation';
 
 test('outline headings keep hierarchy and stable duplicate Unicode targets', () => {
   const nodes = [
@@ -9,33 +11,33 @@ test('outline headings keep hierarchy and stable duplicate Unicode targets', () 
     { type: { name: 'heading' }, attrs: { level: 3 }, textContent: 'Résumé' },
     { type: { name: 'heading' }, attrs: { level: 6 }, textContent: '日本語!' },
   ];
-  const doc = { descendants: (visit: (node: typeof nodes[number]) => void) => nodes.forEach(visit) };
+  const doc = { descendants: (visit: (node: typeof nodes[number], position: number) => void) => nodes.forEach((node, index) => visit(node, index * 10)) };
   assert.deepEqual(extractDocumentHeadings(doc), [
-    { id: 'resume', level: 1, text: 'Résumé' },
-    { id: 'resume-1', level: 3, text: 'Résumé' },
-    { id: '日本語', level: 6, text: '日本語!' },
+    { id: 'resume', level: 1, text: 'Résumé', position: 0 },
+    { id: 'resume-1', level: 3, text: 'Résumé', position: 20 },
+    { id: '日本語', level: 6, text: '日本語!', position: 30 },
   ]);
 });
 
 test('live heading changes, active tracking, and large documents remain predictable', () => {
-  const documentWith = (text: string) => ({ descendants: (visit: (node: { type: { name: string }; attrs: { level: number }; textContent: string }) => void) => visit({ type: { name: 'heading' }, attrs: { level: 2 }, textContent: text }) });
-  assert.deepEqual(extractDocumentHeadings(documentWith('Before')), [{ id: 'before', level: 2, text: 'Before' }]);
+  const documentWith = (text: string) => ({ descendants: (visit: (node: { type: { name: string }; attrs: { level: number }; textContent: string }, position: number) => void) => visit({ type: { name: 'heading' }, attrs: { level: 2 }, textContent: text }, 7) });
+  assert.deepEqual(extractDocumentHeadings(documentWith('Before')), [{ id: 'before', level: 2, text: 'Before', position: 7 }]);
   const updated = extractDocumentHeadings(documentWith('After'));
-  assert.deepEqual(updated, [{ id: 'after', level: 2, text: 'After' }]);
+  assert.deepEqual(updated, [{ id: 'after', level: 2, text: 'After', position: 7 }]);
   assert.equal(activeHeadingId(updated, [{ id: 'after', top: 20 }], 30), 'after');
   assert.equal(outlineScrollTop(100, 300, 180), 380);
   assert.equal(outlineScrollTop(100, 0, 20), 0);
-  const large = { descendants: (visit: (node: { type: { name: string }; attrs: { level: number }; textContent: string }) => void) => { for (let i = 0; i < 2000; i++) visit({ type: { name: 'heading' }, attrs: { level: 1 }, textContent: `Section ${i}` }); } };
+  const large = { descendants: (visit: (node: { type: { name: string }; attrs: { level: number }; textContent: string }, position: number) => void) => { for (let i = 0; i < 2000; i++) visit({ type: { name: 'heading' }, attrs: { level: 1 }, textContent: `Section ${i}` }, i); } };
   assert.equal(extractDocumentHeadings(large).length, 2000);
 });
 
 test('outline collapse hides only a heading’s descendants and supports skipped levels', () => {
   const headings = [
-    { id: 'one', level: 1, text: 'One' },
-    { id: 'two', level: 2, text: 'Two' },
-    { id: 'three', level: 3, text: 'Three' },
-    { id: 'four', level: 2, text: 'Four' },
-    { id: 'five', level: 1, text: 'Five' },
+    { id: 'one', level: 1, text: 'One', position: 0 },
+    { id: 'two', level: 2, text: 'Two', position: 1 },
+    { id: 'three', level: 3, text: 'Three', position: 2 },
+    { id: 'four', level: 2, text: 'Four', position: 3 },
+    { id: 'five', level: 1, text: 'Five', position: 4 },
   ];
   assert.equal(outlineHasChildren(headings, 0), true);
   assert.equal(outlineHasChildren(headings, 3), false);
@@ -46,9 +48,57 @@ test('outline collapse hides only a heading’s descendants and supports skipped
 
 test('outline depth follows structure when Markdown skips heading levels', () => {
   const headings = [
-    { id: 'parent', level: 2, text: 'Parent' },
-    { id: 'child', level: 4, text: 'Child' },
-    { id: 'sibling', level: 3, text: 'Sibling' },
+    { id: 'parent', level: 2, text: 'Parent', position: 0 },
+    { id: 'child', level: 4, text: 'Child', position: 1 },
+    { id: 'sibling', level: 3, text: 'Sibling', position: 2 },
   ];
   assert.deepEqual(headings.map((_heading, index) => outlineDepth(headings, index)), [0, 1, 1]);
+});
+
+test('outline selection re-resolves the current ProseMirror position when Milkdown rewrites punctuation IDs', () => {
+  const schema = new Schema({
+    nodes: {
+      doc: { content: 'block+' },
+      paragraph: { content: 'text*', group: 'block' },
+      heading: { attrs: { level: { default: 1 } }, content: 'text*', group: 'block' },
+      text: { group: 'inline' },
+    },
+  });
+  const headingText = 'P13 — 生产级挑战：多租户 / 过滤 / 冷启动 21:00–22:30 ★ 建立信任';
+  const headingNode = schema.node('heading', { level: 2 }, schema.text(headingText));
+  const selectedHeading = extractDocumentHeadings(schema.node('doc', null, [headingNode]))[0];
+  const prefix = schema.node('paragraph', null, schema.text('Inserted before the selected heading.'));
+  const currentDocument = schema.node('doc', null, [prefix, headingNode]);
+  const currentHeading = extractDocumentHeadings(currentDocument)[0];
+  assert.notEqual(currentHeading.position, selectedHeading.position);
+
+  const scrollCalls: ScrollToOptions[] = [];
+  const scroller = {
+    scrollTop: 300,
+    getBoundingClientRect: () => ({ top: 100 }),
+    scrollTo: (options: ScrollToOptions) => scrollCalls.push(options),
+  } as unknown as HTMLElement;
+  const renderedHeading = {
+    tagName: 'H2',
+    id: 'p13-—-生产级挑战：多租户-/-过滤-/-冷启动-21:00–22:30-★-建立信任',
+    getBoundingClientRect: () => ({ top: 180 }),
+  } as unknown as HTMLElement;
+  assert.notEqual(renderedHeading.id, selectedHeading.id);
+  const host = {
+    querySelector: (selector: string) => selector === '.milkdown' ? scroller : null,
+  } as unknown as HTMLElement;
+  const requestedPositions: number[] = [];
+  const view = {
+    state: { doc: currentDocument },
+    nodeDOM: (position: number) => {
+      requestedPositions.push(position);
+      return position === currentHeading.position ? renderedHeading as unknown as Node : null;
+    },
+  } satisfies HeadingNodeView;
+
+  const navigated = scrollOutlineToHeading(host, selectedHeading, view, true);
+
+  assert.equal(navigated, true);
+  assert.deepEqual(requestedPositions, [currentHeading.position]);
+  assert.deepEqual(scrollCalls, [{ top: 380, behavior: 'auto' }]);
 });

--- a/web-src/src/components/CrepeDocument.tsx
+++ b/web-src/src/components/CrepeDocument.tsx
@@ -23,7 +23,8 @@ import { applyChunkHighlight } from './previewChunkHighlight';
 import { portableImageMarkdownPath, relativeAssetPath } from '../milkdown/paths';
 import { splitLeadingYamlFrontmatter } from '../milkdown/frontmatter';
 import { resolveLocalImageUrl } from '../milkdown/imageUrls';
-import { activeHeadingId, extractDocumentHeadings, headingSlug, outlineScrollTop, type DocumentHeading } from '../milkdown/headings';
+import { activeHeadingId, extractDocumentHeadings, headingSlug, type DocumentHeading, type ProseMirrorDocument } from '../milkdown/headings';
+import { documentScroller, headingElementAtPosition, scrollOutlineToHeading, type HeadingNodeView } from '../milkdown/outlineNavigation';
 import { useDocumentOutline } from './DocumentOutlineContext';
 
 /**
@@ -50,6 +51,7 @@ export function CrepeDocument({ tabId, name, content, readOnly, active }: {
   const suppressChangeRef = useRef(false);
   const refreshHeadingsRef = useRef<() => void>(() => {});
   const frontmatterRef = useRef(splitLeadingYamlFrontmatter(content).source);
+  const headingSnapshotRef = useRef<HeadingSnapshot | null>(null);
   const [headings, setHeadings] = useState<DocumentHeading[]>([]);
   const [activeHeading, setActiveHeading] = useState<string | null>(null);
   nameRef.current = name;
@@ -60,6 +62,7 @@ export function CrepeDocument({ tabId, name, content, readOnly, active }: {
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
+    headingSnapshotRef.current = null;
     let disposed = false;
     const editor = new CrepeBuilder({ root: host, defaultValue: splitLeadingYamlFrontmatter(contentRef.current).body })
       .addFeature(placeholder, { text: 'Start writing… or type /', mode: 'block' })
@@ -84,7 +87,10 @@ export function CrepeDocument({ tabId, name, content, readOnly, active }: {
       .addFeature(codeMirror, { languages, copyText: 'Copy code' })
       .addFeature(latex);
 
-    const updateHeadings = () => setHeadings(extractDocumentHeadings(editor.editor.action((ctx) => ctx.get(editorViewCtx).state.doc)));
+    const updateHeadings = () => {
+      const view = currentEditorView(editor);
+      setHeadings(headingsForView(view, headingSnapshotRef));
+    };
     refreshHeadingsRef.current = updateHeadings;
     editor.setReadonly(readOnlyRef.current);
     editor.on((listener) => listener.markdownUpdated((_ctx, markdown, previous) => {
@@ -172,8 +178,13 @@ export function CrepeDocument({ tabId, name, content, readOnly, active }: {
     const scroller = documentScroller(host);
     const updateActive = () => {
       const threshold = scroller.getBoundingClientRect().top + 16;
-      const positions = Array.from(host.querySelectorAll<HTMLElement>('h1,h2,h3,h4,h5,h6')).map((heading, index) => ({ id: heading.id || headings[index]?.id || '', top: heading.getBoundingClientRect().top }));
-      setActiveHeading(activeHeadingId(headings, positions, threshold));
+      const view = currentEditorView(editorRef.current);
+      const currentHeadings = headingsForView(view, headingSnapshotRef);
+      const positions = currentHeadings.flatMap((heading) => {
+        const element = headingElementAtPosition(view, heading.position);
+        return element ? [{ id: heading.id, top: element.getBoundingClientRect().top }] : [];
+      });
+      setActiveHeading(activeHeadingId(currentHeadings, positions, threshold));
     };
     scroller.addEventListener('scroll', updateActive, { passive: true });
     updateActive();
@@ -184,7 +195,12 @@ export function CrepeDocument({ tabId, name, content, readOnly, active }: {
     publishOutline({
       headings,
       activeId: activeHeading,
-      onSelect: (id) => scrollOutlineToHeading(hostRef.current, id),
+      onSelect: (heading) => scrollOutlineToHeading(
+        hostRef.current,
+        heading,
+        currentEditorView(editorRef.current),
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+      ),
     });
   }, [activeHeading, headings, publishOutline]);
 
@@ -329,19 +345,17 @@ function applyHeadingIds(host: HTMLElement, entries?: DocumentHeading[]) {
   });
 }
 
-function scrollOutlineToHeading(host: HTMLElement | null, id: string) {
-  const heading = host?.querySelector<HTMLElement>(`#${CSS.escape(id)}`);
-  if (!host || !heading) return;
-  const scroller = documentScroller(host);
-  const top = outlineScrollTop(
-    scroller.getBoundingClientRect().top,
-    scroller.scrollTop,
-    heading.getBoundingClientRect().top,
-  );
-  scroller.scrollTo({ top, behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth' });
+function currentEditorView(editor: CrepeBuilder | null): HeadingNodeView | null {
+  return editor?.editor.action((ctx) => ctx.get(editorViewCtx)) ?? null;
 }
 
-/** Milkdown owns the visible document scrollbar; the shell only hosts it. */
-function documentScroller(host: HTMLElement) {
-  return host.querySelector<HTMLElement>('.milkdown') ?? host;
+type HeadingSnapshot = { doc: ProseMirrorDocument; headings: DocumentHeading[] };
+
+function headingsForView(view: HeadingNodeView | null, cache: { current: HeadingSnapshot | null }): DocumentHeading[] {
+  if (!view) return [];
+  const current = cache.current;
+  if (current?.doc === view.state.doc) return current.headings;
+  const headings = extractDocumentHeadings(view.state.doc);
+  cache.current = { doc: view.state.doc, headings };
+  return headings;
 }

--- a/web-src/src/components/DocumentOutline.tsx
+++ b/web-src/src/components/DocumentOutline.tsx
@@ -9,7 +9,7 @@ export function DocumentOutline({
 }: {
   headings: DocumentHeading[];
   activeId: string | null;
-  onSelect: (id: string) => void;
+  onSelect: (heading: DocumentHeading) => void;
 }) {
   const listRef = React.useRef<HTMLDivElement>(null);
   const [collapsed, setCollapsed] = React.useState<Set<string>>(() => new Set());
@@ -49,7 +49,7 @@ export function DocumentOutline({
             else next.add(heading.id);
             return next;
           })}><ChevronDownIcon /></button> : <span className="document-outline-disclosure-spacer" aria-hidden="true" />}
-          <button type="button" className="outline-tree-entry" title={label} aria-label={`Heading level ${heading.level}: ${label}`} aria-current={activeId === heading.id ? 'location' : undefined} onClick={() => onSelect(heading.id)}><span className="label">{label}</span></button>
+          <button type="button" className="outline-tree-entry" title={label} aria-label={`Heading level ${heading.level}: ${label}`} aria-current={activeId === heading.id ? 'location' : undefined} onClick={() => onSelect(heading)}><span className="label">{label}</span></button>
         </div>;
       })}
     </div>

--- a/web-src/src/components/DocumentOutlineContext.tsx
+++ b/web-src/src/components/DocumentOutlineContext.tsx
@@ -4,7 +4,7 @@ import type { DocumentHeading } from '../milkdown/headings';
 type DocumentOutlineModel = {
   headings: DocumentHeading[];
   activeId: string | null;
-  onSelect: (id: string) => void;
+  onSelect: (heading: DocumentHeading) => void;
 };
 
 const emptyOutline: DocumentOutlineModel = {

--- a/web-src/src/milkdown/headings.ts
+++ b/web-src/src/milkdown/headings.ts
@@ -1,6 +1,7 @@
-export type DocumentHeading = { id: string; level: number; text: string };
+export type DocumentHeading = { id: string; level: number; text: string; position: number };
 
-type ProseMirrorDocument = { descendants: (visit: (node: { type: { name: string }; attrs: { level?: number }; textContent: string }) => void) => void };
+export type ProseMirrorDocument = { descendants: (visit: (node: { type: { name: string }; attrs: { level?: number }; textContent: string }, position: number) => void) => void };
+const headingNodes = new WeakMap<DocumentHeading, object>();
 
 export function headingSlug(text: string): string {
   return text.trim().toLowerCase().normalize('NFKD')
@@ -11,15 +12,33 @@ export function headingSlug(text: string): string {
 export function extractDocumentHeadings(doc: ProseMirrorDocument): DocumentHeading[] {
   const headings: DocumentHeading[] = [];
   const used = new Map<string, number>();
-  doc.descendants((node) => {
+  doc.descendants((node, position) => {
     if (node.type.name !== 'heading') return;
     const text = node.textContent.trim();
     const base = headingSlug(text);
     const seen = used.get(base) ?? 0;
     used.set(base, seen + 1);
-    headings.push({ id: seen === 0 ? base : `${base}-${seen}`, level: Number(node.attrs.level) || 1, text });
+    const heading = { id: seen === 0 ? base : `${base}-${seen}`, level: Number(node.attrs.level) || 1, text, position };
+    headingNodes.set(heading, node);
+    headings.push(heading);
   });
   return headings;
+}
+
+/** Maps an outline entry retained across a React render to its latest
+ * ProseMirror position. Unchanged nodes keep identity across transactions. */
+export function resolveCurrentDocumentHeading(current: DocumentHeading[], selected: DocumentHeading): DocumentHeading | null {
+  const selectedNode = headingNodes.get(selected);
+  const identityMatch = selectedNode
+    ? current.find((heading) => headingNodes.get(heading) === selectedNode)
+    : undefined;
+  if (identityMatch) return identityMatch;
+  return current.find((heading) =>
+    heading.id === selected.id
+    && heading.level === selected.level
+    && heading.text === selected.text
+    && heading.position === selected.position,
+  ) ?? null;
 }
 
 /** A heading owns every following, deeper heading until the next peer or

--- a/web-src/src/milkdown/outlineNavigation.ts
+++ b/web-src/src/milkdown/outlineNavigation.ts
@@ -1,0 +1,41 @@
+import { extractDocumentHeadings, outlineScrollTop, resolveCurrentDocumentHeading, type DocumentHeading, type ProseMirrorDocument } from './headings';
+
+export type HeadingNodeView = {
+  nodeDOM: (position: number) => Node | null;
+  state: { doc: ProseMirrorDocument };
+};
+
+/** Scrolls to a retained document heading. The node resolver is supplied by
+ * the live ProseMirror view so navigation can follow editor-owned state. */
+export function scrollOutlineToHeading(
+  host: HTMLElement | null,
+  selectedHeading: DocumentHeading,
+  view: HeadingNodeView | null,
+  reducedMotion: boolean,
+): boolean {
+  if (!host || !view) return false;
+  const currentHeadings = extractDocumentHeadings(view.state.doc);
+  const heading = resolveCurrentDocumentHeading(currentHeadings, selectedHeading);
+  if (!heading) return false;
+  const headingElement = headingElementAtPosition(view, heading.position);
+  if (!headingElement) return false;
+  const scroller = documentScroller(host);
+  const top = outlineScrollTop(
+    scroller.getBoundingClientRect().top,
+    scroller.scrollTop,
+    headingElement.getBoundingClientRect().top,
+  );
+  scroller.scrollTo({ top, behavior: reducedMotion ? 'auto' : 'smooth' });
+  return true;
+}
+
+export function headingElementAtPosition(view: HeadingNodeView | null, position: number): HTMLElement | null {
+  const node = view?.nodeDOM(position) as HTMLElement | null | undefined;
+  if (!node || !/^H[1-6]$/.test(node.tagName) || typeof node.getBoundingClientRect !== 'function') return null;
+  return node;
+}
+
+/** Milkdown owns the visible document scrollbar; the shell only hosts it. */
+export function documentScroller(host: HTMLElement) {
+  return host.querySelector<HTMLElement>('.milkdown') ?? host;
+}


### PR DESCRIPTION
## Summary

- navigate document-outline selections through the current retained ProseMirror document instead of mutable Milkdown DOM IDs
- re-resolve heading positions after edits and keep active-section tracking aligned with the live editor view
- cover punctuation-heavy headings and shifted positions with a regression test
- document the resilient outline-navigation invariant

Closes #120

## Validation

- `pnpm test:renderer` — 119 passed
- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`

## Review

- Standards review: no findings
- Spec review: no findings
