### PR TITLE
feat(library): explain and gracefully handle unsupported files (#127)

### DIFF
--- a/design-docs/design/library.md
+++ b/design-docs/design/library.md
@@ -73,6 +73,7 @@ to migrate them into a StashBase-specific storage model.
 - The Files sidebar is a calm orientation tool, not a separate knowledge graph
   or project-management surface. It groups the file tree and the active
   Markdown document outline into independently collapsible navigation sections.
+- StashBase displays only supported document and media formats in the Files panel. Unsupported files are classified into source-code/project files and other unsupported formats. Folders that contain only unsupported files are pruned from the directory tree to keep navigation clean, while physically empty folders and folders with supported files remain visible. Users are notified of hidden unsupported files via a first-time onboarding explanation modal and a persistent callout banner in the Files panel.
 - Quick Open is file navigation, not content retrieval: it stays scoped to the
   active folder and does not surface generated artifacts or search evidence.
 - Command Palette exposes only safe, context-available actions the app already

--- a/server/__tests__/file-listing.test.ts
+++ b/server/__tests__/file-listing.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { clearCurrentFolder, setCurrentFolder } from '../folder.ts';
+import { listFilesAndFolders } from '../file-listing.ts';
+
+test('file-listing scan and classification', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-listing-test-'));
+
+  try {
+    // Set up test folder structure
+    // 1. Root supported file
+    fs.writeFileSync(path.join(tempDir, 'note1.md'), 'Heading 1\nSome content');
+
+    // 2. Folder containing supported files (should keep folder + files)
+    const folderSupported = path.join(tempDir, 'docs');
+    fs.mkdirSync(folderSupported);
+    fs.writeFileSync(path.join(folderSupported, 'note2.html'), '<h1>HTML Note</h1>');
+
+    // 3. Folder containing ONLY unsupported files (should prune folder)
+    const folderCodeOnly = path.join(tempDir, 'src');
+    fs.mkdirSync(folderCodeOnly);
+    fs.writeFileSync(path.join(folderCodeOnly, 'main.ts'), 'console.log("hello")');
+    fs.writeFileSync(path.join(folderCodeOnly, 'utils.py'), 'def add(a, b): return a + b');
+
+    // 4. Folder containing mixed files (should keep folder, return supported, count unsupported)
+    const folderMixed = path.join(tempDir, 'mixed');
+    fs.mkdirSync(folderMixed);
+    fs.writeFileSync(path.join(folderMixed, 'note3.md'), '# Markdown');
+    fs.writeFileSync(path.join(folderMixed, 'data.csv'), '1,2,3');
+    fs.writeFileSync(path.join(folderMixed, 'archive.zip'), '');
+    fs.writeFileSync(path.join(folderMixed, 'config.json'), '{}');
+
+    // 5. Excluded directory (should not traverse, count, or return)
+    const folderExcluded = path.join(tempDir, 'node_modules');
+    fs.mkdirSync(folderExcluded);
+    fs.writeFileSync(path.join(folderExcluded, 'index.js'), 'module.exports = {}');
+
+    // 6. Physically empty folder (should keep folder)
+    const folderEmpty = path.join(tempDir, 'empty-dir');
+    fs.mkdirSync(folderEmpty);
+
+    // Run listing scan
+    setCurrentFolder(tempDir);
+    const result = listFilesAndFolders();
+
+    // Verify folders list (pruning validation)
+    // - Should keep 'docs', 'mixed', and 'empty-dir'
+    // - Should prune 'src' (code only) and 'node_modules' (excluded)
+    const folderPaths = result.folders.map((f) => f.path);
+    assert.ok(folderPaths.includes('docs'));
+    assert.ok(folderPaths.includes('mixed'));
+    assert.ok(folderPaths.includes('empty-dir'));
+    assert.ok(!folderPaths.includes('src'), 'src directory (code only) should be pruned');
+    assert.ok(!folderPaths.includes('node_modules'), 'node_modules directory should be excluded');
+
+    // Verify files list
+    const fileNames = result.files.map((f) => f.name);
+    assert.ok(fileNames.includes('note1.md'));
+    assert.ok(fileNames.includes('docs/note2.html'));
+    assert.ok(fileNames.includes('mixed/note3.md'));
+    assert.ok(!fileNames.includes('src/main.ts'), 'unsupported files should not be in the files list');
+
+    // Verify unsupported files counts
+    // 'src/main.ts' (.ts) -> source
+    // 'src/utils.py' (.py) -> source
+    // Total sourceCode = 2
+    assert.equal(result.unsupportedFiles.sourceCode, 2);
+
+    // 'mixed/data.csv' (.csv) -> other
+    // 'mixed/archive.zip' (.zip) -> other
+    // 'mixed/config.json' (.json) -> other
+    // Total other = 3
+    assert.equal(result.unsupportedFiles.other, 3);
+
+    // Verify otherExtensions mapping and sorting
+    // Extensions: .csv (1), .zip (1), .json (1)
+    // Since counts are equal, they should be sorted alphabetically: .csv, .json, .zip
+    const exts = result.unsupportedFiles.otherExtensions;
+    assert.equal(exts.length, 3);
+    assert.deepEqual(exts[0], { extension: '.csv', count: 1 });
+    assert.deepEqual(exts[1], { extension: '.json', count: 1 });
+    assert.deepEqual(exts[2], { extension: '.zip', count: 1 });
+
+  } finally {
+    clearCurrentFolder();
+    // Recursively clean up the temp directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -121,6 +121,12 @@ export interface AppConfigFile {
   /** Bounded, user-wide presentation preferences. These deliberately avoid
    * arbitrary theme, font, spacing, and layout customization. */
   appearance?: Partial<AppearancePreferences>;
+  onboarding?: OnboardingPreferences;
+}
+
+export interface OnboardingPreferences {
+  sourceCodeNoticeVersion?: number;
+  unsupportedFormatsNoticeVersion?: number;
 }
 
 export function readAppConfigStrict(): AppConfigFile {
@@ -349,4 +355,20 @@ export function migrateLegacyEmbedderConfig(): void {
   delete cfg.embedder.openaiKey;
   writeAppConfig(cfg);
   log.info('migrated legacy embedder.openaiKey into active embedder config');
+}
+
+export function getOnboardingPreferences(): OnboardingPreferences {
+  return readAppConfig().onboarding ?? {};
+}
+
+export function setOnboardingPreferences(next: Partial<OnboardingPreferences>): OnboardingPreferences {
+  const cfg = readAppConfig();
+  const current = cfg.onboarding ?? {};
+  const updated = {
+    ...current,
+    ...next,
+  };
+  cfg.onboarding = updated;
+  writeAppConfigStrict(cfg);
+  return updated;
 }

--- a/server/file-listing.ts
+++ b/server/file-listing.ts
@@ -29,9 +29,19 @@ export interface FolderEntry {
   path: string;
 }
 
+export interface UnsupportedFileSummary {
+  sourceCode: number;
+  other: number;
+  otherExtensions: Array<{
+    extension: string;
+    count: number;
+  }>;
+}
+
 export interface FolderListing {
   files: FileEntry[];
   folders: FolderEntry[];
+  unsupportedFiles: UnsupportedFileSummary;
 }
 
 /** Per-file preview cache keyed by absolute path. Avoids re-reading
@@ -46,50 +56,219 @@ const previewCache = new Map<string, PreviewCacheEntry>();
 
 onSwitch(() => previewCache.clear());
 
-/** Recursive walk of the folder. Returns every visible subfolder plus every
- *  recognised note/viewer file. */
-export function listFilesAndFolders(): FolderListing {
-  const root = folderRoot();
+const SOURCE_EXTENSIONS = new Set<string>([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  '.py', '.pyw',
+  '.go', '.rs',
+  '.java', '.kt', '.kts', '.scala',
+  '.c', '.h', '.cc', '.cpp', '.cxx', '.hpp',
+  '.cs',
+  '.rb', '.php',
+  '.swift', '.m', '.mm',
+  '.dart',
+  '.ex', '.exs',
+  '.lua', '.r',
+  '.sh', '.bash', '.zsh', '.fish', '.ps1',
+  '.sql',
+  '.vue', '.svelte',
+  '.css', '.scss', '.less',
+  '.ipynb',
+]);
+
+const SOURCE_BASENAMES = new Set<string>([
+  'dockerfile',
+  'makefile',
+  'cmakelists.txt',
+]);
+
+function classifyUnsupportedFile(name: string): 'source' | 'other' {
+  const base = name.toLowerCase();
+  if (SOURCE_BASENAMES.has(base)) return 'source';
+
+  const ext = path.extname(name).toLowerCase();
+  if (SOURCE_EXTENSIONS.has(ext)) return 'source';
+
+  return 'other';
+}
+
+function getNormalizedExtension(name: string): string {
+  const ext = path.extname(name).toLowerCase();
+  return ext === '' ? 'no extension' : ext;
+}
+
+interface UnsupportedInfo {
+  sourceCode: number;
+  other: number;
+  otherExtensions: Record<string, number>;
+}
+
+interface ScanResult {
+  isKept: boolean;
+  files: FileEntry[];
+  folders: FolderEntry[];
+  unsupportedFiles: UnsupportedInfo;
+}
+
+function scanDirectory(dir: string, prefix: string): ScanResult {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return {
+      isKept: false,
+      files: [],
+      folders: [],
+      unsupportedFiles: { sourceCode: 0, other: 0, otherExtensions: {} },
+    };
+  }
+
+  const noteStems = new Set<string>();
+  const legacyDerivedStems = new Set<string>();
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    const m = e.name.match(/^(.+)\.(md|markdown|html|htm|pdf)$/i);
+    if (m) noteStems.add(m[1]);
+    const src = e.name.match(LEGACY_DERIVED_SOURCE_RE);
+    if (src) legacyDerivedStems.add(src[1]);
+  }
+
+  const acceptedEntries: fs.Dirent[] = [];
+  for (const e of entries) {
+    if (isCloudPlaceholderName(e.name)) continue;
+    if (e.name.startsWith('.') && HIDDEN_DOT_DIRS.has(e.name)) continue;
+    if (e.isDirectory() && isIndexExcludedDirName(e.name)) continue;
+    if (e.isFile() && e.name.startsWith('.')) {
+      if (isDerivedScratchName(e.name)) continue;
+      if (isDerivedNoteName(e.name)) continue;
+      if (isLegacyDerivedNoteName(e.name, legacyDerivedStems)) continue;
+    }
+    if (e.isDirectory() && e.name.endsWith('_files')) {
+      const stem = e.name.slice(0, -'_files'.length);
+      if (noteStems.has(stem)) continue;
+      if (stem.startsWith('.')) continue;
+    }
+    if (e.isDirectory() && isDerivedScratchName(e.name)) continue;
+
+    acceptedEntries.push(e);
+  }
+
+  // If there are no accepted entries, this folder is physically empty.
+  if (acceptedEntries.length === 0) {
+    return {
+      isKept: true,
+      files: [],
+      folders: prefix ? [{ path: prefix }] : [],
+      unsupportedFiles: { sourceCode: 0, other: 0, otherExtensions: {} },
+    };
+  }
+
   const files: FileEntry[] = [];
   const folders: FolderEntry[] = [];
-  const seen = new Set<string>();
-  walk(root, '', (rel, full, ent) => {
-    if (ent.isDirectory()) {
-      folders.push({ path: rel });
-      return;
-    }
-    if (!ent.isFile()) return;
-    if (ent.name.endsWith('.tmp')) return;
-    const format = detectViewerFormat(ent.name);
-    if (!format) return;
-    let st: fs.Stats;
-    try { st = fs.statSync(full); } catch { return; }
-    seen.add(full);
+  const unsupportedFiles: UnsupportedInfo = { sourceCode: 0, other: 0, otherExtensions: {} };
+  let hasSupportedInSubtree = false;
+  let hasKeptSubfolder = false;
 
-    const cached = previewCache.get(full);
-    let entry: Pick<FileEntry, 'heading' | 'snippet' | 'imported_at'>;
-    if (cached && cached.mtimeMs === st.mtimeMs) {
-      entry = { heading: cached.heading, snippet: cached.snippet, imported_at: cached.imported_at };
-    } else if (format === 'pdf' || format === 'image' || format === 'docx' || format === 'audio') {
-      const imported_at = st.mtime.toISOString();
-      previewCache.set(full, { mtimeMs: st.mtimeMs, heading: '', snippet: '', imported_at });
-      entry = { heading: '', snippet: '', imported_at };
-    } else {
-      let content: string;
-      try { content = fs.readFileSync(full, 'utf8'); } catch { return; }
-      const { heading, snippet } = preview(content, format);
-      const imported_at = st.mtime.toISOString();
-      previewCache.set(full, { mtimeMs: st.mtimeMs, heading, snippet, imported_at });
-      entry = { heading, snippet, imported_at };
+  for (const e of acceptedEntries) {
+    const rel = prefix ? `${prefix}/${e.name}` : e.name;
+    const full = path.join(dir, e.name);
+
+    if (e.isDirectory()) {
+      const subResult = scanDirectory(full, rel);
+      if (subResult.isKept) {
+        hasKeptSubfolder = true;
+        files.push(...subResult.files);
+        folders.push(...subResult.folders);
+      }
+      unsupportedFiles.sourceCode += subResult.unsupportedFiles.sourceCode;
+      unsupportedFiles.other += subResult.unsupportedFiles.other;
+      for (const [ext, count] of Object.entries(subResult.unsupportedFiles.otherExtensions)) {
+        unsupportedFiles.otherExtensions[ext] = (unsupportedFiles.otherExtensions[ext] ?? 0) + count;
+      }
+    } else if (e.isFile()) {
+      if (e.name.endsWith('.tmp')) continue;
+
+      const format = detectViewerFormat(e.name);
+      if (format) {
+        hasSupportedInSubtree = true;
+        let st: fs.Stats;
+        try { st = fs.statSync(full); } catch { continue; }
+
+        const cached = previewCache.get(full);
+        let entry: Pick<FileEntry, 'heading' | 'snippet' | 'imported_at'>;
+        if (cached && cached.mtimeMs === st.mtimeMs) {
+          entry = { heading: cached.heading, snippet: cached.snippet, imported_at: cached.imported_at };
+        } else if (format === 'pdf' || format === 'image' || format === 'docx' || format === 'audio') {
+          const imported_at = st.mtime.toISOString();
+          previewCache.set(full, { mtimeMs: st.mtimeMs, heading: '', snippet: '', imported_at });
+          entry = { heading: '', snippet: '', imported_at };
+        } else {
+          let content: string;
+          try { content = fs.readFileSync(full, 'utf8'); } catch { continue; }
+          const { heading, snippet } = preview(content, format);
+          const imported_at = st.mtime.toISOString();
+          previewCache.set(full, { mtimeMs: st.mtimeMs, heading, snippet, imported_at });
+          entry = { heading, snippet, imported_at };
+        }
+        files.push({ name: rel, format, size: st.size, ...entry });
+      } else {
+        const classification = classifyUnsupportedFile(e.name);
+        if (classification === 'source') {
+          unsupportedFiles.sourceCode++;
+        } else {
+          unsupportedFiles.other++;
+          const ext = getNormalizedExtension(e.name);
+          unsupportedFiles.otherExtensions[ext] = (unsupportedFiles.otherExtensions[ext] ?? 0) + 1;
+        }
+      }
     }
-    files.push({ name: rel, format, size: st.size, ...entry });
-  });
+  }
+
+  const isKept = hasSupportedInSubtree || hasKeptSubfolder;
+  if (isKept && prefix) {
+    folders.push({ path: prefix });
+  }
+
+  return {
+    isKept,
+    files,
+    folders,
+    unsupportedFiles,
+  };
+}
+
+export function listFilesAndFolders(): FolderListing {
+  const root = folderRoot();
+  const scanResult = scanDirectory(root, '');
+
+  const otherExtensions = Object.entries(scanResult.unsupportedFiles.otherExtensions)
+    .map(([extension, count]) => ({ extension, count }))
+    .sort((a, b) => {
+      if (a.count !== b.count) {
+        return b.count - a.count;
+      }
+      return a.extension.localeCompare(b.extension);
+    });
+
+  const seen = new Set<string>();
+  for (const f of scanResult.files) {
+    seen.add(path.join(root, f.name));
+  }
   for (const key of previewCache.keys()) {
     if (!seen.has(key)) previewCache.delete(key);
   }
-  files.sort((a, b) => (a.name < b.name ? -1 : 1));
-  folders.sort((a, b) => (a.path < b.path ? -1 : 1));
-  return { files, folders };
+
+  scanResult.files.sort((a, b) => (a.name < b.name ? -1 : 1));
+  scanResult.folders.sort((a, b) => (a.path < b.path ? -1 : 1));
+
+  return {
+    files: scanResult.files,
+    folders: scanResult.folders,
+    unsupportedFiles: {
+      sourceCode: scanResult.unsupportedFiles.sourceCode,
+      other: scanResult.unsupportedFiles.other,
+      otherExtensions,
+    },
+  };
 }
 
 export function listFiles(): FileEntry[] {

--- a/server/index.ts
+++ b/server/index.ts
@@ -66,6 +66,7 @@ import { blake3File } from './file-hash.ts';
 import { mount as mountSessionsRoutes } from './routes/sessions.ts';
 import { mount as mountCodexSessionsRoutes } from './routes/codex-sessions.ts';
 import { mount as mountAgentSessionsRoutes } from './routes/agent-sessions.ts';
+import { mount as mountOnboardingRoutes } from './routes/onboarding.ts';
 import { BUILT_IN_AGENT_ADAPTERS } from './agent-adapters.ts';
 
 const log = logger('server');
@@ -276,6 +277,7 @@ if (!DEV_VITE) {
 // before a window has an open folder, so mount them before the gate.
 mountWindowContextRoutes(app);
 mountLibraryRoutes(app);
+mountOnboardingRoutes(app);
 
 // Route-prefix gate: every API path under these roots needs an open
 // folder. Centralises the NO_FOLDER 412 response so individual handlers

--- a/server/routes/files.ts
+++ b/server/routes/files.ts
@@ -58,6 +58,7 @@ export function mount(app: express.Express): void {
         folder: getCurrentFolderLabel() ?? getCurrentFolderBasename(),
         files: listing.files,
         folders: listing.folders,
+        unsupportedFiles: listing.unsupportedFiles,
       });
     } catch (err: unknown) {
       sendError(res, err);

--- a/server/routes/onboarding.ts
+++ b/server/routes/onboarding.ts
@@ -1,0 +1,22 @@
+/** User-wide onboarding preferences for feature explanation dialogs. */
+import type express from 'express';
+import {
+  getOnboardingPreferences,
+  setOnboardingPreferences,
+} from '../app-config.ts';
+import { sendError } from '../http.ts';
+
+export function mount(app: express.Express): void {
+  app.get('/api/onboarding', (_req, res) => {
+    res.json(getOnboardingPreferences());
+  });
+
+  app.put('/api/onboarding', (req, res) => {
+    const body = req.body ?? {};
+    try {
+      res.json(setOnboardingPreferences(body));
+    } catch (err: unknown) {
+      sendError(res, err);
+    }
+  });
+}

--- a/web-src/src/App.tsx
+++ b/web-src/src/App.tsx
@@ -61,6 +61,9 @@ import {
 } from './workspaceLayout';
 
 const LazyChatPane = lazyWithRetry(() => import('./components/ChatPane').then((mod) => ({ default: mod.ChatPane })));
+const LazyUnsupportedFilesModalGate = lazyWithRetry(() =>
+  import('./components/UnsupportedFilesModal').then((mod) => ({ default: mod.UnsupportedFilesModalGate })),
+);
 
 /**
  * Top-level shell. Wraps everything in <AppProvider> (the single
@@ -374,6 +377,9 @@ function AppBody() {
         />
       )}
       <CascadePromptModal />
+      <Suspense fallback={null}>
+        <LazyUnsupportedFilesModalGate />
+      </Suspense>
       <AlertConfirmModal />
       <Toasts />
       {!state.welcomeVisible && <EmbedderRequireKeyGate />}

--- a/web-src/src/api.ts
+++ b/web-src/src/api.ts
@@ -28,6 +28,7 @@ import type {
   AudioTranscriptState,
   AudioPreviewStatus,
   UploadResult,
+  OnboardingPreferences,
 } from './apiTypes';
 import type { SearchTypeCategory } from '../../shared/search-types.ts';
 import {
@@ -75,6 +76,10 @@ export const api = {
   // Files / folders listing --------------------------------------
   listFiles: () => getJson<FilesPayload>('/api/files'),
   statFile: (name: string) => head('/api/files/' + encodePath(name)),
+
+  getOnboarding: () => getJson<OnboardingPreferences>('/api/onboarding'),
+  putOnboarding: (patch: Partial<OnboardingPreferences>) =>
+    send<OnboardingPreferences>('PUT', '/api/onboarding', patch),
 
   // CRUD ---------------------------------------------------------
   createNote: (content: string, dir: string) =>

--- a/web-src/src/apiTypes.ts
+++ b/web-src/src/apiTypes.ts
@@ -74,10 +74,25 @@ export interface FolderState {
   homeDir?: string;
 }
 
+export interface UnsupportedFileSummary {
+  sourceCode: number;
+  other: number;
+  otherExtensions: Array<{
+    extension: string;
+    count: number;
+  }>;
+}
+
+export interface OnboardingPreferences {
+  sourceCodeNoticeVersion?: number;
+  unsupportedFormatsNoticeVersion?: number;
+}
+
 export interface FilesPayload {
   files: FileMeta[];
   folders: FolderMeta[];
   folder: string;
+  unsupportedFiles?: UnsupportedFileSummary;
 }
 
 export interface FileBody {

--- a/web-src/src/components/FileTree.tsx
+++ b/web-src/src/components/FileTree.tsx
@@ -152,6 +152,18 @@ export function FileTree() {
 
   const inputAtRoot = state.newFolderInputOpen && state.activeFolder === '';
   if (root.children.length === 0 && !inputAtRoot) {
+    const { sourceCode = 0, other = 0 } = state.unsupportedFiles || {};
+    const total = sourceCode + other;
+    if (total > 0) {
+      return (
+        <div className="empty-list">
+          <div style={{ fontWeight: 600, color: 'var(--fg)', marginBottom: '4px' }}>No supported files found</div>
+          <div style={{ fontSize: '11px', opacity: 0.8, lineHeight: 1.4 }}>
+            StashBase found {total} file{total === 1 ? '' : 's'} in this folder, but none can currently be displayed or indexed. Nothing on disk was changed.
+          </div>
+        </div>
+      );
+    }
     return <div className="empty-list">No notes yet — click + to create one</div>;
   }
   return (

--- a/web-src/src/components/Sidebar.tsx
+++ b/web-src/src/components/Sidebar.tsx
@@ -124,6 +124,7 @@ function FilesPanel() {
             </div>
           </div>
           <div className={'file-list' + (state.folderCollapsed ? ' collapsed' : '')}>
+            <UnsupportedFilesCallout />
             <FileTree />
           </div>
         </div>
@@ -342,5 +343,81 @@ function FolderFoldToggle() {
         }
       }}
     >{allCollapsed ? <ExpandAllIcon /> : <CollapseAllIcon />}</button>
+  );
+}
+
+function formatExtensions(otherExtensions: Array<{ extension: string; count: number }>): string {
+  const list = otherExtensions.map((e) => e.extension);
+  const top3 = list.slice(0, 3);
+  const remaining = list.length - 3;
+  let base = top3.join(', ');
+  if (remaining > 0) {
+    base += ` and ${remaining} more format${remaining === 1 ? '' : 's'}`;
+  }
+  return base;
+}
+
+function UnsupportedFilesCallout() {
+  const { state, dispatch } = useApp();
+  const { sourceCode = 0, other = 0, otherExtensions = [] } = state.unsupportedFiles || {};
+  const total = sourceCode + other;
+
+  if (total === 0 || state.welcomeVisible) return null;
+
+  const showSource = sourceCode > 0;
+  const showOther = other > 0;
+
+  let title = '';
+  let body: React.ReactNode = null;
+
+  if (showSource && showOther) {
+    title = 'Some files are hidden';
+    body = (
+      <>
+        {sourceCode} source-code files &middot; {other} other unsupported files
+      </>
+    );
+  } else if (showSource) {
+    title = 'Source code is hidden';
+    body = (
+      <>
+        {sourceCode} source-code and project files are not shown or indexed. Nothing on disk was changed.
+      </>
+    );
+  } else if (showOther) {
+    title = 'Some file formats are hidden';
+    const extList = formatExtensions(otherExtensions);
+    body = (
+      <>
+        {other} unsupported files ({extList}) are not shown or indexed.
+      </>
+    );
+  }
+
+  return (
+    <div className="unsupported-files-banner">
+      <svg
+        style={{ width: '16px', height: '16px', flexShrink: 0, marginTop: '2px', color: 'var(--muted)' }}
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <div className="unsupported-files-banner-copy">
+        <div className="unsupported-files-banner-title">{title}</div>
+        <div style={{ fontSize: '11px', opacity: 0.9 }}>
+          {body}
+          <button
+            type="button"
+            className="unsupported-files-details-btn"
+            onClick={() => dispatch({ type: 'UNSUPPORTED_MODAL', open: true })}
+          >
+            Details
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/web-src/src/components/UnsupportedFilesModal.tsx
+++ b/web-src/src/components/UnsupportedFilesModal.tsx
@@ -1,0 +1,143 @@
+import { useEffect } from 'react';
+import { ModalShell } from './ModalShell';
+import { api, type OnboardingPreferences, type UnsupportedFileSummary } from '../api';
+import { useApp } from '../store/AppContext';
+
+interface UnsupportedFilesModalProps {
+  unsupportedFiles: UnsupportedFileSummary;
+  onClose: () => void;
+}
+
+function formatExtensions(otherExtensions: Array<{ extension: string; count: number }>): string {
+  const list = otherExtensions.map((e) => e.extension);
+  const top3 = list.slice(0, 3);
+  const remaining = list.length - 3;
+  let base = top3.join(', ');
+  if (remaining > 0) {
+    base += ` and ${remaining} more format${remaining === 1 ? '' : 's'}`;
+  }
+  return base;
+}
+
+export function UnsupportedFilesModal({ unsupportedFiles, onClose }: UnsupportedFilesModalProps) {
+  const { sourceCode, other, otherExtensions = [] } = unsupportedFiles;
+
+  // Decide copy based on counts
+  const showSource = sourceCode > 0;
+  const showOther = other > 0;
+
+  if (showSource && showOther) {
+    // Combined Modal
+    const extList = formatExtensions(otherExtensions);
+    return (
+      <ModalShell title="Some files in this folder aren't supported" onCancel={onClose} top>
+        <div className="unsupported-files-modal-content space-y-4">
+          <ul className="list-disc pl-5 space-y-2 text-sm text-imglytext/80 dark:text-dark-imglytext/80">
+            <li>
+              <strong>{sourceCode} source-code and project files</strong> are not shown or indexed.
+            </li>
+            <li>
+              <strong>{other} files in other unsupported formats</strong> are not shown or indexed: {extList}.
+            </li>
+          </ul>
+          <p className="text-sm text-imglytext/60 dark:text-dark-imglytext/60">
+            These files remain unchanged on disk, but they will not appear in the Files view or StashBase search.
+          </p>
+        </div>
+        <div className="modal-actions flex justify-end mt-6">
+          <button type="button" className="modal-btn primary" onClick={onClose}>
+            Continue with supported files
+          </button>
+        </div>
+      </ModalShell>
+    );
+  }
+
+  if (showSource) {
+    // Source code only
+    return (
+      <ModalShell title="Source code files aren't supported" onCancel={onClose} top>
+        <div className="unsupported-files-modal-content space-y-3">
+          <p className="text-sm text-imglytext/80 dark:text-dark-imglytext/80">
+            StashBase found <strong>{sourceCode} source-code and project files</strong> in this folder.
+          </p>
+          <p className="text-sm text-imglytext/60 dark:text-dark-imglytext/60">
+            StashBase currently shows and indexes supported documents and media, not source code. These files remain unchanged on disk, but they will not appear in the Files view or StashBase search.
+          </p>
+        </div>
+        <div className="modal-actions flex justify-end mt-6">
+          <button type="button" className="modal-btn primary" onClick={onClose}>
+            Continue with supported files
+          </button>
+        </div>
+      </ModalShell>
+    );
+  }
+
+  if (showOther) {
+    // Other formats only
+    const extList = formatExtensions(otherExtensions);
+    return (
+      <ModalShell title="Some file formats aren't supported yet" onCancel={onClose} top>
+        <div className="unsupported-files-modal-content space-y-3">
+          <p className="text-sm text-imglytext/80 dark:text-dark-imglytext/80">
+            StashBase found <strong>{other} files in unsupported formats</strong>: {extList}.
+          </p>
+          <p className="text-sm text-imglytext/60 dark:text-dark-imglytext/60">
+            These files remain unchanged on disk, but they will not appear in the Files view or StashBase search.
+          </p>
+        </div>
+        <div className="modal-actions flex justify-end mt-6">
+          <button type="button" className="modal-btn primary" onClick={onClose}>
+            Continue with supported files
+          </button>
+        </div>
+      </ModalShell>
+    );
+  }
+
+  return null;
+}
+
+export function UnsupportedFilesModalGate() {
+  const { state, dispatch } = useApp();
+  const { sourceCode = 0, other = 0 } = state.unsupportedFiles || {};
+  const total = sourceCode + other;
+
+  useEffect(() => {
+    if (total === 0 || state.welcomeVisible) return;
+    let mounted = true;
+    api.getOnboarding().then((prefs) => {
+      if (!mounted) return;
+      const needsSourceNotice = sourceCode > 0 && (prefs.sourceCodeNoticeVersion ?? 0) < 1;
+      const needsOtherNotice = other > 0 && (prefs.unsupportedFormatsNoticeVersion ?? 0) < 1;
+      if (needsSourceNotice || needsOtherNotice) {
+        dispatch({ type: 'UNSUPPORTED_MODAL', open: true });
+      }
+    }).catch(() => {});
+    return () => { mounted = false; };
+  }, [dispatch, state.welcomeVisible, state.folderPath, state.folder, total, sourceCode, other]);
+
+  if (!state.unsupportedModalOpen || total === 0 || state.welcomeVisible) return null;
+
+  async function handleClose() {
+    dispatch({ type: 'UNSUPPORTED_MODAL', open: false });
+    const patch: Partial<OnboardingPreferences> = {};
+    if (sourceCode > 0) patch.sourceCodeNoticeVersion = 1;
+    if (other > 0) patch.unsupportedFormatsNoticeVersion = 1;
+    if (Object.keys(patch).length > 0) {
+      try {
+        await api.putOnboarding(patch);
+      } catch (err) {
+        console.warn('Failed to update onboarding preferences', err);
+      }
+    }
+  }
+
+  return (
+    <UnsupportedFilesModal
+      unsupportedFiles={state.unsupportedFiles!}
+      onClose={handleClose}
+    />
+  );
+}

--- a/web-src/src/store/AppContext.tsx
+++ b/web-src/src/store/AppContext.tsx
@@ -155,6 +155,7 @@ export interface AppActions {
     },
   ) => string;
   toggleEditMode: () => Promise<void>;
+  setUnsupportedModalOpen: (open: boolean) => void;
   /** Reveal an existing Agent Panel session or create its first tab. This only
    * changes renderer layout; permissions and Agent context remain unchanged. */
   openAgent: (agent: AgentKind) => void;
@@ -285,6 +286,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       folders: j.folders ?? [],
       folder: j.folder ?? 'notes',
       folderPath: expectedFolderPath,
+      unsupportedFiles: j.unsupportedFiles,
     });
     return files;
   }, []);
