### PR TITLE
feat(agent): add adaptive chat-first workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ When you open StashBase for the first time:
 2. **(Optional) Configure semantic search**: If you want AI-powered semantic search, add an OpenAI or OpenRouter API key in **Settings → Embedding**. An OpenAI restricted key needs access only to embeddings with `text-embedding-3-small`; model-list access is not required.
 3. **(Optional) Set up transcription**: To transcribe audio or video, download a speech model from **Settings → Transcription**. Small (465 MiB) is the default; Tiny (74 MiB) and Base (141 MiB) are lighter options. Transcription runs entirely on your machine, with no API cost, and you can cancel or rerun it while viewing the file
 4. **(Optional) Connect to Claude/Codex**: From **Settings → MCP**, connect external AI tools to access your searchable library
-5. Start searching! Use the search box to find files by content
+5. **Start in Chat**: Opening a folder starts a fresh built-in Agent chat.
+   Codex is the first default; after you choose Claude or Codex, StashBase
+   remembers that choice. Selecting a source file brings the document
+   alongside the same conversation.
 
 Your library is **opt-in**: only folders you open in StashBase are indexed. You can remove a folder at any time; StashBase clears its index but never deletes your files from disk.
 
@@ -193,13 +196,19 @@ For manual stdio setup, URL-based clients, Docker access, ports, CORS boundaries
 
 ---
 
-## Built-In Agent Panel
+## Built-In Agent Chat
 
-StashBase includes a built-in panel for running local Agent CLIs such as Claude Code and Codex against the current folder.
+StashBase includes a built-in chat for running local Agent CLIs such as Claude
+Code and Codex against the current folder. Chat fills the workspace until you
+open a document, then adapts into a side panel so the conversation and source
+stay visible together.
 
-The panel is a convenient client of the same MCP server, not a separate knowledge base. It adds:
+The chat is a convenient client of the same MCP server, not a separate
+knowledge base. It adds:
 
 - Sessions run in the current folder, next to the files they work on.
+- A fresh conversation opens with each folder; Codex is the first default and
+  later folder chats use the Agent you last selected.
 - Tool calls and file edits can be reviewed in the app.
 - Session history stays in the Agent CLI's normal storage.
 - `@` mentions find files and folders with forgiving workspace-path search;

--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -6,7 +6,9 @@ This document captures the product design contract for the built-in Claude/Codex
 
 ## Direction
 
-The built-in Agent panel should feel like a VS Code-style agent side panel for local files, not a separate AI workspace.
+The built-in Agent panel is one folder-scoped chat surface. It should feel like
+a focused chat when no document is open and a VS Code-style side panel when a
+document is active, not a separate AI workspace.
 
 The panel may make agent work easier to scan, but it should stay quiet:
 
@@ -46,6 +48,21 @@ Community contributions can land as useful first iterations, but the long-term d
 ## Design Rules
 
 - Keep the panel renderer-led. Do not change agent transport, session persistence, MCP, indexing, or permission policy just to support presentation changes.
+- Derive the shell layout from Chat visibility, document presence, and compact
+  viewport state; do not add RAG/CoWork product modes. The chat-primary layout
+  removes the document and splitter grid tracks without unmounting either
+  surface. Hidden primary surfaces are inert so zero-width content cannot keep
+  keyboard focus.
+- Opening a folder creates one fresh chat tab for the app-wide preferred
+  Agent. The preference defaults to Codex, changes only through explicit Agent
+  selection, and is recoverable when local UI storage is unavailable. Runtime
+  availability remains authoritative: never silently fall back from an
+  unavailable preferred Agent.
+- Keep the first compact-window document transition document-first. The
+  responsive auto-collapse may be undone by an explicit Chat launcher action;
+  once the user does that, layout effects must not immediately close Chat
+  again. Restore a responsively collapsed chat when the last document closes
+  or the window becomes wide, unless the user has since changed visibility.
 - Prefer small, familiar agent-chat affordances over a bespoke workbench UI.
 - Treat user-action states as first-class. Permission approvals, retry actions, and stopped-turn editing must remain visible and directly actionable.
 - A discovered missing Agent CLI is a setup state, not a disabled launcher or a
@@ -54,6 +71,9 @@ Community contributions can land as useful first iterations, but the long-term d
   installed runtime that has failed.
 - Keep background activity compact. Tool calls may be grouped or summarized, but the user must be able to inspect them when needed.
 - File outputs should be easy to open, but artifact UI should stay lightweight. Prefer rows or compact affordances over large delivery cards.
+- Successful file-changing tools refresh folder and index state but never
+  select their output automatically. Only the user's artifact or local-link
+  action opens a document and causes Chat to dock.
 - Streaming should not steal the user's scroll position. If the user has scrolled away from the bottom, show a clear jump-to-latest affordance.
 - The current document is never implicit agent context. Users attach files by drag/drop, file picker, `@` mention, or a composer-focused image paste. Image paste must reuse transient attachments, preserve accompanying text, and suppress the competing clipboard library-import offer.
 - The top-bar Claude and Codex icons select or toggle existing chats. Creating a new chat belongs to the in-panel `+`.
