### PR TITLE
feat(agent-panel): add skill discovery and invocation

### DIFF
--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -57,6 +57,10 @@ Community contributions can land as useful first iterations, but the long-term d
 - Streaming should not steal the user's scroll position. If the user has scrolled away from the bottom, show a clear jump-to-latest affordance.
 - The current document is never implicit agent context. Users attach files by drag/drop, file picker, `@` mention, or a composer-focused image paste. Image paste must reuse transient attachments, preserve accompanying text, and suppress the competing clipboard library-import offer.
 - The top-bar Claude and Codex icons select or toggle existing chats. Creating a new chat belongs to the in-panel `+`.
+- Skills are runtime-owned, folder-scoped composer choices. Keep the renderer
+  contract opaque: adapters resolve IDs to native invocation data, filter
+  disabled Codex skills, and discard stale refresh responses. Stale selected
+  skills must end the rejected turn so ordinary prompting remains recoverable.
 - Model catalogs and identifiers belong to their native runtime: use Claude's
   SDK discovery and Codex app-server `model/list`, never a shared hard-coded
   list. `undefined` means Default and must not change global CLI settings.

--- a/design-docs/design/agent-panel.md
+++ b/design-docs/design/agent-panel.md
@@ -59,6 +59,9 @@ context, not a separate AI workspace.
   while the fresh Agent session reconnects, so users can observe or refine the
   setting. The current model and effort choices remain visually prominent using
   the active application theme.
+- The composer can inspect and select a runtime-owned skill for one prompt.
+  This compact choice never installs or edits skills, and ordinary prompts
+  retain each runtime's implicit skill matching.
 - The panel complements external MCP clients; it does not replace the
   bring-your-own-agent direction.
 

