### PR TITLE
feat(agent): add available skill discovery and invocation

### DIFF
--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -122,5 +122,14 @@ The accepted baseline includes:
   titles; do not replace their semantic buttons with non-interactive artwork.
   Use clean, optically centred `+` and `−` line glyphs for zoom rather than
   ornate magnifying-glass icons; keep the floating control surfaces borderless.
+- Skills use the composer’s `/` suggestion path, not a separate workbench
+  control. The shared contract exposes only opaque selection ids and compact
+  metadata; native paths remain server-side. The inline `/skill` composer token
+  is display state and must not be serialized into the user prompt. Codex resolves a current id from
+  `skills/list`, refreshes on `skills/changed`, and sends a native skill input;
+  Claude discovers commands through its SDK and invokes the selected command
+  natively. An empty or failed discovery response remains visible from the
+  composer; retry only refreshes the catalog and never blocks normal prompts.
+  Never concatenate skill-file contents into a prompt.
 
 These are still implementation details, not a new product category. If the panel starts to feel heavier than VS Code/Codex/Claude Code side chat, the preferred follow-up is to reduce visual weight rather than add more structure.

--- a/design-docs/design/agent-panel.md
+++ b/design-docs/design/agent-panel.md
@@ -59,6 +59,13 @@ context, not a separate AI workspace.
   while the fresh Agent session reconnects, so users can observe or refine the
   setting. The current model and effort choices remain visually prominent using
   the active application theme.
+- Typing `/` in the composer opens the same compact, keyboard-accessible
+  suggestion surface used for `@` file mentions, filtered to skills available
+  to the active runtime. Selecting a skill leaves an inline `/skill` token in
+  the composer and applies it only to the next message; ordinary prompts remain
+  unchanged. An empty catalog and a discovery failure remain visible inline;
+  the latter offers a retry without blocking ordinary prompts. StashBase discovers and invokes skills but
+  never installs, edits, or otherwise manages them.
 - The panel complements external MCP clients; it does not replace the
   bring-your-own-agent direction.
 

--- a/server/__tests__/agent.test.ts
+++ b/server/__tests__/agent.test.ts
@@ -4,6 +4,8 @@ import {
   claudeActiveModelEvent,
   claudeModelCatalogFailureEvent,
   claudePermissionMode,
+  claudeSkillCatalogEvent,
+  claudeSkillPrompt,
   selectClaudeModel,
 } from '../agent.ts';
 
@@ -52,4 +54,15 @@ test('Claude catalog failure does not claim a fallback for a resumed native sess
   const event = claudeModelCatalogFailureEvent('stale-tab-model', true);
   assert.deepEqual(event.models, []);
   assert.equal(event.fallback, undefined);
+});
+
+test('Claude publishes single-slash skill labels and sends the selected native command', () => {
+  const event = claudeSkillCatalogEvent([{ name: 'release-notes', description: 'Prepare release notes', argumentHint: '<version>' }]);
+  assert.deepEqual(event, {
+    t: 'skills',
+    state: 'available',
+    skills: [{ id: 'release-notes', label: 'release-notes', description: 'Prepare release notes', argumentHint: '<version>' }],
+  });
+  assert.equal(claudeSkillPrompt('prepare the release', 'release-notes'), '/release-notes prepare the release');
+  assert.deepEqual(claudeSkillCatalogEvent([]), { t: 'skills', state: 'empty', skills: [] });
 });