@@ -91,6 +111,9 @@ The accepted baseline includes:
   locale-independent order, and raw workspace-relative paths remain the
   stable item IDs and inserted tokens.
 - smooth chat-side resize without drag-frequency global state updates
+- adaptive chat-first layout with a centred readable transcript/composer width,
+  side-panel width restoration, explicit-hide precedence, and a document-first
+  compact-window transition
 - compact activity grouping for non-actionable tool calls, with inspectable
   command/read/search labels rather than lifecycle-only summaries
 - visible permission cards outside collapsed activity

--- a/design-docs/design/agent-panel.md
+++ b/design-docs/design/agent-panel.md
@@ -1,13 +1,23 @@
 # Agent Panel
 
-The built-in Agent Panel is a compact, VS Code-like side panel for working
-alongside the current local folder. It is a convenient client of StashBase
-context, not a separate AI workspace.
+The built-in Agent Panel is one adaptive chat surface for the current local
+folder. Chat is the primary workspace until a document is opened, then becomes
+a compact, VS Code-like side panel alongside that document. It is a convenient
+client of StashBase context, not a separate AI workspace.
 
 ## Current
 
 - Users can work with supported Agent runtimes in separate chats and restore
   prior chat history.
+- Opening a folder starts a fresh chat with the user's last selected Agent.
+  Codex is the default until the user explicitly selects another Agent. An
+  unavailable preferred runtime remains a visible setup state; StashBase does
+  not silently substitute another runtime.
+- With no document open, Chat fills the workspace beside the Files sidebar.
+  Opening a file, search result, local response link, artifact, or new note
+  moves the same mounted chat into the side panel. Closing the last document
+  expands an open chat again. On compact windows a newly opened document takes
+  priority; explicitly reopening Chat gives it the primary area until hidden.
 - When a runtime supplies its native model catalog, a compact per-session
   selector shows Default plus that runtime's available models. Default leaves
   the user's CLI configuration intact; StashBase never rewrites it or turns the
@@ -30,7 +40,9 @@ context, not a separate AI workspace.
 - Permission requests remain actionable. Limited edit workflows can be
   streamlined, while deletion, commands, network access, and broader access
   stay explicit approval decisions.
-- Agent file outputs and local file links lead back into the local workspace.
+- Agent file outputs refresh the Files sidebar without moving the user away
+  from Chat. Their compact Open affordances and local file links lead back into
+  the local workspace only when the user chooses them.
 - Agent response Markdown supports GFM, but treats raw HTML and remote images
   as inert content; only workspace-relative links and HTTP(S) links are active.
 - If a supported Agent CLI is missing, its launcher opens a compact setup state
@@ -41,6 +53,12 @@ context, not a separate AI workspace.
 
 - Keep the panel quiet: compact controls, restrained chrome, and no decorative
   workbench metaphor.
+- Treat chat-primary and document-side-panel presentation as two layouts of
+  the same mounted session. Layout changes must preserve transcript state,
+  streaming work, attachments, scroll position, and the user's remembered
+  side-panel width.
+- Respect explicit visibility choices. Automatically open Chat once per folder
+  entry, but do not reopen it after the user hides or closes it in that folder.
 - Do not hide permission cards or recovery actions inside collapsed activity.
 - Streaming must not steal reading position from a user inspecting earlier
   transcript content.
@@ -78,7 +96,8 @@ context, not a separate AI workspace.
 - Improve attachment and mention selection, including more focused document
   context handoff.
 - Clarify runtime, recovery, settings, and context diagnostics.
-- Continue refining the low-chrome side-panel visual language.
+- Continue refining the low-chrome adaptive chat and side-panel visual
+  language.
 
 ### Coordinate First
 

--- a/design-docs/design/library.md
+++ b/design-docs/design/library.md
@@ -17,6 +17,9 @@ to migrate them into a StashBase-specific storage model.
   Ctrl+Shift+W as an alternative. Cmd/Ctrl+W remains the active-tab command.
 - Users can create, rename, move, and delete files or folders through explicit
   file operations.
+- A folder opens into a chat-first workspace with the Files sidebar still
+  visible. Selecting or creating a document reveals the source pane and docks
+  the same conversation beside it.
 - The main pane opens the source file the user selected; generated artifacts
   stay hidden.
 - Cmd/Ctrl+T opens a new blank tab, the keyboard equivalent of the tab
@@ -63,6 +66,9 @@ to migrate them into a StashBase-specific storage model.
 - Sidebar and Agent-panel widths work with pointer input and with
   Arrow/Home/End keys on macOS, Windows, and Linux; reduced-motion users do
   not receive layout movement animation.