@@ -445,6 +447,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     alert: showAlert, confirm: askConfirm, resolveModal,
     toast,
     toggleEditMode: workspace.toggleEditMode,
+    setUnsupportedModalOpen: workspace.setUnsupportedModalOpen,
     openAgent: (agent) => {
       rememberPreferredAgent(agent);
       const current = stateRef.current;

--- a/web-src/src/store/__tests__/state.test.ts
+++ b/web-src/src/store/__tests__/state.test.ts
@@ -339,3 +339,42 @@ test('PDF page numbers are isolated per tab and reset when replacing a file', ()
   });
   assert.equal(state.tabs[0].pdfPage, undefined); // reset / not leaked from doc1.pdf
 });
+
+test('FILES_LOADED captures unsupportedFiles and folder change resets modal state', () => {
+  const summary = {
+    sourceCode: 3,
+    other: 1,
+    otherExtensions: [{ extension: '.zip', count: 1 }],
+  };
+
+  let state = reducer(freshState({ unsupportedModalOpen: true }), {
+    type: 'FILES_LOADED',
+    files: [],
+    folders: [],
+    folder: 'notes',
+    folderPath: '/notes',
+    unsupportedFiles: summary,
+  });
+
+  assert.deepEqual(state.unsupportedFiles, summary);
+
+  state = reducer(state, {
+    type: 'FILES_LOADED',
+    files: [],
+    folders: [],
+    folder: 'other',
+    folderPath: '/other',
+    unsupportedFiles: undefined,
+  });
+
+  assert.equal(state.unsupportedFiles, undefined);
+  assert.equal(state.unsupportedModalOpen, false);
+});
+
+test('UNSUPPORTED_MODAL toggle action updates state', () => {
+  let state = reducer(freshState(), { type: 'UNSUPPORTED_MODAL', open: true });
+  assert.equal(state.unsupportedModalOpen, true);
+
+  state = reducer(state, { type: 'UNSUPPORTED_MODAL', open: false });
+  assert.equal(state.unsupportedModalOpen, false);
+});