--- a/server/__tests__/codex-agent.test.ts
+++ b/server/__tests__/codex-agent.test.ts
@@ -41,7 +41,7 @@ class FakeWebSocket extends EventEmitter {
 
 function catalogProcess(
   models: Array<Record<string, unknown>> = [{ id: 'native-model', displayName: 'Native model' }],
-  options: { pages?: Array<Record<string, unknown>[]>; threadModel?: string; selectedTurnError?: string } = {},
+  options: { pages?: Array<Record<string, unknown>[]>; skills?: Array<Record<string, unknown>>; skillsListError?: string; threadModel?: string; selectedTurnError?: string } = {},
 ): { proc: FakeCodexProcess; requests: Array<{ method: string; params: Record<string, unknown> }> } {
   const proc = new FakeCodexProcess();
   const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -52,10 +52,13 @@ function catalogProcess(
     requests.push({ method: request.method, params: request.params });
     const catalog = options.pages ?? [models];
     const result = request.method === 'model/list' ? { data: catalog[page] ?? [], ...(page++ < catalog.length - 1 ? { nextCursor: `page-${page}` } : {}) }
+      : request.method === 'skills/list' ? { data: [{ cwd: Array.isArray(request.params.cwds) ? request.params.cwds[0] : undefined, skills: options.skills ?? [] }] }
       : request.method === 'thread/start' ? { thread: { id: 'thread-1' }, model: options.threadModel ?? 'runtime-default' }
       : request.method === 'thread/resume' ? { thread: { id: 'thread-1' }, model: 'resumed-model' }
         : request.method === 'turn/start' ? { turn: { id: 'turn-1' } } : {};
-    if (request.method === 'turn/start' && options.selectedTurnError && request.params.model && !rejected) {
+    if (request.method === 'skills/list' && options.skillsListError) {
+      proc.stdout.write(`${JSON.stringify({ id: request.id, error: { code: -32000, message: options.skillsListError } })}\n`);
+    } else if (request.method === 'turn/start' && options.selectedTurnError && request.params.model && !rejected) {
       rejected = true;
       proc.stdout.write(`${JSON.stringify({ id: request.id, error: { code: -32000, message: options.selectedTurnError } })}\n`);
     } else {
@@ -84,7 +87,8 @@ test('Codex publishes its native model catalog before ready and forwards a selec
   assert.equal(events[0]?.t, 'models', JSON.stringify(events));
   assert.equal(events[0]?.models?.[0]?.id, 'native-model');
   assert.equal(events[0]?.activeModel, undefined, 'selection is not active until the native turn accepts it');
-  assert.equal(events[1]?.t, 'ready');
+  assert.equal(events.some((event) => event.t === 'skills'), true);
+  assert.equal(events.some((event) => event.t === 'ready'), true);
 
   ws.emit('message', JSON.stringify({ t: 'prompt', text: 'hello' }));
   await settle();
@@ -144,6 +148,59 @@ test('Codex reports the native Default model after starting a new thread', async
   assert.equal(active?.activeModel, 'runtime-default');
   assert.equal('model' in (native.requests.find((request) => request.method === 'turn/start')?.params ?? {}), false);
   session.dispose();
+});
+
+test('Codex invokes an enabled selected skill and never publishes disabled skills', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-codex-skills-'));
+  runWithWindowId('skills-window', () => setCurrentFolder(folder));
+  t.after(() => { runWithWindowId('skills-window', () => clearCurrentFolder()); fs.rmSync(folder, { recursive: true, force: true }); });
+  const ws = new FakeWebSocket();
+  const native = catalogProcess(undefined, {
+    skills: [
+      { name: 'release-notes', path: '/skills/release-notes/SKILL.md', enabled: true },
+      { name: 'disabled-skill', path: '/skills/disabled-skill/SKILL.md', enabled: false },
+    ],
+  });
+  const session = new CodexSession(ws as unknown as WebSocket, 'skills-window', undefined, undefined, undefined, undefined, undefined, () => native.proc as unknown as ChildProcessWithoutNullStreams);
+  session.begin();
+  await settle();
+
+  const skills = ws.sent.map((item) => JSON.parse(item) as { t: string; skills?: Array<{ id: string; label: string }> }).find((event) => event.t === 'skills');
+  assert.deepEqual(skills?.skills?.map((skill) => skill.label), ['release-notes']);
+  const skillId = skills?.skills?.[0]?.id;
+  assert.ok(skillId);
+  ws.emit('message', JSON.stringify({ t: 'prompt', text: 'prepare the release', skill: skillId }));
+  await settle();
+
+  assert.deepEqual(native.requests.find((request) => request.method === 'turn/start')?.params.input, [
+    { type: 'text', text: '$release-notes prepare the release', text_elements: [] },
+    { type: 'skill', name: 'release-notes', path: '/skills/release-notes/SKILL.md' },
+  ]);
+  session.dispose();
+});
+
+test('Codex reports an empty or failed skill catalog without blocking the session', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-codex-skills-'));
+  runWithWindowId('empty-skills-window', () => setCurrentFolder(folder));
+  runWithWindowId('failed-skills-window', () => setCurrentFolder(folder));
+  t.after(() => { runWithWindowId('empty-skills-window', () => clearCurrentFolder()); runWithWindowId('failed-skills-window', () => clearCurrentFolder()); fs.rmSync(folder, { recursive: true, force: true }); });
+
+  const emptyWs = new FakeWebSocket();
+  const empty = new CodexSession(emptyWs as unknown as WebSocket, 'empty-skills-window', undefined, undefined, undefined, undefined, undefined, () => catalogProcess().proc as unknown as ChildProcessWithoutNullStreams);
+  empty.begin();
+  await settle();
+  assert.equal(emptyWs.sent.map((item) => JSON.parse(item) as { t: string; state?: string }).find((event) => event.t === 'skills')?.state, 'empty');
+  assert.equal(emptyWs.sent.some((item) => (JSON.parse(item) as { t: string }).t === 'ready'), true);
+  empty.dispose();
+
+  const failedWs = new FakeWebSocket();
+  const failedNative = catalogProcess(undefined, { skillsListError: 'skills unavailable' });
+  const failed = new CodexSession(failedWs as unknown as WebSocket, 'failed-skills-window', undefined, undefined, undefined, undefined, undefined, () => failedNative.proc as unknown as ChildProcessWithoutNullStreams);
+  failed.begin();
+  await settle();
+  assert.equal(failedWs.sent.map((item) => JSON.parse(item) as { t: string; state?: string }).find((event) => event.t === 'skills')?.state, 'failed');
+  assert.equal(failedWs.sent.some((item) => (JSON.parse(item) as { t: string }).t === 'ready'), true);
+  failed.dispose();
 });
 
 test('Codex forwards a runtime-native effort identifier without remapping it', async (t) => {

--- a/server/agent-adapters.ts
+++ b/server/agent-adapters.ts
@@ -20,6 +20,7 @@ const SHARED_PANEL_CAPABILITIES = {
   modes: true,
   effort: true,
   models: true,
+  skills: true,
 } as const;
 
 export const BUILT_IN_AGENT_ADAPTERS: readonly AgentAdapter[] = [

--- a/server/agent-contract.ts
+++ b/server/agent-contract.ts
@@ -42,6 +42,7 @@ export interface AgentCapabilities {
   effort: boolean;
   /** The runtime can enumerate and select its own session models. */
   models: boolean;
+  skills: boolean;
   steering: boolean;
   titleHint: boolean;
 }
@@ -62,11 +63,13 @@ export interface AgentModel {
   description?: string;
   supportedEfforts?: string[];
 }
+export interface AgentSkill { id: string; label: string; description?: string; argumentHint?: string }
 
 /** The stable panel wire protocol. Adapters may translate native events,
  * but they must only emit this transcript and lifecycle vocabulary. */
 export type AgentClientEvent =
-  | { t: 'prompt'; text: string; titleHint?: string }
+  | { t: 'prompt'; text: string; titleHint?: string; skill?: string }
+  | { t: 'refresh-skills' }
   | { t: 'steer'; id: string; text: string }
   | { t: 'permission-reply'; id: string; allow: boolean; always?: boolean }
   | { t: 'interrupt' }
@@ -78,6 +81,7 @@ export type AgentServerEvent =
   | { t: 'session-id'; id: string }
   | { t: 'session-title'; title: string }
   | { t: 'models'; models: AgentModel[]; activeModel?: string; fallback?: string }
+  | { t: 'skills'; skills: AgentSkill[]; state: 'available' | 'empty' | 'failed'; error?: string }
   | { t: 'turn-start' }
   | { t: 'text'; delta: string }
   | { t: 'thinking'; delta: string }

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -55,9 +55,20 @@ import { agentCliEnv, agentCliNeedsShell, commandDir, resolveAgentCli } from './
 import { ensureClaudeBridgeFile } from './agent-rules.ts';
 import { noteTreeChanged } from './watcher.ts';
 import { isAgentAccessMode, reportAgentRuntimeFailure, type AgentAccessMode } from './agent-contract.ts';
-import type { AgentClientEvent, AgentModel, AgentServerEvent } from './agent-contract.ts';
+import type { AgentClientEvent, AgentModel, AgentServerEvent, AgentSkill } from './agent-contract.ts';
 import { detectViewerFormat } from './format.ts';
 import { isAgentReadableDerivedTextReady } from './library-file-reader.ts';
+
+type ClaudeSkillCommand = { name: string; description: string; argumentHint: string };
+
+export function claudeSkillCatalogEvent(commands: readonly ClaudeSkillCommand[]): Extract<AgentServerEvent, { t: 'skills' }> {
+  const skills: AgentSkill[] = commands.filter((command) => Boolean(command.name)).map((command) => ({ id: command.name, label: command.name, ...(command.description ? { description: command.description } : {}), ...(command.argumentHint ? { argumentHint: command.argumentHint } : {}) }));
+  return { t: 'skills', skills, state: skills.length ? 'available' : 'empty' };
+}
+
+export function claudeSkillPrompt(body: string, skill?: string): string {
+  return skill ? `/${skill}${body.trim() ? ` ${body}` : ''}` : body;
+}
 
 const log = logger('agent');
 
@@ -245,6 +256,7 @@ class AgentSession {
    *  client so the history dropdown can mark this session active. */
   private sessionId: string | null = null;
   private models: AgentModel[] = [];
+  private skills = new Set<string>();
 
   constructor(
     private ws: WebSocket,
@@ -348,6 +360,7 @@ class AgentSession {
       return;
     }
     await this.publishModels();
+    await this.publishSkills();
     this.send({ t: 'ready' });
     void this.pump();
   }
@@ -377,6 +390,16 @@ class AgentSession {
     }
   }
 
+  private async publishSkills(): Promise<void> {
+    if (!this.q) return;
+    try { this.publishSkillCommands(await this.q.supportedCommands()); }
+    catch { this.skills.clear(); this.send({ t: 'skills', skills: [], state: 'failed', error: 'Could not load skills. Try again.' }); }
+  }
+  private publishSkillCommands(commands: Array<{ name: string; description: string; argumentHint: string }>): void {
+    this.skills = new Set(commands.map((command) => command.name).filter(Boolean));
+    this.send(claudeSkillCatalogEvent(commands));
+  }
+
   /** Drain the SDK message stream until it ends or errors. */
   private async pump(): Promise<void> {
     if (!this.q) return;
@@ -403,6 +426,7 @@ class AgentSession {
     if (msg.type === 'system' && msg.subtype === 'init' && msg.model) {
       this.send(claudeActiveModelEvent(this.models, msg.model));
     }
+    if (msg.type === 'system' && msg.subtype === 'commands_changed') this.publishSkillCommands(msg.commands);
     switch (msg.type) {
       case 'stream_event': {
         // Partial deltas → typewriter streaming for text + thinking.
@@ -497,15 +521,18 @@ class AgentSession {
     switch (msg.t) {
       case 'prompt': {
         const body = typeof msg.text === 'string' ? msg.text : '';
-        if (!body.trim()) return;
+        const skill = typeof msg.skill === 'string' ? msg.skill : undefined;
+        if (skill && !this.skills.has(skill)) { this.send({ t: 'error', message: 'That skill is no longer available. Type / to choose another.' }); return; }
+        if (!body.trim() && !skill) return;
         this.send({ t: 'turn-start' });
         this.input.push({
           type: 'user',
-          message: { role: 'user', content: body },
+          message: { role: 'user', content: claudeSkillPrompt(body, skill) },
           parent_tool_use_id: null,
         } as SDKUserMessage);
         break;
       }
+      case 'refresh-skills': void this.publishSkills(); break;
       case 'permission-reply': {
         const id = typeof msg.id === 'string' ? msg.id : '';
         const p = this.pending.get(id);

--- a/server/codex-session-runtime.ts
+++ b/server/codex-session-runtime.ts
@@ -13,6 +13,7 @@ import {
   reportAgentRuntimeFailure,
   type AgentAccessMode,
   type AgentModel,
+  type AgentSkill,
   type AgentClientEvent,
   type AgentServerEvent,
 } from './agent-contract.ts';
@@ -80,6 +81,8 @@ export class CodexSession {
   private selectedModel: string | undefined;
   private activeModel: string | undefined;
   private models: AgentModel[] = [];
+  private skills = new Map<string, { name: string; path: string }>();
+  private skillSequence = 0;
 
   readonly windowId: string;
 
@@ -120,6 +123,7 @@ export class CodexSession {
     try {
       await this.ensureAppServer();
       await this.resolveModel();
+      await this.publishSkills();
       // Loading a historic thread is what lets the native app-server return
       // its persisted model metadata before the panel becomes interactive.
       if (this.resumeThreadId) await this.ensureThread();
@@ -218,10 +222,12 @@ export class CodexSession {
       case 'prompt': {
         const body = typeof msg.text === 'string' ? msg.text : '';
         const titleHint = typeof msg.titleHint === 'string' ? msg.titleHint : '';
-        if (!body.trim()) return;
-        void this.runTurn(body, titleHint);
+        const skill = typeof msg.skill === 'string' ? msg.skill : undefined;
+        if (!body.trim() && !skill) return;
+        void this.runTurn(body, titleHint, skill);
         break;
       }
+      case 'refresh-skills': void this.publishSkills(true); break;
       case 'steer': {
         const id = typeof msg.id === 'string' ? msg.id : '';
         const body = typeof msg.text === 'string' ? msg.text : '';
@@ -261,7 +267,7 @@ export class CodexSession {
     }
   }
 
-  private async runTurn(prompt: string, titleHint = ''): Promise<void> {
+  private async runTurn(prompt: string, titleHint = '', skillId?: string): Promise<void> {
     if (this.closed) return;
     if (!this.ready || !this.cwd) {
       this.send({ t: 'error', message: 'Codex is not ready yet.' });
@@ -277,6 +283,8 @@ export class CodexSession {
     this.interruptingTurnId = null;
     this.send({ t: 'turn-start' });
     try {
+      const skill = skillId ? this.skills.get(skillId) : undefined;
+      if (skillId && !skill) throw new Error('That skill is no longer available. Type / to choose another.');
       const model = await this.resolveModel();
       this.throwIfInterruptedBeforeTurn();
       const threadId = await this.ensureThread(titleHint);
@@ -286,7 +294,7 @@ export class CodexSession {
         cwd: this.cwd,
         ...codexEffortOption(this.effort),
         ...(override ? { model: override } : {}),
-        input: [{ type: 'text', text: prompt, text_elements: [] }],
+        input: [{ type: 'text', text: skill ? `$${skill.name}${prompt ? ` ${prompt}` : ''}` : prompt, text_elements: [] }, ...(skill ? [{ type: 'skill', name: skill.name, path: skill.path }] : [])],
       }) as Promise<JsonObject>;
       let result: JsonObject;
       try {
@@ -377,6 +385,28 @@ export class CodexSession {
       cursor = nextCursor;
     }
     return models;
+  }
+
+  private async publishSkills(forceReload = false): Promise<void> {
+    if (!this.cwd) return;
+    try {
+      const result = await this.request('skills/list', { cwds: [this.cwd], ...(forceReload ? { forceReload: true } : {}) }) as JsonObject;
+      const entries = Array.isArray(result.data) ? result.data : [];
+      const entry = entries.find((item) => stringValue((item as JsonObject).cwd) === this.cwd) as JsonObject | undefined;
+      const raw = Array.isArray(entry?.skills) ? entry.skills : [];
+      this.skills.clear();
+      const skills: AgentSkill[] = [];
+      for (const item of raw) {
+        if (!item || typeof item !== 'object') continue;
+        const value = item as JsonObject;
+        const name = stringValue(value.name), path = stringValue(value.path);
+        if (!name || !path || value.enabled === false) continue;
+        const id = `skill-${++this.skillSequence}`;
+        this.skills.set(id, { name, path });
+        skills.push({ id, label: stringValue(value.displayName) || name, ...(stringValue(value.shortDescription) || stringValue(value.description) ? { description: stringValue(value.shortDescription) || stringValue(value.description) } : {}) });
+      }
+      this.send({ t: 'skills', skills, state: skills.length ? 'available' : 'empty' });
+    } catch (err) { this.skills.clear(); this.send({ t: 'skills', skills: [], state: 'failed', error: 'Could not load skills. Try again.' }); log.debug(errorMessage(err)); }
   }
 
   private async ensureThread(titleHint = ''): Promise<string> {
@@ -613,6 +643,7 @@ export class CodexSession {
 
   private onNotification(method: string, params: JsonObject): void {
     switch (method) {
+      case 'skills/changed': void this.publishSkills(true); break;
       case 'thread/started': {
         const threadId = stringValue(params.threadId) || stringValue((params.thread as JsonObject | undefined)?.id);
         if (threadId && !this.threadId) {

--- a/web-src/src/agentCatalog.tsx
+++ b/web-src/src/agentCatalog.tsx
@@ -16,6 +16,7 @@ export interface AgentPanelCapabilities {
   modes: boolean;
   effort: boolean;
   models: boolean;
+  skills: boolean;
   steering: boolean;
   titleHint: boolean;
 }
@@ -38,7 +39,7 @@ export const AGENT_META: Record<AgentKind, AgentMeta> = {
     shortName: 'Claude',
     launcherLabel: 'Claude Code',
     mcpClientId: 'claude-code',
-    capabilities: { connection: true, prompts: true, interrupt: true, transcript: true, approvals: true, history: true, modes: true, effort: true, models: true, steering: false, titleHint: false },
+    capabilities: { connection: true, prompts: true, interrupt: true, transcript: true, approvals: true, history: true, modes: true, effort: true, models: true, skills: true, steering: false, titleHint: false },
     controlsNote: 'Access applies live · Effort on new session',
     Icon: ClaudeIcon,
   },
@@ -48,7 +49,7 @@ export const AGENT_META: Record<AgentKind, AgentMeta> = {
     shortName: 'Codex',
     launcherLabel: 'Codex',
     mcpClientId: 'codex-cli',
-    capabilities: { connection: true, prompts: true, interrupt: true, transcript: true, approvals: true, history: true, modes: true, effort: true, models: true, steering: true, titleHint: true },
+    capabilities: { connection: true, prompts: true, interrupt: true, transcript: true, approvals: true, history: true, modes: true, effort: true, models: true, skills: true, steering: true, titleHint: true },
     controlsNote: 'Access and effort apply on new session',
     Icon: CodexIcon,
   },

--- a/web-src/src/apiTypes.ts
+++ b/web-src/src/apiTypes.ts
@@ -293,6 +293,7 @@ export interface Agent {
     modes: boolean;
     effort: boolean;
     models: boolean;
+    skills: boolean;
     steering: boolean;
     titleHint: boolean;
   };

--- a/web-src/src/components/AgentView.tsx
+++ b/web-src/src/components/AgentView.tsx
@@ -25,7 +25,7 @@ import { MessageList, type QueuedTurnPreview } from './agent/AgentMessages';
 import { baseName, mergeAttachments, readImageDims } from './agent/attachments';
 import { agentConnectionUrl } from './agent/connectionUrl';
 import { applyModelEvent, modelMenuLocked, modelMenuVisible, type ModelControlState } from './agent/modelState';
-import type { Attachment, Block, EffortLevel, PermMode, ServerEvent, ToolBlock } from './agent/types';
+import type { AgentSkill, Attachment, Block, EffortLevel, PermMode, ServerEvent, ToolBlock } from './agent/types';
 
 let blockSeq = 0;
 const nextId = () => `b${++blockSeq}`;
@@ -38,6 +38,7 @@ interface QueuedPrompt {
   text: string;
   attachments: Attachment[];
   titleHint?: string;
+  skill?: string;
   status: 'waiting' | 'steering' | 'steered';
 }
 
@@ -45,6 +46,7 @@ interface PromptToSend {
   text: string;
   attachments: Attachment[];
   titleHint?: string;
+  skill?: string;
   appendBlock: boolean;
   clearAttachments?: boolean;
 }
@@ -104,6 +106,8 @@ export function AgentView({
   // User intent and runtime telemetry must stay separate: an active model
   // reached through Default must never become an explicit override later.
   const [modelControl, setModelControl] = useState<ModelControlState>({ models: [], notice: null, resumedSession: false });
+  const [skills, setSkills] = useState<AgentSkill[]>([]);
+  const [skillState, setSkillState] = useState<'available' | 'empty' | 'failed'>('empty');
   const modelControlRef = useRef(modelControl);
   // The live session's SDK id (from the `session-id` event) — lets the
   // History dropdown mark the current session active. `resumeIdRef` holds
@@ -337,6 +341,7 @@ export function AgentView({
           return next;
         });
         break;
+      case 'skills': setSkills(ev.skills); setSkillState(ev.state); break;
       case 'session-title':
         if (isDefaultChatTitle(titleRef.current)) {
           const t = ev.title.trim();
@@ -482,7 +487,7 @@ export function AgentView({
       text: p.text,
       attachments: p.attachments.length ? p.attachments : undefined,
       status: p.status,
-      canSteer: capabilities?.steering === true,
+      canSteer: capabilities?.steering === true && !p.skill,
     }));
   }
 
@@ -491,17 +496,22 @@ export function AgentView({
     setQueuedTurns(queuePreview());
   }
 
-  function send(text: string) {
+  function send(text: string, skill?: string) {
     const atts = attachments;
     const titleHint = capabilities?.titleHint && isDefaultChatTitle(titleRef.current) ? text : undefined;
     if (turnActiveRef.current) {
       const id = nextId();
-      queuedPromptsRef.current.push({ id, text, attachments: atts, titleHint, status: 'waiting' });
+      queuedPromptsRef.current.push({ id, text, attachments: atts, titleHint, skill, status: 'waiting' });
       setQueuedTurns(queuePreview());
       setAttachments([]);
       return;
     }
-    void sendPromptNow({ text, attachments: atts, titleHint, appendBlock: true, clearAttachments: true });
+    void sendPromptNow({ text, attachments: atts, titleHint, skill, appendBlock: true, clearAttachments: true });
+  }
+
+  function refreshSkills() {
+    if (phase !== 'live') return;
+    wsRef.current?.send(JSON.stringify({ t: 'refresh-skills' }));
   }
 
   function runNextQueuedPrompt() {
@@ -541,6 +551,7 @@ export function AgentView({
     text,
     attachments: atts,
     titleHint,
+    skill,
     appendBlock,
     clearAttachments = false,
   }: PromptToSend) {
@@ -565,6 +576,7 @@ export function AgentView({
         t: 'prompt',
         text: wire,
         ...(titleHint ? { titleHint } : {}),
+        ...(skill ? { skill } : {}),
       }));
       if (clearAttachments) clearComposerAttachments();
     } catch (err) {
@@ -903,6 +915,9 @@ export function AgentView({
         showModeMenu={capabilities?.modes === true}
         showEffortMenu={capabilities?.effort === true}
         showModelMenu={modelMenuVisible(capabilities?.models === true, modelControl.models)}
+        skills={skills}
+        skillState={skillState}
+        onRefreshSkills={refreshSkills}
         agentShortName={meta.shortName}
         attachments={attachments}
         uploading={uploading}

--- a/web-src/src/components/agent/AgentComposer.tsx
+++ b/web-src/src/components/agent/AgentComposer.tsx
@@ -18,7 +18,7 @@ import { baseName } from './attachments';
 import { changedEffortSelection, effortLabel, effortMenuState, effortOptions } from './effortMenuState';
 import { MentionComposer, type MentionComposerHandle, type MentionQuery } from './MentionComposer';
 import { rankMentionSuggestions } from './mentionRanking';
-import type { AgentModel, Attachment, EffortLevel, PermMode } from './types';
+import type { AgentModel, AgentSkill, Attachment, EffortLevel, PermMode } from './types';
 import { modelMenuLabel } from './modelState';
 
 const MODES: { id: PermMode; label: string; desc: string; Icon: typeof HandIcon }[] = [
@@ -185,7 +185,7 @@ function ModelMenu({ selectedModel, activeModel, models, locked, disabled, resum
 
 export function AgentComposer({
   phase, disabled, turnActive, active, mode, onSetMode, effort, onSetEffort,
-  effortLocked, supportedEfforts, selectedModel, activeModel, models, modelLocked, modelNotice, resumedSession, onSetModel, attachments, uploading, agentShortName, showModeMenu, showEffortMenu, showModelMenu, onPickFiles, onPasteImages, onFocusChange, onRemoveAttachment, onSend, onStop,
+  effortLocked, supportedEfforts, selectedModel, activeModel, models, modelLocked, modelNotice, resumedSession, onSetModel, skills, skillState, onRefreshSkills, attachments, uploading, agentShortName, showModeMenu, showEffortMenu, showModelMenu, onPickFiles, onPasteImages, onFocusChange, onRemoveAttachment, onSend, onStop,
 }: {
   phase: 'connecting' | 'live' | 'closed';
   disabled: boolean;
@@ -204,6 +204,9 @@ export function AgentComposer({
   modelNotice: string | null;
   resumedSession: boolean;
   onSetModel: (model?: string) => void;
+  skills: AgentSkill[];
+  skillState: 'available' | 'empty' | 'failed';
+  onRefreshSkills: () => void;
   attachments: Attachment[];
   uploading: boolean;
   agentShortName: string;
@@ -214,7 +217,7 @@ export function AgentComposer({
   onPasteImages: (files: File[]) => void;
   onFocusChange: (focused: boolean) => void;
   onRemoveAttachment: (path: string) => void;
-  onSend: (text: string) => void;
+  onSend: (text: string, skill?: string) => void;
   onStop: () => void;
 }) {
   const [text, setText] = useState('');
@@ -226,8 +229,9 @@ export function AgentComposer({
   const [modeOpen, setModeOpen] = useState(false);
   const [effortOpen, setEffortOpen] = useState(false);
   const [previewAttachment, setPreviewAttachment] = useState<Attachment | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<AgentSkill>();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const activeMentionRef = useRef<HTMLDivElement>(null);
+  const mentionListRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => { if (active) composerRef.current?.focus(); }, [active]);
 
@@ -241,16 +245,30 @@ export function AgentComposer({
   }
 
   const suggestions = useMemo(() => {
-    if (!mention) return [];
+    if (!mention || mention.kind !== 'mention') return [];
     return rankMentionSuggestions(state.files, state.folders, mention.q);
   }, [mention, state.files, state.folders]);
 
-  const activeSuggestionIndex = Math.min(activeMentionIndex, Math.max(suggestions.length - 1, 0));
+  const skillSuggestions = useMemo(() => mention?.kind === 'skill'
+    ? skills.filter((skill) => skill.label.toLowerCase().includes(mention.q.toLowerCase()) || (skill.description ?? '').toLowerCase().includes(mention.q.toLowerCase()))
+    : [], [mention, skills]);
+  const choices = mention?.kind === 'skill' ? skillSuggestions : suggestions;
+
+  const activeSuggestionIndex = Math.min(activeMentionIndex, Math.max(choices.length - 1, 0));
   const compatibleEfforts = effortOptions(supportedEfforts);
 
   useEffect(() => {
-    activeMentionRef.current?.scrollIntoView({ block: 'nearest' });
-  }, [activeSuggestionIndex]);
+    const frame = requestAnimationFrame(() => {
+      const list = mentionListRef.current;
+      const active = list?.querySelector<HTMLElement>('.agent-mention-item.active');
+      if (!list || !active) return;
+      // `offsetTop` is relative to the positioned popup, not necessarily this
+      // scroll container. Let the browser find the containing scrollport so a
+      // selected row never lands partly above or below the visible list.
+      active.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [activeSuggestionIndex, choices.length]);
 
   const placeholder = phase === 'connecting'
     ? 'Connecting…'
@@ -261,49 +279,51 @@ export function AgentComposer({
         : `Message ${agentShortName}…`;
 
   function pickMention(path: string) {
-    if (!mention) return;
+    if (!mention || mention.kind !== 'mention') return;
     composerRef.current?.insertMention(path, mention);
     setMention(null);
   }
-
   function submit(t: string) {
     const trimmed = t.trim();
-    if ((!trimmed && attachments.length === 0) || disabled || uploading) return false;
-    onSend(trimmed);
+    if ((!trimmed && attachments.length === 0 && !selectedSkill) || disabled || uploading) return false;
+    onSend(trimmed, selectedSkill?.id);
+    setSelectedSkill(undefined);
     setMention(null);
     return true;
   }
 
   function moveMention(direction: 1 | -1) {
-    if (!suggestions.length) return;
-    setActiveMentionIndex((index) => (index + direction + suggestions.length) % suggestions.length);
+    if (!choices.length) return;
+    setActiveMentionIndex((index) => (index + direction + choices.length) % choices.length);
   }
 
   return (
     <div className="agent-composer">
-      {mention && suggestions.length > 0 && (
+      {mention && (choices.length > 0 || mention.kind === 'skill') && (
         <div className="agent-mention">
           <div className="agent-mention-head">
-            <span>Files and folders</span>
-            <span>↑↓ navigate · Enter select · Esc dismiss</span>
+            <span>{mention.kind === 'skill' ? 'Available skills' : 'Files and folders'}</span>
+            <span>{choices.length ? '↑↓ navigate · Enter select · Esc dismiss' : 'Esc dismiss'}</span>
           </div>
-          <VisuallyHidden>
+          {choices.length > 0 && <VisuallyHidden>
             <div role="status">
-              {`${baseName(suggestions[activeSuggestionIndex].path)}, ${activeSuggestionIndex + 1} of ${suggestions.length}`}
+              {`${mention.kind === 'skill' ? (skillSuggestions[activeSuggestionIndex]?.label ?? '') : baseName(suggestions[activeSuggestionIndex].path)}, ${activeSuggestionIndex + 1} of ${choices.length}`}
             </div>
-          </VisuallyHidden>
-          <ListBox
+          </VisuallyHidden>}
+          {choices.length > 0 ? <ListBox
+            ref={mentionListRef}
             id={mentionListboxId}
             className="agent-mention-list"
-            aria-label="Matching library files and folders"
+            aria-label={mention.kind === 'skill' ? 'Matching available skills' : 'Matching library files and folders'}
             selectionMode="single"
-            selectedKeys={[suggestions[activeSuggestionIndex].path]}
-            onAction={(key) => pickMention(String(key))}
+            selectedKeys={[mention.kind === 'skill' ? skillSuggestions[activeSuggestionIndex]?.id ?? '' : suggestions[activeSuggestionIndex].path]}
+            onAction={(key) => { if (mention.kind === 'skill') { const skill = skills.find((item) => item.id === String(key)); if (skill) { setSelectedSkill(skill); composerRef.current?.insertSkill(skill.label, mention); setMention(null); } } else pickMention(String(key)); }}
           >
-            {suggestions.map((suggestion, index) => (
+            {mention.kind === 'skill' ? skillSuggestions.map((skill, index) => (
+              <ListBoxItem key={skill.id} id={skill.id} className={({ isSelected }) => 'agent-mention-item' + (isSelected ? ' active' : '')} textValue={skill.label}><FileGenericIcon className="agent-mention-icon" /><span className="agent-mention-text"><span className="agent-mention-name">{skill.label}</span>{skill.description && <span className="agent-mention-path">{skill.description}</span>}</span></ListBoxItem>
+            )) : suggestions.map((suggestion, index) => (
               <ListBoxItem
                 key={suggestion.path}
-                ref={index === activeSuggestionIndex ? activeMentionRef : null}
                 id={suggestion.path}
                 className={({ isSelected }) => 'agent-mention-item' + (isSelected ? ' active' : '')}
                 textValue={suggestion.path}
@@ -317,7 +337,11 @@ export function AgentComposer({
                 </span>
               </ListBoxItem>
             ))}
-          </ListBox>
+          </ListBox> : (
+            <div className="agent-mention-empty" role="status">
+              {skillState === 'failed' ? <><span>Could not load skills.</span><Button className="agent-mention-retry" onPress={onRefreshSkills}>Retry</Button></> : <span>No skills are available for this folder.</span>}
+            </div>
+          )}
         </div>
       )}
       <div className="agent-composer-box">
@@ -366,12 +390,15 @@ export function AgentComposer({
             setActiveMentionIndex(0);
           }}
           onMentionNavigate={moveMention}
-          onMentionAccept={() => {
-            if (!suggestions.length) return false;
+            onMentionAccept={() => {
+            if (!mention) return false;
+            if (!choices.length) return mention.kind === 'skill';
+            if (mention.kind === 'skill') { const skill = skillSuggestions[activeSuggestionIndex]; if (!skill) return false; setSelectedSkill(skill); composerRef.current?.insertSkill(skill.label, mention); setMention(null); return true; }
             pickMention(suggestions[activeSuggestionIndex].path);
             return true;
           }}
-          onMentionDismiss={() => setMention(null)}
+            onMentionDismiss={() => setMention(null)}
+          onSkillMarkerRemoved={() => setSelectedSkill(undefined)}
           onShiftTab={() => {
             if (!showModeMenu || disabled) return false;
             cycleMode();
@@ -380,8 +407,8 @@ export function AgentComposer({
           onSubmit={submit}
           onPasteImages={onPasteImages}
           onFocusChange={onFocusChange}
-          mentionOpen={Boolean(mention && suggestions.length)}
-          mentionListboxId={mention && suggestions.length ? mentionListboxId : undefined}
+          mentionOpen={Boolean(mention && (choices.length > 0 || mention.kind === 'skill'))}
+          mentionListboxId={mention && choices.length ? mentionListboxId : undefined}
         />
         <input
           ref={fileInputRef}
@@ -432,7 +459,7 @@ export function AgentComposer({
             <Button
               className="agent-send"
               aria-label="Send message"
-              isDisabled={disabled || uploading || (!text.trim() && attachments.length === 0)}
+              isDisabled={disabled || uploading || (!text.trim() && attachments.length === 0 && !selectedSkill)}
               onPress={() => composerRef.current?.submit()}
             >
               <ArrowUpIcon />

--- a/web-src/src/components/agent/MentionComposer.tsx
+++ b/web-src/src/components/agent/MentionComposer.tsx
@@ -7,11 +7,13 @@ import { handleComposerPaste } from './clipboardAttachments';
 
 const MENTION = '\uFFFC';
 
-export type MentionQuery = { q: string; from: number } | null;
+export type MentionQuery = { kind: 'mention' | 'skill'; q: string; from: number } | null;
 
 export type MentionComposerHandle = {
   focus: () => void;
   insertMention: (path: string, query: Exclude<MentionQuery, null>) => void;
+  insertSkill: (label: string, query: Exclude<MentionQuery, null>) => void;
+  clearQuery: (query: Exclude<MentionQuery, null>) => void;
   submit: () => void;
 };
 
@@ -20,37 +22,37 @@ class Mention extends RangeValue {
   // Otherwise RangeSet mapping expands the range and keepMentionMarkers removes it.
   endSide = -1;
 
-  constructor(readonly path: string) { super(); }
+  constructor(readonly path: string, readonly kind: 'file' | 'skill' = 'file') { super(); }
 
   eq(other: Mention) {
-    return this.path === other.path;
+    return this.path === other.path && this.kind === other.kind;
   }
 }
 
 class MentionWidget extends WidgetType {
-  constructor(private readonly path: string) { super(); }
+  constructor(private readonly path: string, private readonly kind: 'file' | 'skill') { super(); }
 
   eq(other: MentionWidget) {
-    return this.path === other.path;
+    return this.path === other.path && this.kind === other.kind;
   }
 
   toDOM() {
     const token = document.createElement('span');
-    token.className = 'agent-file-mention';
-    token.textContent = this.path.split('/').pop() ?? this.path;
+    token.className = this.kind === 'skill' ? 'agent-skill-mention' : 'agent-file-mention';
+    token.textContent = this.kind === 'skill' ? `/${this.path}` : this.path.split('/').pop() ?? this.path;
     token.title = this.path;
-    token.setAttribute('aria-label', `File mention: ${this.path}`);
+    token.setAttribute('aria-label', this.kind === 'skill' ? `Selected skill: ${this.path}` : `File mention: ${this.path}`);
     return token;
   }
 }
 
 type MentionState = { mentions: RangeSet<Mention>; decorations: DecorationSet };
 
-const addMention = StateEffect.define<{ from: number; path: string }>({
+const addMention = StateEffect.define<{ from: number; path: string; kind?: 'file' | 'skill' }>({
   map: (value, changes) => ({ ...value, from: changes.mapPos(value.from, -1) }),
 });
 
-const removeMention = StateEffect.define<{ from: number; path: string }>({
+const removeMention = StateEffect.define<{ from: number; path: string; kind?: 'file' | 'skill' }>({
   map: (value, changes) => ({ ...value, from: changes.mapPos(value.from, -1) }),
 });
 
@@ -61,12 +63,12 @@ const mentionField = StateField.define<MentionState>({
     for (const effect of transaction.effects) {
       if (effect.is(addMention)) {
         mentions = mentions.update({
-          add: [new Mention(effect.value.path).range(effect.value.from, effect.value.from + MENTION.length)],
+          add: [new Mention(effect.value.path, effect.value.kind).range(effect.value.from, effect.value.from + MENTION.length)],
           sort: true,
         });
       } else if (effect.is(removeMention)) {
         mentions = mentions.update({
-          filter: (from, _to, mention) => from !== effect.value.from || mention.path !== effect.value.path,
+          filter: (from, _to, mention) => from !== effect.value.from || mention.path !== effect.value.path || mention.kind !== effect.value.kind,
         });
       }
     }
@@ -81,7 +83,7 @@ const mentionField = StateField.define<MentionState>({
 function buildMentionState(mentions: RangeSet<Mention>): MentionState {
   const decorations: ReturnType<Decoration['range']>[] = [];
   mentions.between(0, Infinity, (from, to, mention) => {
-    decorations.push(Decoration.replace({ widget: new MentionWidget(mention.path) }).range(from, to));
+    decorations.push(Decoration.replace({ widget: new MentionWidget(mention.path, mention.kind) }).range(from, to));
   });
   return { mentions, decorations: Decoration.set(decorations, true) };
 }
@@ -99,7 +101,7 @@ function serialize(state: EditorState) {
   let cursor = 0;
   let text = '';
   mentions.between(0, state.doc.length, (from, to, mention) => {
-    text += state.doc.sliceString(cursor, from) + `@${mention.path}`;
+    text += state.doc.sliceString(cursor, from) + (mention.kind === 'skill' ? '' : `@${mention.path}`);
     cursor = to;
   });
   return text + state.doc.sliceString(cursor);
@@ -109,8 +111,8 @@ function mentionQuery(state: EditorState): MentionQuery {
   const selection = state.selection.main;
   if (!selection.empty) return null;
   const before = state.doc.sliceString(0, selection.head);
-  const match = /(^|\s)@([^\s@]*)$/.exec(before);
-  return match ? { q: match[2], from: selection.head - match[2].length } : null;
+  const match = /(^|\s)([@/])([^\s@/]*)$/.exec(before);
+  return match ? { kind: match[2] === '/' ? 'skill' : 'mention', q: match[3], from: selection.head - match[3].length } : null;
 }
 
 function deleteMentionSelection(view: EditorView, backward: boolean) {
@@ -131,9 +133,9 @@ function deleteMentionSelection(view: EditorView, backward: boolean) {
     to = target.to;
   }
 
-  const removed: StateEffect<{ from: number; path: string }>[] = [];
+  const removed: StateEffect<{ from: number; path: string; kind?: 'file' | 'skill' }>[] = [];
   mentions.between(from, to, (mentionFrom, mentionTo, mention) => {
-    if (mentionFrom < to && mentionTo > from) removed.push(removeMention.of({ from: mentionFrom, path: mention.path }));
+    if (mentionFrom < to && mentionTo > from) removed.push(removeMention.of({ from: mentionFrom, path: mention.path, kind: mention.kind }));
   });
   if (!removed.length) return false;
   view.dispatch({ changes: { from, to }, effects: removed });
@@ -152,6 +154,7 @@ export function MentionComposer({
   onSubmit,
   onPasteImages,
   onFocusChange,
+  onSkillMarkerRemoved,
   mentionListboxId,
   mentionOpen,
   ref,
@@ -167,6 +170,7 @@ export function MentionComposer({
   onSubmit: (text: string) => boolean;
   onPasteImages: (files: File[]) => void;
   onFocusChange: (focused: boolean) => void;
+  onSkillMarkerRemoved: () => void;
   mentionListboxId?: string;
   mentionOpen: boolean;
   ref: React.Ref<MentionComposerHandle>;
@@ -183,6 +187,7 @@ export function MentionComposer({
   const onSubmitRef = useRef(onSubmit);
   const onPasteImagesRef = useRef(onPasteImages);
   const onFocusChangeRef = useRef(onFocusChange);
+  const onSkillMarkerRemovedRef = useRef(onSkillMarkerRemoved);
   const mentionOpenRef = useRef(mentionOpen);
   const mentionDismissedRef = useRef(false);
   const editableCompartmentRef = useRef(new Compartment());
@@ -198,6 +203,7 @@ export function MentionComposer({
   onSubmitRef.current = onSubmit;
   onPasteImagesRef.current = onPasteImages;
   onFocusChangeRef.current = onFocusChange;
+  onSkillMarkerRemovedRef.current = onSkillMarkerRemoved;
   mentionOpenRef.current = mentionOpen;
 
   function submit() {
@@ -217,6 +223,23 @@ export function MentionComposer({
         effects: addMention.of({ from, path }),
         selection: { anchor: from + MENTION.length + 1 },
       });
+      view.focus();
+    },
+    insertSkill: (label, query) => {
+      const view = viewRef.current;
+      if (!view) return;
+      const from = query.from - 1;
+      view.dispatch({
+        changes: { from, to: view.state.selection.main.head, insert: MENTION + ' ' },
+        effects: addMention.of({ from, path: label, kind: 'skill' }),
+        selection: { anchor: from + MENTION.length + 1 },
+      });
+      view.focus();
+    },
+    clearQuery: (query) => {
+      const view = viewRef.current;
+      if (!view) return;
+      view.dispatch({ changes: { from: query.from - 1, to: view.state.selection.main.head }, selection: { anchor: query.from - 1 } });
       view.focus();
     },
     submit,
@@ -309,6 +332,11 @@ export function MentionComposer({
             if (update.docChanged) {
               mentionDismissedRef.current = false;
               onChangeRef.current(serialize(update.state));
+              let hasSkillMarker = false;
+              update.state.field(mentionField).mentions.between(0, update.state.doc.length, (_from, _to, marker) => {
+                if (marker.kind === 'skill') hasSkillMarker = true;
+              });
+              if (!hasSkillMarker) onSkillMarkerRemovedRef.current();
             }
             if (update.docChanged || update.selectionSet) {
               onMentionChangeRef.current(mentionDismissedRef.current ? null : mentionQuery(update.state));

--- a/web-src/src/components/agent/types.ts
+++ b/web-src/src/components/agent/types.ts
@@ -32,5 +32,5 @@ export type Block =
 export type ServerEvent = AgentServerEvent;
 
 export type AgentKind = 'claude' | 'codex';
-export type { AgentModel } from '../../../../server/agent-contract.ts';
+export type { AgentModel, AgentSkill } from '../../../../server/agent-contract.ts';
 import type { AgentServerEvent } from '../../../../server/agent-contract.ts';

--- a/web-src/src/styles/chat.css
+++ b/web-src/src/styles/chat.css
@@ -1134,6 +1134,16 @@
       vertical-align: baseline;
       white-space: nowrap;
     }
+    .agent-skill-mention {
+      display: inline-block;
+      padding: 0 4px;
+      border-radius: 4px;
+      background: var(--active);
+      color: var(--fg);
+      line-height: inherit;
+      vertical-align: baseline;
+      white-space: nowrap;
+    }
     /* Action bar under the textarea: + … mode / send.
      * A full-width rule separates it from the input — the negative side
      * margins bleed past the box's 8px padding so the line spans edge to
@@ -1348,7 +1358,14 @@
       padding: 4px;
       z-index: 30;
     }
-    .agent-mention-list { max-height: 210px; overflow-y: auto; }
+    /* The header and list must fit in the same 220px popup.  Giving the list
+       its own 210px maximum used to create a hidden lower portion: keyboard
+       navigation scrolled a row into the list's viewport, but not the popup's
+       visible viewport. */
+    .agent-mention-list { max-height: 182px; overflow-y: auto; scroll-padding-block: 4px; }
+    .agent-mention-empty { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px; color: var(--muted); font-size: calc(12px * var(--ui-scale)); }
+    .agent-mention-retry { border: 0; border-radius: 4px; background: var(--active); color: var(--fg); padding: 3px 7px; font: inherit; cursor: pointer; }
+    .agent-mention-retry:focus-visible { outline: 2px solid var(--focus); outline-offset: 1px; }
     .agent-mention-head { display: flex; justify-content: space-between; gap: 8px; padding: 4px 8px 6px; color: var(--muted); font-size: calc(10.5px * var(--ui-scale)); }
     .agent-mention-head > span:first-child { color: var(--fg); font-weight: 600; }
     .agent-mention-item {
@@ -1368,4 +1385,4 @@
     .agent-mention-icon { flex: 0 0 auto; width: 14px; height: 14px; margin-top: 2px; color: var(--muted); }
     .agent-mention-text { display: flex; flex: 1; min-width: 0; flex-direction: column; }
     .agent-mention-name { font-size: calc(12.5px * var(--ui-scale)); color: var(--fg); }
-    .agent-mention-path { font-size: calc(11px * var(--ui-scale)); color: var(--muted); }
+    .agent-mention-path { font-size: calc(11px * var(--ui-scale)); color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
## Summary

- surface each runtime’s available skills through the existing compact composer suggestion path
- invoke selected Claude commands and Codex skills through their native runtime protocols
- keep disabled Codex skills out of the catalog, refresh on runtime invalidation, and provide inline empty/error/retry states
- add Agent Panel contracts and focused regression coverage for catalog and invocation behavior

## Why

The built-in Agent Panel preserved each CLI’s configuration but did not expose or deterministically invoke available skills. This made workflow skills difficult to discover and unreliable to select from the panel.

## User impact

In either Agent tab, typing `/` opens a keyboard-accessible list of skills available for the current folder. A selected skill is visibly attached to the next message and can be removed; normal prompts and implicit runtime skill matching continue unchanged. Empty catalogs and discovery failures remain recoverable without blocking chat.

## Documentation

Updated the Agent Panel design guide and maintainer review contract with the compact composer boundary, native-runtime invocation rules, and catalog recovery behavior.

## Validation

- `git diff --check`
- `pnpm test:agent` (33 passing)
- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`

Closes #82