--- a/server/agent-adapters.ts
+++ b/server/agent-adapters.ts
@@ -20,6 +20,7 @@ const SHARED_PANEL_CAPABILITIES = {
   modes: true,
   effort: true,
   models: true,
+  skills: true,
 } as const;
 
 export const BUILT_IN_AGENT_ADAPTERS: readonly AgentAdapter[] = [

--- a/server/agent-contract.ts
+++ b/server/agent-contract.ts
@@ -44,6 +44,16 @@ export interface AgentCapabilities {
   models: boolean;
   steering: boolean;
   titleHint: boolean;
+  skills: true;
+}
+
+/** A runtime-owned workflow surfaced by the compact composer picker. The
+ * renderer deliberately never receives native invocation details. */
+export interface AgentSkill {
+  /** Opaque runtime-scoped identity; never a filesystem path. */
+  id: string;
+  name: string;
+  description: string;
 }
 
 export interface AgentConnectionOptions {
@@ -66,7 +76,8 @@ export interface AgentModel {
 /** The stable panel wire protocol. Adapters may translate native events,
  * but they must only emit this transcript and lifecycle vocabulary. */
 export type AgentClientEvent =
-  | { t: 'prompt'; text: string; titleHint?: string }
+  | { t: 'prompt'; text: string; titleHint?: string; skill?: { id: string } }
+  | { t: 'skills-refresh' }
   | { t: 'steer'; id: string; text: string }
   | { t: 'permission-reply'; id: string; allow: boolean; always?: boolean }
   | { t: 'interrupt' }
@@ -75,6 +86,7 @@ export type AgentClientEvent =
 
 export type AgentServerEvent =
   | { t: 'ready' }
+  | { t: 'skills'; skills: AgentSkill[]; loading?: boolean; error?: string }
   | { t: 'session-id'; id: string }
   | { t: 'session-title'; title: string }
   | { t: 'models'; models: AgentModel[]; activeModel?: string; fallback?: string }

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -55,7 +55,7 @@ import { agentCliEnv, agentCliNeedsShell, commandDir, resolveAgentCli } from './
 import { ensureClaudeBridgeFile } from './agent-rules.ts';
 import { noteTreeChanged } from './watcher.ts';
 import { isAgentAccessMode, reportAgentRuntimeFailure, type AgentAccessMode } from './agent-contract.ts';
-import type { AgentClientEvent, AgentModel, AgentServerEvent } from './agent-contract.ts';
+import type { AgentClientEvent, AgentModel, AgentServerEvent, AgentSkill } from './agent-contract.ts';
 import { detectViewerFormat } from './format.ts';
 import { isAgentReadableDerivedTextReady } from './library-file-reader.ts';
 
@@ -72,6 +72,12 @@ function resolveClaudeBinary(): string | null {
 function missingClaudeMessage(): string {
   return 'Claude CLI not found. Install Claude Code or set STASHBASE_CLAUDE_BIN to the claude executable.';
 }
+
+export function claudeSkillsFromCommands(commands: Array<{ name: string; description: string }>): AgentSkill[] {
+  return commands.filter((command) => command.name.trim()).map((command) => ({ id: command.name, name: command.name, description: command.description || 'Claude Code skill' }));
+}
+
+export function claudeSkillPrompt(prompt: string, skill?: AgentSkill): string { return skill ? `/${skill.name} ${prompt}` : prompt; }
 
 /** Map the Shared Agent Contract's Access value to the native Claude SDK
  * permission mode. Keep the validation at this adapter boundary so callers
@@ -245,6 +251,9 @@ class AgentSession {
    *  client so the history dropdown can mark this session active. */
   private sessionId: string | null = null;
   private models: AgentModel[] = [];
+  private skills: AgentSkill[] = [];
+  private skillsGeneration = 0;
+  private commandsChanged = false;
 
   constructor(
     private ws: WebSocket,
@@ -349,6 +358,7 @@ class AgentSession {
     }
     await this.publishModels();
     this.send({ t: 'ready' });
+    void this.refreshSkills();
     void this.pump();
   }
 
@@ -403,6 +413,7 @@ class AgentSession {
     if (msg.type === 'system' && msg.subtype === 'init' && msg.model) {
       this.send(claudeActiveModelEvent(this.models, msg.model));
     }
+    if (msg.type === 'system' && msg.subtype === 'commands_changed') this.setSkills(msg.commands, true);
     switch (msg.type) {
       case 'stream_event': {
         // Partial deltas → typewriter streaming for text + thinking.
@@ -498,14 +509,17 @@ class AgentSession {
       case 'prompt': {
         const body = typeof msg.text === 'string' ? msg.text : '';
         if (!body.trim()) return;
+        const selected = msg.skill && typeof msg.skill.id === 'string' ? this.skills.find((skill) => skill.id === msg.skill!.id) : undefined;
+        if (msg.skill && !selected) { this.send({ t: 'error', message: 'That Claude skill is no longer available. Refresh skills and try again.' }); this.send({ t: 'turn-end', isError: true }); return; }
         this.send({ t: 'turn-start' });
         this.input.push({
           type: 'user',
-          message: { role: 'user', content: body },
+          message: { role: 'user', content: claudeSkillPrompt(body, selected) },
           parent_tool_use_id: null,
         } as SDKUserMessage);
         break;
       }
+      case 'skills-refresh': void this.refreshSkills(); break;
       case 'permission-reply': {
         const id = typeof msg.id === 'string' ? msg.id : '';
         const p = this.pending.get(id);
@@ -541,6 +555,19 @@ class AgentSession {
         this.dispose();
         break;
     }
+  }
+
+  private async refreshSkills(): Promise<void> {
+    this.send({ t: 'skills', skills: [], loading: true });
+    if (this.commandsChanged) { this.send({ t: 'skills', skills: this.skills }); return; }
+    const generation = this.skillsGeneration;
+    try { const commands = await this.q?.supportedCommands() ?? []; if (!this.commandsChanged && generation === this.skillsGeneration) this.setSkills(commands); }
+    catch (err: unknown) { if (!this.commandsChanged && generation === this.skillsGeneration) this.send({ t: 'skills', skills: [], error: `Could not load Claude skills: ${errorMessage(err)}` }); }
+  }
+
+  private setSkills(commands: Array<{ name: string; description: string }>, changed = false): void {
+    if (changed) this.commandsChanged = true;
+    this.skills = claudeSkillsFromCommands(commands); this.skillsGeneration += 1; this.send({ t: 'skills', skills: this.skills });
   }
 
   private send(obj: AgentServerEvent): void {

--- a/server/codex-session-runtime.ts
+++ b/server/codex-session-runtime.ts
@@ -13,6 +13,7 @@ import {
   reportAgentRuntimeFailure,
   type AgentAccessMode,
   type AgentModel,
+  type AgentSkill,
   type AgentClientEvent,
   type AgentServerEvent,
 } from './agent-contract.ts';
@@ -42,6 +43,9 @@ import { errorMessage, logger } from './log.ts';
 import { noteTreeChanged } from './watcher.ts';
 
 const log = logger('codex-agent');
+
+interface CodexResolvedSkill extends AgentSkill { path: string }
+function codexSkillInput(prompt: string, skill?: CodexResolvedSkill): JsonObject[] { return [{ type: 'text', text: skill ? `$${skill.name} ${prompt}` : prompt, text_elements: [] }, ...(skill ? [{ type: 'skill', name: skill.name, path: skill.path }] : [])]; }
 
 interface PendingApproval {
   requestId: JsonRpcId;
@@ -80,6 +84,10 @@ export class CodexSession {
   private selectedModel: string | undefined;
   private activeModel: string | undefined;
   private models: AgentModel[] = [];
+  private skills: CodexResolvedSkill[] = [];
+  private skillIds = new Map<string, string>();
+  private nextSkillId = 0;
+  private skillsRefreshGeneration = 0;
 
   readonly windowId: string;
 
@@ -125,6 +133,7 @@ export class CodexSession {
       if (this.resumeThreadId) await this.ensureThread();
       this.ready = true;
       this.send({ t: 'ready' });
+      void this.refreshSkills();
     } catch (err: unknown) {
       this.send({ t: 'error', message: errorMessage(err) });
       this.finish();
@@ -219,9 +228,12 @@ export class CodexSession {
         const body = typeof msg.text === 'string' ? msg.text : '';
         const titleHint = typeof msg.titleHint === 'string' ? msg.titleHint : '';
         if (!body.trim()) return;
-        void this.runTurn(body, titleHint);
+        const skill = msg.skill && typeof msg.skill.id === 'string' ? this.skills.find((candidate) => candidate.id === msg.skill!.id) : undefined;
+        if (msg.skill && !skill) { this.send({ t: 'error', message: 'That Codex skill is no longer available. Refresh skills and try again.' }); this.send({ t: 'turn-end', isError: true }); return; }
+        void this.runTurn(body, titleHint, skill);
         break;
       }
+      case 'skills-refresh': void this.refreshSkills(true); break;
       case 'steer': {
         const id = typeof msg.id === 'string' ? msg.id : '';
         const body = typeof msg.text === 'string' ? msg.text : '';
@@ -261,7 +273,7 @@ export class CodexSession {
     }
   }
 
-  private async runTurn(prompt: string, titleHint = ''): Promise<void> {
+  private async runTurn(prompt: string, titleHint = '', skill?: CodexResolvedSkill): Promise<void> {
     if (this.closed) return;
     if (!this.ready || !this.cwd) {
       this.send({ t: 'error', message: 'Codex is not ready yet.' });
@@ -286,7 +298,7 @@ export class CodexSession {
         cwd: this.cwd,
         ...codexEffortOption(this.effort),
         ...(override ? { model: override } : {}),
-        input: [{ type: 'text', text: prompt, text_elements: [] }],
+        input: codexSkillInput(prompt, skill),
       }) as Promise<JsonObject>;
       let result: JsonObject;
       try {
@@ -325,6 +337,30 @@ export class CodexSession {
         this.send({ t: 'turn-end', isError: !(err instanceof CodexTurnCancelledError) });
       }
     }
+  }
+
+  private async refreshSkills(forceReload = false): Promise<void> {
+    if (!this.cwd || this.closed) return;
+    const generation = ++this.skillsRefreshGeneration;
+    this.send({ t: 'skills', skills: [], loading: true });
+    try {
+      await this.ensureAppServer();
+      const result = await this.request('skills/list', { cwds: [this.cwd], ...(forceReload ? { forceReload: true } : {}) }) as JsonObject;
+      const rows = Array.isArray(result.data) ? result.data : [];
+      const row = rows.find((value) => value && typeof value === 'object' && stringValue((value as JsonObject).cwd) === this.cwd) as JsonObject | undefined;
+      if (this.closed || generation !== this.skillsRefreshGeneration) return;
+      this.skills = (Array.isArray(row?.skills) ? row!.skills : []).flatMap((value) => {
+        if (!value || typeof value !== 'object') return [];
+        const raw = value as JsonObject;
+        if (raw.enabled === false) return [];
+        const name = stringValue(raw.name), path = stringValue(raw.path), scope = typeof raw.scope === 'string' ? raw.scope : JSON.stringify(raw.scope ?? '');
+        if (!name || !path) return [];
+        const key = `${scope}\0${path}`;
+        let id = this.skillIds.get(key); if (!id) { id = `skill-${++this.nextSkillId}`; this.skillIds.set(key, id); }
+        return [{ id, name, path, description: stringValue(raw.description) || 'Codex skill' }];
+      });
+      this.send({ t: 'skills', skills: this.skills.map(({ id, name, description }) => ({ id, name, description })) });
+    } catch (err: unknown) { if (!this.closed && generation === this.skillsRefreshGeneration) this.send({ t: 'skills', skills: [], error: `Could not load Codex skills: ${errorMessage(err)}` }); }
   }
 
   /** `model/list` is the source of truth, including custom providers and
@@ -651,6 +687,9 @@ export class CodexSession {
         break;
       case 'turn/completed':
         this.onTurnCompleted(params);
+        break;
+      case 'skills/changed':
+        void this.refreshSkills(true);
         break;
       case 'error':
         this.onErrorNotification(params);

--- a/web-src/src/__tests__/agent-skill-menu.test.ts
+++ b/web-src/src/__tests__/agent-skill-menu.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { reconciledSkillSelection, skillMenuState } from '../components/agent/skillMenuState.ts';
+
+test('skill picker distinguishes discovery, an empty catalog, errors, and available skills', () => {
+  assert.deepEqual(skillMenuState({ loading: true, skills: [], error: null }), { kind: 'loading', message: 'Finding skills for this folder…' });
+  assert.deepEqual(skillMenuState({ loading: false, skills: [], error: null }), { kind: 'empty', message: 'No skills are available for this folder.' });
+  assert.deepEqual(skillMenuState({ loading: false, skills: [], error: 'Runtime unavailable' }), { kind: 'error', message: 'Runtime unavailable' });
+  assert.deepEqual(skillMenuState({ loading: false, skills: [{ id: 'review', name: 'review', description: 'Review code' }], error: null }), { kind: 'ready' });
+});
+
+test('skill picker clears a selection invalidated by a refreshed catalog', () => {
+  const selected = { id: 'user-review', name: 'review', description: 'Review code' };
+  assert.deepEqual(reconciledSkillSelection(selected, [selected]), selected);
+  assert.equal(reconciledSkillSelection(selected, [{ id: 'project-review', name: 'review', description: 'Project review' }]), null);
+});

--- a/web-src/src/agentCatalog.tsx
+++ b/web-src/src/agentCatalog.tsx
@@ -18,6 +18,7 @@ export interface AgentPanelCapabilities {
   models: boolean;
   steering: boolean;
   titleHint: boolean;
+  skills: true;
 }
 
 export interface AgentMeta {
@@ -38,7 +39,7 @@ export const AGENT_META: Record<AgentKind, AgentMeta> = {
     shortName: 'Claude',
     launcherLabel: 'Claude Code',
     mcpClientId: 'claude-code',
-    capabilities: { connection: true, prompts: true, interrupt: true, transcript: true, approvals: true, history: true, modes: true, effort: true, models: true, steering: false, titleHint: false },
+    capabilities: { connection: true, prompts: true, interrupt: true, transcript: true, approvals: true, history: true, modes: true, effort: true, models: true, steering: false, titleHint: false, skills: true },
     controlsNote: 'Access applies live · Effort on new session',
     Icon: ClaudeIcon,
   },
@@ -48,7 +49,7 @@ export const AGENT_META: Record<AgentKind, AgentMeta> = {
     shortName: 'Codex',
     launcherLabel: 'Codex',
     mcpClientId: 'codex-cli',
-    capabilities: { connection: true, prompts: true, interrupt: true, transcript: true, approvals: true, history: true, modes: true, effort: true, models: true, steering: true, titleHint: true },
+    capabilities: { connection: true, prompts: true, interrupt: true, transcript: true, approvals: true, history: true, modes: true, effort: true, models: true, steering: true, titleHint: true, skills: true },
     controlsNote: 'Access and effort apply on new session',
     Icon: CodexIcon,
   },

--- a/web-src/src/components/AgentView.tsx
+++ b/web-src/src/components/AgentView.tsx
@@ -25,7 +25,7 @@ import { MessageList, type QueuedTurnPreview } from './agent/AgentMessages';
 import { baseName, mergeAttachments, readImageDims } from './agent/attachments';
 import { agentConnectionUrl } from './agent/connectionUrl';
 import { applyModelEvent, modelMenuLocked, modelMenuVisible, type ModelControlState } from './agent/modelState';
-import type { Attachment, Block, EffortLevel, PermMode, ServerEvent, ToolBlock } from './agent/types';
+import type { AgentSkill, Attachment, Block, EffortLevel, PermMode, ServerEvent, ToolBlock } from './agent/types';
 
 let blockSeq = 0;
 const nextId = () => `b${++blockSeq}`;
@@ -38,6 +38,7 @@ interface QueuedPrompt {
   text: string;
   attachments: Attachment[];
   titleHint?: string;
+  skill?: AgentSkill;
   status: 'waiting' | 'steering' | 'steered';
 }
 
@@ -45,6 +46,7 @@ interface PromptToSend {
   text: string;
   attachments: Attachment[];
   titleHint?: string;
+  skill?: AgentSkill;
   appendBlock: boolean;
   clearAttachments?: boolean;
 }
@@ -118,6 +120,10 @@ export function AgentView({
   const idRef = useRef(id); idRef.current = id;
   const titleRef = useRef(title); titleRef.current = title;
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [skills, setSkills] = useState<AgentSkill[]>([]);
+  const [selectedSkill, setSelectedSkill] = useState<AgentSkill | null>(null);
+  const [skillsLoading, setSkillsLoading] = useState(true);
+  const [skillsError, setSkillsError] = useState<string | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const readyRef = useRef(false);
   const toolNamesRef = useRef<Map<string, string>>(new Map());
@@ -337,6 +343,10 @@ export function AgentView({
           return next;
         });
         break;
+      case 'skills':
+        setSkills(ev.skills); setSkillsLoading(ev.loading === true); setSkillsError(ev.error ?? null);
+        setSelectedSkill((selected) => selected && ev.skills.some((skill) => skill.id === selected.id) ? selected : null);
+        break;
       case 'session-title':
         if (isDefaultChatTitle(titleRef.current)) {
           const t = ev.title.trim();
@@ -493,15 +503,16 @@ export function AgentView({
 
   function send(text: string) {
     const atts = attachments;
+    const skill = selectedSkill ?? undefined;
     const titleHint = capabilities?.titleHint && isDefaultChatTitle(titleRef.current) ? text : undefined;
     if (turnActiveRef.current) {
       const id = nextId();
-      queuedPromptsRef.current.push({ id, text, attachments: atts, titleHint, status: 'waiting' });
+      queuedPromptsRef.current.push({ id, text, attachments: atts, titleHint, skill, status: 'waiting' });
       setQueuedTurns(queuePreview());
       setAttachments([]);
       return;
     }
-    void sendPromptNow({ text, attachments: atts, titleHint, appendBlock: true, clearAttachments: true });
+    void sendPromptNow({ text, attachments: atts, titleHint, skill, appendBlock: true, clearAttachments: true }); setSelectedSkill(null);
   }
 
   function runNextQueuedPrompt() {
@@ -541,6 +552,7 @@ export function AgentView({
     text,
     attachments: atts,
     titleHint,
+    skill,
     appendBlock,
     clearAttachments = false,
   }: PromptToSend) {
@@ -565,6 +577,7 @@ export function AgentView({
         t: 'prompt',
         text: wire,
         ...(titleHint ? { titleHint } : {}),
+        ...(skill ? { skill: { id: skill.id } } : {}),
       }));
       if (clearAttachments) clearComposerAttachments();
     } catch (err) {
@@ -900,6 +913,8 @@ export function AgentView({
         resumedSession={modelControl.resumedSession}
         supportedEfforts={supportedEfforts}
         onSetModel={changeModel}
+        skills={skills} selectedSkill={selectedSkill} skillsLoading={skillsLoading} skillsError={skillsError}
+        onPickSkill={setSelectedSkill} onClearSkill={() => setSelectedSkill(null)} onRefreshSkills={() => wsRef.current?.send(JSON.stringify({ t: 'skills-refresh' }))}
         showModeMenu={capabilities?.modes === true}
         showEffortMenu={capabilities?.effort === true}
         showModelMenu={modelMenuVisible(capabilities?.models === true, modelControl.models)}

--- a/web-src/src/components/agent/AgentComposer.tsx
+++ b/web-src/src/components/agent/AgentComposer.tsx
@@ -18,7 +18,8 @@ import { baseName } from './attachments';
 import { changedEffortSelection, effortLabel, effortMenuState, effortOptions } from './effortMenuState';
 import { MentionComposer, type MentionComposerHandle, type MentionQuery } from './MentionComposer';
 import { rankMentionSuggestions } from './mentionRanking';
-import type { AgentModel, Attachment, EffortLevel, PermMode } from './types';
+import type { AgentModel, AgentSkill, Attachment, EffortLevel, PermMode } from './types';
+import { skillMenuState } from './skillMenuState';
 import { modelMenuLabel } from './modelState';
 
 const MODES: { id: PermMode; label: string; desc: string; Icon: typeof HandIcon }[] = [
@@ -183,9 +184,14 @@ function ModelMenu({ selectedModel, activeModel, models, locked, disabled, resum
   );
 }
 
+function SkillsMenu({ skills, selected, loading, error, disabled, onPick, onClear, onRefresh }: { skills: AgentSkill[]; selected: AgentSkill | null; loading: boolean; error: string | null; disabled: boolean; onPick: (skill: AgentSkill) => void; onClear: () => void; onRefresh: () => void }) {
+  const [open, setOpen] = useState(false); const state = skillMenuState({ loading, skills, error });
+  return <MenuTrigger isOpen={open} onOpenChange={setOpen}><Button className="agent-mode-btn" isDisabled={disabled}><ClipboardListIcon className="agent-mode-icon" />{selected?.name ?? 'Skills'}<ChevronDownIcon className="agent-mode-chevron" /></Button><Popover className="agent-mode-menu" placement="top end"><div className="agent-mode-menu-head"><span>Skills</span></div>{state.kind !== 'ready' ? <div className="agent-skills-state" role="status"><span>{state.message}</span>{state.kind !== 'loading' && <Button onPress={onRefresh}>Refresh</Button>}</div> : <Menu aria-label="Available skills" onAction={(key) => { const skill = skills.find((item) => item.id === String(key)); if (skill) { onPick(skill); setOpen(false); } }}>{skills.map((skill) => <MenuItem key={skill.id} id={skill.id} className="agent-mode-opt" textValue={skill.name}><span className="agent-mode-opt-text"><span className="agent-mode-opt-title">{skill.name}</span><span className="agent-mode-opt-desc">{skill.description}</span></span>{selected?.id === skill.id && <CheckIcon className="agent-mode-opt-check" />}</MenuItem>)}</Menu>}{selected && <Button onPress={() => { onClear(); setOpen(false); }}>Clear selected skill</Button>}</Popover></MenuTrigger>;
+}
+
 export function AgentComposer({
   phase, disabled, turnActive, active, mode, onSetMode, effort, onSetEffort,
-  effortLocked, supportedEfforts, selectedModel, activeModel, models, modelLocked, modelNotice, resumedSession, onSetModel, attachments, uploading, agentShortName, showModeMenu, showEffortMenu, showModelMenu, onPickFiles, onPasteImages, onFocusChange, onRemoveAttachment, onSend, onStop,
+  effortLocked, supportedEfforts, selectedModel, activeModel, models, modelLocked, modelNotice, resumedSession, onSetModel, skills, selectedSkill, skillsLoading, skillsError, onPickSkill, onClearSkill, onRefreshSkills, attachments, uploading, agentShortName, showModeMenu, showEffortMenu, showModelMenu, onPickFiles, onPasteImages, onFocusChange, onRemoveAttachment, onSend, onStop,
 }: {
   phase: 'connecting' | 'live' | 'closed';
   disabled: boolean;
@@ -204,6 +210,7 @@ export function AgentComposer({
   modelNotice: string | null;
   resumedSession: boolean;
   onSetModel: (model?: string) => void;
+  skills: AgentSkill[]; selectedSkill: AgentSkill | null; skillsLoading: boolean; skillsError: string | null; onPickSkill: (skill: AgentSkill) => void; onClearSkill: () => void; onRefreshSkills: () => void;
   attachments: Attachment[];
   uploading: boolean;
   agentShortName: string;
@@ -424,6 +431,7 @@ export function AgentComposer({
               onSetEffort={onSetEffort}
             />
           )}
+          <SkillsMenu skills={skills} selected={selectedSkill} loading={skillsLoading} error={skillsError} disabled={disabled} onPick={onPickSkill} onClear={onClearSkill} onRefresh={onRefreshSkills} />
           {turnActive ? (
             <Button className="agent-send stop" aria-label="Stop agent" onPress={onStop}>
               <StopIcon />

--- a/web-src/src/components/agent/skillMenuState.ts
+++ b/web-src/src/components/agent/skillMenuState.ts
@@ -1,0 +1,15 @@
+import type { AgentSkill } from './types';
+
+export function skillMenuState({ loading, skills, error }: { loading: boolean; skills: AgentSkill[]; error: string | null }): {
+  kind: 'loading' | 'error' | 'empty' | 'ready';
+  message?: string;
+} {
+  if (loading) return { kind: 'loading', message: 'Finding skills for this folder…' };
+  if (error) return { kind: 'error', message: error };
+  if (!skills.length) return { kind: 'empty', message: 'No skills are available for this folder.' };
+  return { kind: 'ready' };
+}
+
+export function reconciledSkillSelection(selected: AgentSkill | null, skills: AgentSkill[]): AgentSkill | null {
+  return selected && skills.some((skill) => skill.id === selected.id) ? selected : null;
+}

--- a/web-src/src/components/agent/types.ts
+++ b/web-src/src/components/agent/types.ts
@@ -9,6 +9,7 @@ export type ToolStatus = 'running' | 'awaiting' | 'done' | 'error' | 'denied';
  * object URL while composing; restored sessions use a constrained local
  * preview URL. The agent only receives `path`, never either preview URL. */
 export interface Attachment { path: string; name: string; dims?: string; previewUrl?: string }
+export interface AgentSkill { id: string; name: string; description: string }
 
 export interface ToolBlock {
   kind: 'tool';


### PR DESCRIPTION
## Summary

Adds compact, runtime-owned skill discovery and explicit invocation to the built-in Claude Code and Codex Agent Panel tabs.

- Adds an accessible composer Skills picker with loading, empty, error, refresh, selection, and clear states.
- Keeps selections one-turn-only; ordinary prompts retain native implicit skill matching.
- Claude discovers native commands from its configured user/project/local session and invokes a selection via its native slash-command path.
- Codex uses app-server `skills/list`, refreshes on `skills/changed`, filters disabled skills, and passes the resolved native `skill` input item alongside `$skill` text.
- Uses opaque runtime-scoped IDs in the renderer contract, so duplicate skill names cannot resolve to the wrong Codex path.
- Protects recoverability: stale selections emit a terminal rejected turn, and catalogs avoid stale refresh overwrites.
- Integrates with the current runtime model/connection work without changing attachment, approval, MCP, access-mode, or transcript behavior.

## Documentation

Updates the Agent Panel design and review contracts to record native runtime ownership, opaque selection IDs, refresh/invalidation behavior, disabled-skill filtering, and stale-selection liveness.

## Validation

- `pnpm test:agent`
- `pnpm test:renderer`
- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`
- `git diff --check`