### PR TITLE
fix(renderer): retain PDF page number across tab switches

### DIFF
--- a/design-docs/design/library.md
+++ b/design-docs/design/library.md
@@ -22,6 +22,7 @@ to migrate them into a StashBase-specific storage model.
   the same conversation beside it.
 - The main pane opens the source file the user selected; generated artifacts
   stay hidden.
+- PDF tabs retain their active reading position (page number) across tab switches during a session. Reusing a preview tab for a different file resets the stored page position.
 - Cmd/Ctrl+T opens a new blank tab, the keyboard equivalent of the tab
   strip's `+` button — distinct from Cmd/Ctrl+N, which creates a note file.
 - Cmd/Ctrl+O opens a focused Quick Open for visible source files in the active

--- a/web-src/src/components/MainPane.tsx
+++ b/web-src/src/components/MainPane.tsx
@@ -106,7 +106,7 @@ export function MainPane({ workspaceHidden = false }: { workspaceHidden?: boolea
           // preparation failure banner + Reprocess live inside PdfPreview.
           <LazyLoadBoundary className="pdf-loading" label="PDF preview" resetKey={resourceResetKey}>
             <Suspense fallback={<div className="pdf-loading">Loading PDF…</div>}>
-              <LazyPdfPreview name={cur.name} />
+              <LazyPdfPreview key={activeTab?.id} name={cur.name} />
             </Suspense>
           </LazyLoadBoundary>
         )}

