### PR TITLE
fix(agent-panel): show one error for a failed terminal event (Fixes #130)

### DIFF
--- a/web-src/src/components/AgentView.tsx
+++ b/web-src/src/components/AgentView.tsx
@@ -128,6 +128,7 @@ export function AgentView({
   // Which streaming block kind is currently "open" (so consecutive text
   // deltas append to one bubble; a tool call closes it).
   const openKind = useRef<'assistant' | 'thinking' | null>(null);
+  const turnErrorExplainedRef = useRef(false);
   const knownFilePaths = useMemo(() => new Set(state.files.map((f) => f.name)), [state.files]);
 
   useEffect(() => {
@@ -350,6 +351,7 @@ export function AgentView({
         break;
       case 'turn-start':
         openKind.current = null;
+        turnErrorExplainedRef.current = false;
         setTurnBusy(true);
         break;
       case 'text':
@@ -439,6 +441,9 @@ export function AgentView({
             });
         }
         runNextQueuedPrompt();
+        if (ev.isError && !turnErrorExplainedRef.current) {
+          setBlocks((bs) => [...bs, { kind: 'error', id: nextId(), text: 'The Agent turn failed before returning a response.' }]);
+        }
         break;
       case 'error':
         openKind.current = null;
@@ -456,6 +461,7 @@ export function AgentView({
           setFatal(ev.message);
           setPhase('closed');
         } else {
+          turnErrorExplainedRef.current = true;
           setBlocks((bs) => [...bs, { kind: 'error', id: nextId(), text: ev.message }]);
         }
         break;


### PR DESCRIPTION
## Summary

When the Agent panel receives `{ t: "turn-end", isError: true }` without a preceding `error` event, the working state cleared but no error was shown — the user saw their prompt vanish silently.

This PR adds a per-turn error-explained guard so that:

- **`error(message) → turn-end(isError: true)`**: renders the specific message exactly once, no generic duplicate.
- **`turn-end(isError: true)` without a prior `error`**: renders "The Agent turn failed before returning a response."
- **`turn-end(isError: false)`**: no error added.
- The guard resets on every `turn-start`.

## Changes

- `AgentView.tsx`: Added `turnErrorExplainedRef` — a per-turn ref that tracks whether the current turn has already shown an error. Reset on `turn-start`, set when a live `error` event is appended, and checked in the `turn-end` handler to add a generic fallback when no specific error was emitted.

## Acceptance criteria

- [x] `ready → prompt → turn-end(isError: true)` renders one persistent inline error.
- [x] `error(message) → turn-end(isError: true)` renders the specific message exactly once, with no generic duplicate.
- [x] `turn-end(isError: false)` adds no error.
- [x] A failed turn stops the working indicator, preserves prompt and partial output, and leaves the composer usable.
- [x] A waiting follow-up is sent exactly once under the existing recoverable-turn queue policy.
- [x] Successful turns, stopped-turn editing, permission cards, transcript scrolling, and history restoration remain unchanged.

Closes #130