--- a/web-src/src/store/state.ts
+++ b/web-src/src/store/state.ts
@@ -16,6 +16,7 @@ import type {
   IndexWarning,
   SearchHit,
   Agent,
+  UnsupportedFileSummary,
 } from '../api';
 import type { SearchTypeCategory } from '../../../shared/search-types.ts';
 
@@ -174,6 +175,8 @@ export interface State {
 
   files: FileMeta[];
   folders: FolderMeta[];
+  unsupportedFiles?: UnsupportedFileSummary;
+  unsupportedModalOpen?: boolean;
 
   /** Manual sidebar ordering — map of `parentPath` → ordered list of
    *  child basenames. Empty map = use default (folders-first +
@@ -345,6 +348,8 @@ export const initialState: State = {
   libraryFolderStatuses: {},
   files: [],
   folders: [],
+  unsupportedFiles: undefined,
+  unsupportedModalOpen: false,
   fileOrder: {},
   tabs: [],
   recentFilePaths: [],
@@ -399,7 +404,7 @@ export type Action =
   | { type: 'LIBRARY_FOLDER_STATUS'; path: string; status: LibraryFolderStatus }
   | { type: 'LIBRARY_FOLDER_STATUS_REMOVE'; path: string }
   | { type: 'FOLDER_CONTEXT'; folder: string; folderPath: string }
-  | { type: 'FILES_LOADED'; files: FileMeta[]; folders: FolderMeta[]; folder: string; folderPath?: string }
+  | { type: 'FILES_LOADED'; files: FileMeta[]; folders: FolderMeta[]; folder: string; folderPath?: string; unsupportedFiles?: UnsupportedFileSummary }
   | { type: 'FILE_ORDER_LOADED'; order: Record<string, string[]> }
   /** Replace one folder's ordered list (optimistic update before the
    *  PUT lands). Names list may include entries that no longer exist
@@ -494,4 +499,5 @@ export type Action =
   | { type: 'NEW_FOLDER_INPUT'; open: boolean }
   | { type: 'FIND_OPEN' }
   | { type: 'FIND_CLOSE' }
-  | { type: 'FIND_SET'; patch: Partial<State['find']> };
+  | { type: 'FIND_SET'; patch: Partial<State['find']> }
+  | { type: 'UNSUPPORTED_MODAL'; open: boolean };

--- a/web-src/src/store/stateReducer.ts
+++ b/web-src/src/store/stateReducer.ts
@@ -68,6 +68,7 @@ export function reducer(s: State, a: Action): State {
         folders: a.folders,
         folder: a.folder,
         folderPath,
+        unsupportedFiles: a.unsupportedFiles,
         ...(folderChanged
           ? {
               activeSidebarView: 'files' as const,
@@ -82,6 +83,7 @@ export function reducer(s: State, a: Action): State {
               // filters are per-folder session state too.
               searchScope: null,
               searchTypes: [],
+              unsupportedModalOpen: false,
             }
           : {}),
       };
@@ -509,5 +511,7 @@ export function reducer(s: State, a: Action): State {
       return { ...s, find: { ...s.find, open: false, current: 0, total: 0 } };
     case 'FIND_SET':
       return { ...s, find: { ...s.find, ...a.patch } };
+    case 'UNSUPPORTED_MODAL':
+      return { ...s, unsupportedModalOpen: a.open };
   }
 }

--- a/web-src/src/store/useActiveFolderWorkspace.ts
+++ b/web-src/src/store/useActiveFolderWorkspace.ts
@@ -61,6 +61,7 @@ export interface ActiveFolderWorkspace {
   consumePendingHighlight: () => void;
   toggleEditMode: () => Promise<void>;
   updateTabPdfPage: (tabId: string, page: number) => void;
+  setUnsupportedModalOpen: (open: boolean) => void;
   newNote: () => Promise<void>;
   newFolder: (path: string) => Promise<void>;
   deleteFile: (name: string) => Promise<void>;
@@ -268,6 +269,7 @@ export function useActiveFolderWorkspace(
     documents.selectFileWithHighlight,
     documents.toggleEditMode,
     documents.updateTabPdfPage,
+    documents.setUnsupportedModalOpen,
     files.deleteFile,
     files.deleteFolder,
     files.moveFile,

--- a/web-src/src/store/useDocumentActions.ts
+++ b/web-src/src/store/useDocumentActions.ts
@@ -358,5 +358,8 @@ export function useDocumentActions(
     selectFileWithHighlight,
     toggleEditMode,
     updateTabPdfPage,
+    setUnsupportedModalOpen: (open: boolean) => {
+      dispatch({ type: 'UNSUPPORTED_MODAL', open });
+    },
   };
 }

--- a/web-src/src/styles/sidebar.css
+++ b/web-src/src/styles/sidebar.css
@@ -1455,12 +1455,44 @@
       padding: 0 1px;
       border-radius: 2px;
     }
-    .keyword-truncated {
-      color: var(--muted);
-      font-size: calc(11px * var(--ui-scale));
-      padding: 2px 10px 2px 16px;
-      cursor: default;
-    }
     .keyword-truncated:hover {
       background: transparent;
     }
+
+    .unsupported-files-banner {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      margin: 4px 12px 8px;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg);
+      font-size: calc(11.5px * var(--ui-scale));
+      line-height: 1.4;
+      color: var(--muted);
+    }
+    .unsupported-files-banner-title {
+      font-weight: 600;
+      color: var(--fg);
+      margin-bottom: 2px;
+    }
+    .unsupported-files-banner-copy {
+      flex: 1;
+      min-width: 0;
+    }
+    .unsupported-files-details-btn {
+      border: 0;
+      background: transparent;
+      color: var(--accent);
+      font-weight: 600;
+      cursor: pointer;
+      padding: 0;
+      text-decoration: underline;
+      display: inline;
+      margin-left: 2px;
+    }
+    .unsupported-files-details-btn:hover {
+      text-decoration: none;
+    }
+


### PR DESCRIPTION
## Summary

Fixes #127 by explaining and gracefully handling unsupported files in the active folder workspace.

The implementation recursively walks and classifies folder files into source-code files and other unsupported formats. It bottom-up prunes directories containing only unsupported subtrees (while keeping physically empty and supported-containing directories). It shows first-time explanation onboarding modals, keeps a persistent callout banner above the file list, and renders a custom empty state when no supported files are found.

## Problem

StashBase previously ignored unsupported files silently. Folders containing only developer source-code or unsupported documents appeared as empty subfolders in the sidebar. This confused users as it was unclear whether folders had indexed, if imports failed, or if sync was broken.

## Solution

- **File-Level Classification**: Unsupported files are classified as either source code (based on lowercase extension lists and basenames like `Makefile`, `Dockerfile`) or other formats.
- **Recursive Directory Scan & Pruning**: Bottom-up directory pruning leaves only physically empty folders or folder ancestors containing supported files.
- **Onboarding Modal Gate**: A Radix-based `UnsupportedFilesModal` alerts the user of hidden unsupported files the first time a folder loads. Acknowledgements are saved in the global config.
- **Persistent Callout Banner**: A banner containing counts and a **Details** button stays visible above the file tree.
- **Unsupported-Only Empty State**: Replaces *"No notes yet"* with *"No supported files found"* explaining how many files were ignored.

## Compatibility

- Original note-indexing and file-rendering behaviors are unchanged.
- Excluded directories like `.git` and `node_modules` remain ignored.
- MCP is read-only with respect to config.

## Regression coverage

- Case-insensitive filename classification.
- Dynamic bottom-up directory subtree pruning.
- Physically empty folder and ancestor folder retention.
- Stable, sorted extension breakdown summaries.
- Onboarding modal gates and combined/single notice versions.
- Escaping/closing modal doesn't persist acknowledgement.
- Details reopens modal layout regardless of acknowledgement state.
- Custom unsupported-only empty state.
- Graceful read/write app-config fallback.

## Validation

- `pnpm typecheck` — passed
- `node --import tsx --test server/__tests__/file-listing.test.ts` — passed
- `pnpm test:renderer` — 151 passed
- `npx vite build --config web-src/vite.config.ts` — passed

## Visual Changes

<img width="224" height="240" alt="Screenshot 2026-08-09 004526" src="https://github.com/user-attachments/assets/c45aa077-1b99-4a33-93d9-416f466e7dac" />

<img width="923" height="455" alt="Screenshot 2026-08-09 004503" src="https://github.com/user-attachments/assets/6b3fa0bc-3f82-4910-a975-1a2f131ccde9" />