--- a/web-src/src/components/PdfPreview.tsx
+++ b/web-src/src/components/PdfPreview.tsx
@@ -73,7 +73,7 @@ export function PdfPreview({ name, showConversionBanner = true }: { name: string
   currentRef.current = { folderPath: state.folderPath, name };
   const [doc, setDoc] = useState<PDFDocumentProxy | null>(null);
   const [numPages, setNumPages] = useState(0);
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(activeTab?.pdfPage ?? 1);
   const [scale, setScale] = useState(1);
   const [autoFit, setAutoFit] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -151,7 +151,7 @@ export function PdfPreview({ name, showConversionBanner = true }: { name: string
     setError(null);
     setDoc(null);
     setNumPages(0);
-    setCurrentPage(1);
+    setCurrentPage(activeTab?.pdfPage ?? 1);
     setPageMetrics(null);
     setScale(1);
     setAutoFit(true);
@@ -195,12 +195,44 @@ export function PdfPreview({ name, showConversionBanner = true }: { name: string
     };
   }, [fileUrl, actions]);
 
+  const initialScrollDone = useRef(false);
+  useEffect(() => {
+    initialScrollDone.current = false;
+  }, [fileUrl]);
+
+  useEffect(() => {
+    if (!doc || !pageMetrics || numPages <= 0 || initialScrollDone.current) return;
+    const root = containerRef.current;
+    if (!root || root.clientWidth <= 0) return;
+
+    // Wait for the auto-fit scale to settle before performing the initial scroll jump
+    if (autoFit && Math.abs(scale - fitScale()) > 0.001) return;
+
+    const targetPage = activeTab?.pdfPage ?? 1;
+    if (targetPage > 1 && targetPage <= numPages) {
+      const frame = requestAnimationFrame(() => {
+        scrollToPage(targetPage, 'auto');
+        initialScrollDone.current = true;
+      });
+      return () => cancelAnimationFrame(frame);
+    } else {
+      initialScrollDone.current = true;
+    }
+  }, [doc, pageMetrics, numPages, activeTab?.pdfPage, scale, autoFit]);
+
+  useEffect(() => {
+    if (activeTab && activeTab.file?.format === 'pdf' && activeTab.pdfPage !== currentPage) {
+      actions.updateTabPdfPage(activeTab.id, currentPage);
+    }
+  }, [currentPage, activeTab?.id, activeTab?.file?.format, activeTab?.pdfPage, actions]);
+
   useEffect(() => {
     const root = containerRef.current;
     if (!root || numPages <= 0) return;
     let frame = 0;
     const updateCurrentPage = () => {
       frame = 0;
+      if (!initialScrollDone.current) return;
       const rootRect = root.getBoundingClientRect();
       const markerY = rootRect.top + Math.min(root.clientHeight * 0.35, 160);
       let bestPage = 1;
@@ -688,6 +720,10 @@ function PdfPage({
         if ((err as { name?: string })?.name === 'RenderingCancelledException') return;
         console.error(`[pdf] page ${pageIndex + 1} render failed:`, err);
       });
+    }).catch((err: unknown) => {
+      if (!cancelled) {
+        console.error(`[pdf] page ${pageIndex + 1} load failed:`, err);
+      }
     });
     return () => {
       cancelled = true;

--- a/web-src/src/store/AppContext.tsx
+++ b/web-src/src/store/AppContext.tsx
@@ -124,6 +124,8 @@ export interface AppActions {
    *  (rendered the chunk overlay / kicked off the PDF text search)
    *  so a re-render doesn't re-trigger the effect. */
   consumePendingHighlight: () => void;
+  /** Update the last viewed PDF page for tabId to page. */
+  updateTabPdfPage: (tabId: string, page: number) => void;
   /** Settle the pending cascade dialog with the user's choice. The
    *  rename action awaits this. */
   resolveCascadePrompt: (decision: CascadeDecision) => void;
@@ -438,6 +440,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     closeActiveTab: workspace.closeActiveTab, activateTab: workspace.activateTab,
     navigateTo: workspace.navigateTo, consumePendingScroll: workspace.consumePendingScroll,
     consumePendingHighlight: workspace.consumePendingHighlight,
+    updateTabPdfPage: workspace.updateTabPdfPage,
     resolveCascadePrompt,
     alert: showAlert, confirm: askConfirm, resolveModal,
     toast,

--- a/web-src/src/store/__tests__/state.test.ts
+++ b/web-src/src/store/__tests__/state.test.ts
@@ -283,3 +283,36 @@ test('scope and type filter changes clear both modes\' results', () => {
   const cleared = reducer(scoped, { type: 'SEARCH_SCOPE', scope: null });
   assert.equal(cleared.searchScope, null);
 });
+
+test('PDF page number is retained in tab state, and reset when replacing file', () => {
+  let state = reducer(freshState(), {
+    type: 'FILE_OPEN',
+    body: { name: 'doc1.pdf', format: 'pdf', content: '' },
+    preview: true,
+  });
+  const tabId = state.activeTabId!;
+  assert.equal(state.tabs[0].pdfPage, undefined);
+
+  // Set the PDF page
+  state = reducer(state, { type: 'TAB_PDF_PAGE', id: tabId, page: 4 });
+  assert.equal(state.tabs[0].pdfPage, 4);
+
+  // Open a new tab (not replacing preview)
+  state = reducer(state, {
+    type: 'FILE_OPEN',
+    body: { name: 'doc2.pdf', format: 'pdf', content: '' },
+    newTab: true,
+  });
+  assert.equal(state.tabs.length, 2);
+  assert.equal(state.tabs[0].pdfPage, 4); // retained on the first tab
+  assert.equal(state.tabs[1].pdfPage, undefined); // undefined on the second tab
+
+  // Reuse preview tab to open another file (doc3.pdf) -> should clear the pdfPage
+  state = reducer(state, { type: 'ACTIVATE_TAB', id: tabId });
+  state = reducer(state, {
+    type: 'FILE_OPEN',
+    body: { name: 'doc3.pdf', format: 'pdf', content: '' },
+    preview: true,
+  });
+  assert.equal(state.tabs[0].pdfPage, undefined); // reset / not leaked from doc1.pdf
+});

--- a/web-src/src/store/state.ts
+++ b/web-src/src/store/state.ts
@@ -103,6 +103,7 @@ export interface Tab {
    *  the user navigates to a different file. */
   pendingHighlight: PendingHighlight | null;
   saveStatus: SaveStatus;
+  pdfPage?: number;
 }
 
 /** Search-hit-derived highlight signal: which lines (for HTML / MD /
@@ -482,6 +483,7 @@ export type Action =
    *  Triggered by double-click on a sidebar file, double-click on the
    *  tab title, or entering edit mode on the tab. */
   | { type: 'PROMOTE_TAB'; id: string }
+  | { type: 'TAB_PDF_PAGE'; id: string; page: number }
   /** Move tab `id` to immediately before tab `beforeId` (drag-reorder).
    *  `beforeId === null` appends to the end. No-op when the relative
    *  position wouldn't change — keeps the reducer idempotent so a

--- a/web-src/src/store/stateReducer.ts
+++ b/web-src/src/store/stateReducer.ts
@@ -129,6 +129,7 @@ export function reducer(s: State, a: Action): State {
           saveStatus: { text: '', cls: '' },
           pendingAnchor: null,
           pendingHighlight: null,
+          pdfPage: undefined,
           // Only touch `preview` when explicitly asked — in-place anchor
           // nav reuses the same tab and must keep its existing
           // preview/pinned status.
@@ -463,6 +464,11 @@ export function reducer(s: State, a: Action): State {
       return {
         ...s,
         tabs: s.tabs.map((t) => (t.id === a.id ? { ...t, preview: false } : t)),
+      };
+    case 'TAB_PDF_PAGE':
+      return {
+        ...s,
+        tabs: s.tabs.map((t) => (t.id === a.id ? { ...t, pdfPage: a.page } : t)),
       };
     case 'TABS_REORDER': {
       const fromIdx = s.tabs.findIndex((t) => t.id === a.id);

--- a/web-src/src/store/useActiveFolderWorkspace.ts
+++ b/web-src/src/store/useActiveFolderWorkspace.ts
@@ -60,6 +60,7 @@ export interface ActiveFolderWorkspace {
   consumePendingScroll: () => void;
   consumePendingHighlight: () => void;
   toggleEditMode: () => Promise<void>;
+  updateTabPdfPage: (tabId: string, page: number) => void;
   newNote: () => Promise<void>;
   newFolder: (path: string) => Promise<void>;
   deleteFile: (name: string) => Promise<void>;
@@ -266,6 +267,7 @@ export function useActiveFolderWorkspace(
     documents.selectFile,
     documents.selectFileWithHighlight,
     documents.toggleEditMode,
+    documents.updateTabPdfPage,
     files.deleteFile,
     files.deleteFolder,
     files.moveFile,

--- a/web-src/src/store/useDocumentActions.ts
+++ b/web-src/src/store/useDocumentActions.ts
@@ -338,6 +338,10 @@ export function useDocumentActions(
     editor.current = handle;
   }, [editor]);
 
+  const updateTabPdfPage = useCallback((tabId: string, page: number) => {
+    dispatch({ type: 'TAB_PDF_PAGE', id: tabId, page });
+  }, [dispatch]);
+
   return {
     activateTab,
     closeActiveTab,
@@ -353,5 +357,6 @@ export function useDocumentActions(
     selectFile,
     selectFileWithHighlight,
     toggleEditMode,
+    updateTabPdfPage,
   };
 }


### PR DESCRIPTION
## Summary

- **React Key Isolation**: Added `key={activeTab?.id}` to `<LazyPdfPreview>` inside `MainPane.tsx`. This forces React to cleanly unmount the previous PDF preview component and mount a fresh, isolated one when switching tabs, preventing layout state leaks.
- **Stable Scroll Restoration**: Coordinated the scroll restoration effect in `PdfPreview.tsx` to wait until the container width is measured (greater than 0) and the auto-fit scale has fully settled (`Math.abs(scale - fitScale()) > 0.001` check) before executing the scroll jump.
- **Graceful Cancelation**: Handled promise rejections in `doc.getPage(...)` in `PdfPreview.tsx` to gracefully swallow `Transport destroyed` exceptions when the PDF document worker/transport is destroyed during unmounting.
- **Unit Tests**: Added a unit test suite verifying tab-specific PDF page isolation, tab switches, and file reuse.

## Validation

- Open two PDF tabs, scroll to page 3 on Tab 1 and page 2 on Tab 2. Switch repeatedly in both directions and assert that the correct page numbers are retained and scrolled to instantly.
- Open a `.md` file in a new tab, switch back to the PDF tabs, and verify they retain their page numbers without shifting back to page 1 or intermediate pages.
- Close a PDF tab and re-open it to verify the page number resets to 1.
- Switch tabs rapidly and check that no uncaught exceptions (`Transport destroyed`) appear in the browser console.
- Run typecheck (`pnpm typecheck`) and renderer unit tests (`pnpm test:renderer`) and confirm all tests pass successfully.

## Why

Switching between open PDF tabs currently reuses the same component instance of `PdfPreview` because React does not automatically unmount sibling components of the same type. When the document changes, layout shifts and temporary `scrollTop = 0` snaps trigger scroll events that run against the new active tab's state. This overwrites its saved page number with 1 (or intermediate pages) before the scroll restoration effect can execute, losing the reader's place.

Closes #128

---

### Demo

https://www.loom.com/share/00e11502ac884878aa25b54080a55108