+- Closing the last document lets an open Chat reclaim the main area. Hiding
+  Chat is explicit and leaves a lightweight document/chat launcher instead of
+  immediately reopening it.
 - The Files sidebar is a calm orientation tool, not a separate knowledge graph
   or project-management surface. It groups the file tree and the active
   Markdown document outline into independently collapsible navigation sections.

--- a/design-docs/overview.md
+++ b/design-docs/overview.md
@@ -35,8 +35,9 @@ re-explaining it.
 
 - A local-file workspace for browsing and maintaining ordinary folders.
 - Document preparation and retrieval that make those folders useful as context.
-- An optional side-panel agent that complements, rather than replaces,
-  bring-your-own-agent workflows.
+- An optional built-in Agent chat that leads before a document is opened and
+  adapts into a side panel beside active source work, complementing rather
+  than replacing bring-your-own-agent workflows.
 
 For the durable decision rules, see [Principles](principles.md). For the
 intended product shape, see [Product Direction](product-direction.md). For the

--- a/design-docs/product-direction.md
+++ b/design-docs/product-direction.md
@@ -13,9 +13,11 @@ with a database, block editor, or proprietary storage model.
 
 ## Agent Panel
 
-The built-in Agent Panel belongs alongside the current folder and document. It
-is a convenient client of StashBase context, not a separate AI workspace and
-not a replacement for external agent clients.
+The built-in Agent Panel belongs to the current folder. Before a document is
+opened, that same chat is the primary workspace; once a document appears, it
+adapts into a side panel alongside the source. It is a convenient client of
+StashBase context, not a separate AI workspace and not a replacement for
+external agent clients.
 
 ## Document Indexing
 

--- a/design-docs/use-cases.md
+++ b/design-docs/use-cases.md
@@ -35,6 +35,11 @@ organizes the source material and narrative; it is not the slide editor.
 
 > Chat is for exploring. Canvas is for converging.
 
+The workspace follows that progression without asking the user to choose a
+mode. A folder opens with Chat as the primary surface and the file list still
+visible. Opening a source or creating the Canvas reveals the document beside
+the same conversation; closing the last document lets Chat expand again.
+
 ## 1. Take an Engineering Project from Requirements to Delivery
 
 A freelance developer or engineering team may start with a contract, statement

--- a/electron/tab-strip-layout-smoke.cjs
+++ b/electron/tab-strip-layout-smoke.cjs
@@ -35,6 +35,8 @@ const html = `<!doctype html>
     </main>
   </body>
 </html>`;
+const htmlPath = path.join(smokeRoot, 'tab-strip-layout.html');
+fs.writeFileSync(htmlPath, html, 'utf8');
 
 let finished = false;
 const deadline = setTimeout(() => {
@@ -57,7 +59,11 @@ app.whenReady()
       height: 200,
       webPreferences: { sandbox: true },
     });
-    await win.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(html)}`);
+    // Loading the complete renderer CSS through a data: URL eventually hits
+    // platform-specific URL limits as the stylesheet grows. The shared smoke
+    // root is already temporary and removed by the runner, so load the same
+    // self-contained fixture as a local file instead.
+    await win.loadFile(htmlPath);
     const layout = await win.webContents.executeJavaScript(`
       (() => {
         const closeRect = document.querySelector('.tab-close').getBoundingClientRect();

--- a/web-src/src/App.tsx
+++ b/web-src/src/App.tsx
@@ -41,6 +41,7 @@ import {
   CHAT_MAX_WIDTH,
   CHAT_MIN_WIDTH,
   isSplitterKey,
+  makeChatTab,
   resizeChatByKeyboard,
   resizeSidebarByKeyboard,
   SIDEBAR_COLLAPSE_AT,
@@ -52,6 +53,12 @@ import { getWindowId } from './api';
 import { api } from './api';
 import { applyAppearance, subscribeToAppearance } from './appearance';
 import { isTrustedPreviewSource } from './lib/previewMessages';
+import { readPreferredAgent } from './agentPreference';
+import {
+  COMPACT_WORKSPACE_QUERY,
+  resolveWorkspaceLayout,
+  shouldAutoCollapseChat,
+} from './workspaceLayout';
 
 const LazyChatPane = lazyWithRetry(() => import('./components/ChatPane').then((mod) => ({ default: mod.ChatPane })));
 
@@ -77,11 +84,25 @@ export function App() {
 
 function AppBody() {
   const veilHot = useGlobalDragDrop();
-  const { state, actions } = useApp();
+  const { state, actions, dispatch } = useApp();
   const [previewImage, setPreviewImage] = useState<{ src: string; alt: string } | null>(null);
   const [clipboardOffer, setClipboardOffer] = useState<ClipboardOffer | null>(null);
   const [pendingClipboardOffer, setPendingClipboardOffer] = useState<ClipboardOffer | null>(null);
   const initialFolderPending = useRef(new URLSearchParams(window.location.search).has('folder'));
+  const compactWorkspace = useCompactWorkspace();
+  const hasDocument = state.tabs.length > 0;
+  const workspaceLayout = resolveWorkspaceLayout({
+    chatOpen: state.chatOpen,
+    hasDocument,
+    compact: compactWorkspace,
+  });
+  const defaultChatFolderRef = useRef('');
+  const responsiveChatCollapsedRef = useRef(false);
+  const previousWorkspaceRef = useRef({
+    folderPath: '',
+    hasDocument: false,
+    compact: compactWorkspace,
+  });
   // Mount the chat panel lazily on first open and then NEVER
   // unmount it — top-bar agent selectors only hide the column via CSS,
   // the underlying agent WebSocket sessions stay alive. Killing them
@@ -106,6 +127,59 @@ function AppBody() {
   useEffect(() => {
     if (state.chatOpen) setChatMounted(true);
   }, [state.chatOpen]);
+  useEffect(() => {
+    if (!state.folderPath || state.welcomeVisible) {
+      defaultChatFolderRef.current = '';
+      return;
+    }
+    if (defaultChatFolderRef.current === state.folderPath) return;
+    defaultChatFolderRef.current = state.folderPath;
+    const agent = readPreferredAgent();
+    dispatch({
+      type: 'CHAT_AGENT_OPEN',
+      agent,
+      tab: makeChatTab(agent, state.chatTabs),
+    });
+  }, [dispatch, state.chatTabs, state.folderPath, state.welcomeVisible]);
+  useEffect(() => {
+    const previous = previousWorkspaceRef.current;
+    const folderChanged = previous.folderPath !== state.folderPath;
+    previousWorkspaceRef.current = {
+      folderPath: state.folderPath,
+      hasDocument,
+      compact: compactWorkspace,
+    };
+
+    if (folderChanged) {
+      responsiveChatCollapsedRef.current = false;
+      return;
+    }
+    if (shouldAutoCollapseChat({
+      chatOpen: state.chatOpen,
+      hasDocument,
+      compact: compactWorkspace,
+      previousHasDocument: previous.hasDocument,
+      previousCompact: previous.compact,
+    })) {
+      responsiveChatCollapsedRef.current = true;
+      dispatch({ type: 'CHAT_TOGGLE' });
+      return;
+    }
+    if (responsiveChatCollapsedRef.current && state.chatOpen) {
+      // The user explicitly reopened Chat while the document is still
+      // active, so future document changes must not fight that choice.
+      responsiveChatCollapsedRef.current = false;
+      return;
+    }
+    if (
+      responsiveChatCollapsedRef.current
+      && !state.chatOpen
+      && (!hasDocument || !compactWorkspace)
+    ) {
+      responsiveChatCollapsedRef.current = false;
+      dispatch({ type: 'CHAT_TOGGLE' });
+    }
+  }, [compactWorkspace, dispatch, hasDocument, state.chatOpen, state.folderPath]);
   useEffect(() => {
     document.title = state.folder ? `${state.folder} — StashBase` : 'StashBase';
   }, [state.folder]);
@@ -251,6 +325,7 @@ function AppBody() {
           'app'
           + (state.sidebarCollapsed ? ' sidebar-collapsed' : '')
           + (state.chatOpen ? ' chat-open' : '')
+          + (workspaceLayout === 'chat-primary' ? ' chat-primary' : '')
         }
         style={{
           '--chat-width': `${state.chatWidth}px`,
@@ -260,9 +335,9 @@ function AppBody() {
         <DocumentOutlineProvider>
           <Sidebar />
           {!state.welcomeVisible && <SidebarSplitter />}
-          <MainPane />
+          <MainPane workspaceHidden={workspaceLayout === 'chat-primary'} />
         </DocumentOutlineProvider>
-        {chatMounted && state.chatOpen && <ChatSplitter />}
+        {chatMounted && workspaceLayout === 'split' && <ChatSplitter />}
         {chatMounted && (
           <LazyLoadBoundary
             className="chat-pane-shell"
@@ -305,6 +380,28 @@ function AppBody() {
       <SettingsPortal />
     </>
   );
+}
+
+function useCompactWorkspace() {
+  const [compact, setCompact] = useState(() =>
+    typeof window.matchMedia === 'function'
+      ? window.matchMedia(COMPACT_WORKSPACE_QUERY).matches
+      : window.innerWidth <= 960);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') {
+      const onResize = () => setCompact(window.innerWidth <= 960);
+      window.addEventListener('resize', onResize);
+      return () => window.removeEventListener('resize', onResize);
+    }
+    const query = window.matchMedia(COMPACT_WORKSPACE_QUERY);
+    const onChange = (event: MediaQueryListEvent) => setCompact(event.matches);
+    setCompact(query.matches);
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }, []);
+
+  return compact;
 }
 
 function HomeChromeButton({ onClick }: { onClick: () => void }) {

--- a/web-src/src/__tests__/agent-preference.test.ts
+++ b/web-src/src/__tests__/agent-preference.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  DEFAULT_AGENT,
+  readPreferredAgent,
+  rememberPreferredAgent,
+} from '../agentPreference';
+
+function memoryStorage(initial: string | null = null) {
+  let value = initial;
+  return {
+    getItem: () => value,
+    setItem: (_key: string, next: string) => { value = next; },
+  };
+}
+
+test('Codex is the default until the user chooses another Agent', () => {
+  const storage = memoryStorage();
+
+  assert.equal(DEFAULT_AGENT, 'codex');
+  assert.equal(readPreferredAgent(storage), 'codex');
+
+  rememberPreferredAgent('claude', storage);
+  assert.equal(readPreferredAgent(storage), 'claude');
+});
+
+test('invalid or inaccessible Agent preferences recover to Codex', () => {
+  assert.equal(readPreferredAgent(memoryStorage('other-agent')), 'codex');
+
+  const inaccessible = {
+    getItem: () => { throw new Error('blocked'); },
+    setItem: () => { throw new Error('blocked'); },
+  };
+  assert.equal(readPreferredAgent(inaccessible), 'codex');
+  assert.doesNotThrow(() => rememberPreferredAgent('claude', inaccessible));
+});

--- a/web-src/src/__tests__/workspace-layout.test.ts
+++ b/web-src/src/__tests__/workspace-layout.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  resolveWorkspaceLayout,
+  shouldAutoCollapseChat,
+} from '../workspaceLayout';
+
+test('Chat owns the workspace until a document is opened', () => {
+  assert.equal(resolveWorkspaceLayout({
+    chatOpen: true,
+    hasDocument: false,
+    compact: false,
+  }), 'chat-primary');
+  assert.equal(resolveWorkspaceLayout({
+    chatOpen: true,
+    hasDocument: true,
+    compact: false,
+  }), 'split');
+  assert.equal(resolveWorkspaceLayout({
+    chatOpen: false,
+    hasDocument: false,
+    compact: false,
+  }), 'document');
+});
+
+test('compact workspaces show one primary surface at a time', () => {
+  assert.equal(resolveWorkspaceLayout({
+    chatOpen: true,
+    hasDocument: true,
+    compact: true,
+  }), 'chat-primary');
+  assert.equal(resolveWorkspaceLayout({
+    chatOpen: false,
+    hasDocument: true,
+    compact: true,
+  }), 'document');
+});
+
+test('compact layout collapses Chat only for a document or viewport transition', () => {
+  assert.equal(shouldAutoCollapseChat({
+    chatOpen: true,
+    hasDocument: true,
+    compact: true,
+    previousHasDocument: false,
+    previousCompact: true,
+  }), true);
+  assert.equal(shouldAutoCollapseChat({
+    chatOpen: true,
+    hasDocument: true,
+    compact: true,
+    previousHasDocument: true,
+    previousCompact: false,
+  }), true);
+  assert.equal(shouldAutoCollapseChat({
+    chatOpen: true,
+    hasDocument: true,
+    compact: true,
+    previousHasDocument: true,
+    previousCompact: true,
+  }), false);
+});

--- a/web-src/src/agentPreference.ts
+++ b/web-src/src/agentPreference.ts
@@ -1,0 +1,44 @@
+import { isAgentKind, type AgentKind } from './agentCatalog';
+
+const AGENT_PREFERENCE_KEY = 'stashbase.preferred-agent';
+export const DEFAULT_AGENT: AgentKind = 'codex';
+
+interface AgentPreferenceStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function browserStorage(): AgentPreferenceStorage | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Invalid, missing, or inaccessible UI preference state always recovers to
+ * Codex. Runtime availability remains a separate setup concern. */
+export function readPreferredAgent(
+  storage: AgentPreferenceStorage | undefined = browserStorage(),
+): AgentKind {
+  try {
+    const stored = storage?.getItem(AGENT_PREFERENCE_KEY);
+    return stored && isAgentKind(stored) ? stored : DEFAULT_AGENT;
+  } catch {
+    return DEFAULT_AGENT;
+  }
+}
+
+/** Agent choice is an app-wide presentation preference, not folder or session
+ * state. Storage failures must never block opening a chat. */
+export function rememberPreferredAgent(
+  agent: AgentKind,
+  storage: AgentPreferenceStorage | undefined = browserStorage(),
+): void {
+  try {
+    storage?.setItem(AGENT_PREFERENCE_KEY, agent);
+  } catch {
+    // Private browsing and hardened WebViews may reject localStorage.
+  }
+}

--- a/web-src/src/components/AgentView.tsx
+++ b/web-src/src/components/AgentView.tsx
@@ -378,14 +378,12 @@ export function AgentView({
           const toolName = toolNamesRef.current.get(ev.id);
           if (shouldRefreshAfterTool(toolName)) {
             const toolFolder = folderPathRef.current;
-            const createdFile = fileInCurrentFolderFromToolResult(toolName, ev.content, toolFolder);
             void (async () => {
               await api.sync(toolFolder).catch(() => { /* turn-end / next poll will surface it */ });
               if (folderPathRef.current !== toolFolder) return;
               await actions.loadFiles();
               if (folderPathRef.current !== toolFolder) return;
               void actions.refreshIndexState();
-              if (createdFile) await actions.selectFile(createdFile);
             })().catch((err) => {
               actions.toast(`Could not refresh files: ${errorText(err)}`, { level: 'error' });
             });
@@ -1007,20 +1005,6 @@ function shouldRefreshAfterTool(name: string | undefined): boolean {
   if (!name) return false;
   if (['Write', 'Edit', 'MultiEdit', 'NotebookEdit'].includes(name)) return true;
   return /^mcp__/.test(name) && /(write|delete|rename|update|set_|create|move)/i.test(name);
-}
-
-function fileInCurrentFolderFromToolResult(toolName: string | undefined, content: string, folder: string): string | null {
-  if (!toolName || !/write_file$/i.test(toolName) || !folder) return null;
-  try {
-    const parsed = JSON.parse(content) as { path?: unknown; ok?: unknown };
-    if (parsed.ok !== true || typeof parsed.path !== 'string') return null;
-    const prefix = `${folder}/`;
-    if (!parsed.path.startsWith(prefix)) return null;
-    const rel = parsed.path.slice(prefix.length);
-    return isSafeFolderRelativePath(rel) ? rel : null;
-  } catch {
-    return null;
-  }
 }
 
 function isSafeFolderRelativePath(path: string): boolean {

--- a/web-src/src/components/ChatLaunchButtons.tsx
+++ b/web-src/src/components/ChatLaunchButtons.tsx
@@ -7,10 +7,11 @@
  */
 import { useEffect, useRef } from 'react';
 import { api, type Agent, type AgentsResponse } from '../api';
-import { AGENTS, type AgentMeta } from '../agentCatalog';
+import { AGENTS, type AgentKind, type AgentMeta } from '../agentCatalog';
 import { useApp } from '../store/AppContext';
 import { makeChatTab } from '../store/state';
 import { DeferredTooltipButton } from './DeferredTooltipButton';
+import { rememberPreferredAgent } from '../agentPreference';
 
 export function ChatLaunchButtons() {
   const { state, dispatch } = useApp();
@@ -28,7 +29,8 @@ export function ChatLaunchButtons() {
 
   const activeTab = state.chatTabs.find((t) => t.id === state.activeChatTabId);
 
-  function toggleAgent(agentId: string) {
+  function toggleAgent(agentId: AgentKind) {
+    rememberPreferredAgent(agentId);
     const hasOpenTab = state.chatTabs.some((tab) => tab.agent === agentId);
     dispatch({
       type: 'CHAT_AGENT_TOGGLE',

--- a/web-src/src/components/ChatPane.tsx
+++ b/web-src/src/components/ChatPane.tsx
@@ -13,6 +13,7 @@ import { AgentView } from './AgentView';
 import { LazyLoadBoundary } from './ErrorBoundary';
 import { agentMeta, isAgentKind } from '../agentCatalog';
 import { useApp } from '../store/AppContext';
+import { rememberPreferredAgent } from '../agentPreference';
 
 /** Brand glyph for a tab's agent, shown before its title. */
 function AgentGlyph({ agent }: { agent: string }) {
@@ -49,7 +50,11 @@ export function ChatPane() {
   if (!folder) return null;
 
   return (
-    <div className="chat-pane-shell">
+    <div
+      className="chat-pane-shell"
+      aria-hidden={!state.chatOpen || undefined}
+      inert={!state.chatOpen || undefined}
+    >
       <div className="chat-tabs">
         <div className="chat-tabs-list">
           {tabs.map((tab) => (
@@ -58,7 +63,10 @@ export function ChatPane() {
               className={'chat-tab' + (tab.id === activeId ? ' active' : '')}
               role="tab"
               aria-selected={tab.id === activeId}
-              onClick={() => dispatch({ type: 'CHAT_TAB_ACTIVATE', id: tab.id })}
+              onClick={() => {
+                if (isAgentKind(tab.agent)) rememberPreferredAgent(tab.agent);
+                dispatch({ type: 'CHAT_TAB_ACTIVATE', id: tab.id });
+              }}
               title={tab.title}
             >
               <AgentGlyph agent={tab.agent} />

--- a/web-src/src/components/MainPane.tsx
+++ b/web-src/src/components/MainPane.tsx
@@ -7,6 +7,7 @@ import { HtmlPreview } from './HtmlPreview';
 import { ImagePreview } from './ImagePreview';
 import { TabStrip } from './TabStrip';
 import { LazyLoadBoundary, lazyWithRetry } from './ErrorBoundary';
+import { readPreferredAgent } from '../agentPreference';
 
 const LazyCrepeDocument = lazyWithRetry(() => import('./CrepeDocument').then((mod) => ({ default: mod.CrepeDocument })));
 const LazyPdfPreview = lazyWithRetry(() => import('./PdfPreview').then((mod) => ({ default: mod.PdfPreview })));
@@ -23,7 +24,7 @@ const LazyAudioPreview = lazyWithRetry(() => import('./AudioPreview').then((mod)
  * When there are no tabs at all, `.main.no-file > *` hides every child so
  * the pane is a clean canvas.
  */
-export function MainPane() {
+export function MainPane({ workspaceHidden = false }: { workspaceHidden?: boolean }) {
   const { state, actions, activeTab } = useApp();
   const cur = activeTab?.file ?? null;
   const editMode = activeTab?.editMode ?? false;
@@ -33,25 +34,43 @@ export function MainPane() {
   const resourceResetKey = cur ? `${cur.name}:${cur.version ?? ''}` : undefined;
 
   return (
-    <main className={'main' + (hasTabs ? '' : ' no-file') + (cur ? ' fmt-' + cur.format : '')}>
+    <main
+      className={'main' + (hasTabs ? '' : ' no-file') + (cur ? ' fmt-' + cur.format : '')}
+      aria-hidden={workspaceHidden || undefined}
+      inert={workspaceHidden || undefined}
+    >
       {hasTabs && <TabStrip />}
       <div className="main-body">
         {!hasTabs && (
-          // One <p> wrapper so the grid centers a single block and the
-          // text keeps normal inline flow — otherwise each <br>/inline
-          // child becomes its own grid item and scatters vertically.
           <div className="empty-doc">
-            <p>
-              Drop files or folders anywhere to stash them<br />
-              — Markdown, HTML, PDFs, images, audio —<br />
-              or click{' '}
-              <button
-                type="button"
-                className="empty-doc-new"
-                onClick={() => { void actions.newNote(); }}
-              >+</button>{' '}
-              for a new note (⌘N)
-            </p>
+            <div>
+              <p>Start a conversation or choose a document from Files.</p>
+              <div className="empty-doc-actions">
+                <button
+                  type="button"
+                  className="empty-doc-action primary"
+                  onClick={() => actions.openAgent(readPreferredAgent())}
+                >
+                  Start chat
+                </button>
+                <button
+                  type="button"
+                  className="empty-doc-action"
+                  onClick={() => window.dispatchEvent(new Event('stashbase-open-quick-open'))}
+                >
+                  Open document
+                </button>
+              </div>
+              <p className="empty-doc-secondary">
+                Drop files or folders anywhere to stash them, or click{' '}
+                <button
+                  type="button"
+                  className="empty-doc-new"
+                  onClick={() => { void actions.newNote(); }}
+                >+</button>{' '}
+                for a new note.
+              </p>
+            </div>
           </div>
         )}
         {emptyTab && <EmptyTabLanding />}

--- a/web-src/src/store/AppContext.tsx
+++ b/web-src/src/store/AppContext.tsx
@@ -29,6 +29,7 @@ import {
 } from './state';
 import type { SearchTypeCategory } from '../../../shared/search-types.ts';
 import type { AgentKind } from '../agentCatalog';
+import { rememberPreferredAgent } from '../agentPreference';
 import type { EditorHandle, FindController } from './actionTypes';
 import { useFeedbackActions } from './useFeedbackActions';
 import { useFindActions } from './useFindActions';
@@ -442,6 +443,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     toast,
     toggleEditMode: workspace.toggleEditMode,
     openAgent: (agent) => {
+      rememberPreferredAgent(agent);
       const current = stateRef.current;
       const hasOpenTab = current.chatTabs.some((tab) => tab.agent === agent);
       dispatch({

--- a/web-src/src/styles/chat.css
+++ b/web-src/src/styles/chat.css
@@ -8,6 +8,19 @@
     .app.sidebar-collapsed.chat-open {
       grid-template-columns: 44px 1fr 6px var(--chat-width, 480px);
     }
+    /* With no document, Chat is the workspace instead of a narrow side
+     * panel. The document pane remains mounted so switching back preserves
+     * editor state, but its track and splitter disappear. Compact windows
+     * reuse this shape when the user explicitly brings Chat over a document. */
+    .app.chat-primary {
+      grid-template-columns: calc(44px + var(--sidebar-width, 280px)) 0 0 minmax(0, 1fr);
+    }
+    .app.sidebar-collapsed.chat-primary {
+      grid-template-columns: 44px 0 0 minmax(0, 1fr);
+    }
+    .app.chat-primary .main {
+      visibility: hidden;
+    }
 
     /* Match the sidebar's drag handle (globals.css `.sidebar-splitter`):
      * a 6px transparent hit area whose only visible cue is a crisp 2px
@@ -404,6 +417,21 @@
       flex-direction: column;
       gap: 10px;
       scrollbar-width: thin;
+    }
+    /* Full-width Chat should gain working room without turning prose into
+     * viewport-wide lines. Keep the scroll container full-width and center
+     * its content through responsive padding so wheel/trackpad input works
+     * anywhere over the transcript. */
+    .app.chat-primary .agent-messages {
+      padding-right: max(12px, calc((100% - 920px) / 2));
+      padding-left: max(12px, calc((100% - 920px) / 2));
+    }
+    .app.chat-primary .agent-head,
+    .app.chat-primary .agent-composer {
+      width: min(920px, 100%);
+      margin-right: auto;
+      margin-left: auto;
+      box-sizing: border-box;
     }
     .agent-messages > :first-child { margin-top: 12px; }
     .agent-jump-latest {

--- a/web-src/src/styles/mainpane.css
+++ b/web-src/src/styles/mainpane.css
@@ -1126,6 +1126,33 @@
       margin: 0;
       line-height: 1.9;
     }
+    .empty-doc-actions {
+      display: flex;
+      justify-content: center;
+      gap: 8px;
+      margin-top: 14px;
+    }
+    .empty-doc-action {
+      min-height: 30px;
+      padding: 5px 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg);
+      color: var(--fg);
+      cursor: pointer;
+    }
+    .empty-doc-action:hover {
+      border-color: var(--stroke-strong);
+      background: var(--hover);
+    }
+    .empty-doc-action.primary {
+      border-color: var(--accent);
+      background: var(--accent);
+      color: var(--text-on-accent);
+    }
+    .empty-doc-secondary {
+      margin-top: 14px !important;
+    }
     /* Inline ghost-accent "+" — a small rounded-square add-button so the
      * sentence "or click + for a new note" reads as unmistakably
      * clickable. Matches the sidebar `.icon-btn` shape (4px radius,

--- a/web-src/src/workspaceLayout.ts
+++ b/web-src/src/workspaceLayout.ts
@@ -1,0 +1,41 @@
+export const COMPACT_WORKSPACE_QUERY = '(max-width: 960px)';
+
+export type WorkspaceLayout = 'document' | 'split' | 'chat-primary';
+
+/** Presentation-only layout policy. RAG and CoWork share the same workspace;
+ * the presence of a document is enough to choose between chat-first and
+ * side-by-side collaboration. */
+export function resolveWorkspaceLayout({
+  chatOpen,
+  hasDocument,
+  compact,
+}: {
+  chatOpen: boolean;
+  hasDocument: boolean;
+  compact: boolean;
+}): WorkspaceLayout {
+  if (!chatOpen) return 'document';
+  if (!hasDocument || compact) return 'chat-primary';
+  return 'split';
+}
+
+/** A newly opened document wins on a compact window. Once it has been shown,
+ * reopening Chat is explicit user intent and may take over the main area. */
+export function shouldAutoCollapseChat({
+  chatOpen,
+  hasDocument,
+  compact,
+  previousHasDocument,
+  previousCompact,
+}: {
+  chatOpen: boolean;
+  hasDocument: boolean;
+  compact: boolean;
+  previousHasDocument: boolean;
+  previousCompact: boolean;
+}): boolean {
+  return chatOpen
+    && hasDocument
+    && compact
+    && (!previousHasDocument || !previousCompact);
+}


### PR DESCRIPTION
## What changed

- Open each folder with a fresh built-in Agent chat, defaulting to Codex until the user explicitly chooses another Agent.
- Let Chat fill the workspace while no document is open, then dock the same mounted session beside a selected or newly created document.
- Preserve explicit Chat visibility choices and side-panel width; on compact windows, prioritize a newly opened document while allowing the user to bring Chat back as the primary surface.
- Keep generated file outputs in Chat until the user opens them instead of switching documents automatically.
- Add a lightweight fallback launcher when both Chat and documents are closed.
- Update product, use-case, README, and Agent Panel review contracts for the adaptive workflow.

## Why

Both retrieval and CoWork journeys begin in conversation. The previous fixed side-panel layout made Chat hard to discover and reserved the primary workspace for an empty document canvas. This change makes Chat the entry point and introduces the document only when the user expresses document intent, without adding separate RAG or CoWork modes.

## User impact

Users see a usable Chat immediately after opening a folder. Opening a source, search result, Agent link, artifact, blank tab, or note transitions naturally into document-plus-chat collaboration. Agent choice is remembered app-wide; an unavailable preferred runtime remains an actionable setup state and never silently falls back.

## Validation

- `pnpm test:renderer` — 133 tests passed
- `pnpm typecheck`
- `npx vite build --config web-src/vite.config.ts`
- `pnpm test:renderer-chunks` — 402897 / 409600 initial static JS bytes
- `pnpm test:electron` — 15 tests passed
