### PR TITLE
fix(agent-panel): normalize Codex failed-turn and error events (#132)

### DIFF
--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -80,6 +80,7 @@ Community contributions can land as useful first iterations, but the long-term d
   prompt recover through a fresh native connection. Late events from the
   abandoned start must not enter the renderer; the server-side timeout and
   generation-fencing contract lives in [architecture.md](architecture.md).
+- Codex session error normalization must distinguish between retryable warnings and fatal failures: an error event with `willRetry: true` represents retry-in-progress and must not settle the turn or emit a permanent error to the client, while `willRetry: false` (or unspecified) represents a terminal failure and must emit one error and settle the active turn exactly once. A terminal error notification followed by `turn/completed` must suppress duplicate error and terminal events for that same active turn.
 - A discovered missing Agent CLI is a setup state, not a disabled launcher or a
   generic connection failure. Keep its install command copyable and let the
   user re-run discovery after installation; do not conflate it with an

--- a/server/__tests__/codex-agent.test.ts
+++ b/server/__tests__/codex-agent.test.ts
@@ -778,3 +778,254 @@ test('Codex Session handles steer timeout without ending an active turn', async 
   assert.equal(runtime.activeTurnId, 'turn-1');
   session.dispose();
 });
+
+test('Codex Session failed turn completed with message preserves it', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-codex-err-preserve-'));
+  runWithWindowId('err-preserve-window', () => setCurrentFolder(folder));
+  t.after(() => {
+    clearAgentRuntimeFailure('codex');
+    runWithWindowId('err-preserve-window', () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  const ws = new FakeWebSocket();
+  const native = catalogProcess();
+  const session = new CodexSession(
+    ws as unknown as WebSocket,
+    'err-preserve-window',
+    undefined, undefined, undefined, undefined, undefined,
+    () => native.proc as unknown as ChildProcessWithoutNullStreams,
+  );
+  session.begin();
+  await settle();
+
+  ws.emit('message', JSON.stringify({ t: 'prompt', text: 'hello' }));
+  await settle();
+
+  // Send failed turn with an error message
+  native.proc.stdout.write(`${JSON.stringify({
+    method: 'turn/completed',
+    params: {
+      turn: {
+        id: 'turn-1',
+        status: 'failed',
+        error: { message: 'sandbox service offline' },
+      },
+    },
+  })}\n`);
+  await settle();
+
+  const events = ws.sent.map((item) => JSON.parse(item) as { t: string; message?: string; isError?: boolean });
+  const errorEvent = events.find((e) => e.t === 'error');
+  assert.ok(errorEvent);
+  assert.equal(errorEvent.message, 'sandbox service offline');
+
+  const turnEndEvent = events.find((e) => e.t === 'turn-end');
+  assert.ok(turnEndEvent);
+  assert.equal(turnEndEvent.isError, true);
+  session.dispose();
+});
+
+test('Codex Session failed turn completed without message uses fallback', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-codex-err-fallback-'));
+  runWithWindowId('err-fallback-window', () => setCurrentFolder(folder));
+  t.after(() => {
+    clearAgentRuntimeFailure('codex');
+    runWithWindowId('err-fallback-window', () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  const ws = new FakeWebSocket();
+  const native = catalogProcess();
+  const session = new CodexSession(
+    ws as unknown as WebSocket,
+    'err-fallback-window',
+    undefined, undefined, undefined, undefined, undefined,
+    () => native.proc as unknown as ChildProcessWithoutNullStreams,
+  );
+  session.begin();
+  await settle();
+
+  ws.emit('message', JSON.stringify({ t: 'prompt', text: 'hello' }));
+  await settle();
+
+  // Send failed turn with NO error message
+  native.proc.stdout.write(`${JSON.stringify({
+    method: 'turn/completed',
+    params: {
+      turn: {
+        id: 'turn-1',
+        status: 'failed',
+      },
+    },
+  })}\n`);
+  await settle();
+
+  const events = ws.sent.map((item) => JSON.parse(item) as { t: string; message?: string; isError?: boolean });
+  const errorEvent = events.find((e) => e.t === 'error');
+  assert.ok(errorEvent);
+  assert.equal(errorEvent.message, 'Codex failed before completing the turn.');
+
+  const turnEndEvent = events.find((e) => e.t === 'turn-end');
+  assert.ok(turnEndEvent);
+  assert.equal(turnEndEvent.isError, true);
+  session.dispose();
+});
+
+test('Codex Session error with willRetry: true does not settle turn', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-codex-willretry-true-'));
+  runWithWindowId('willretry-true-window', () => setCurrentFolder(folder));
+  t.after(() => {
+    clearAgentRuntimeFailure('codex');
+    runWithWindowId('willretry-true-window', () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  const ws = new FakeWebSocket();
+  const native = catalogProcess();
+  const session = new CodexSession(
+    ws as unknown as WebSocket,
+    'willretry-true-window',
+    undefined, undefined, undefined, undefined, undefined,
+    () => native.proc as unknown as ChildProcessWithoutNullStreams,
+  );
+  session.begin();
+  await settle();
+
+  ws.emit('message', JSON.stringify({ t: 'prompt', text: 'hello' }));
+  await settle();
+
+  // Send warning/error event with willRetry: true
+  native.proc.stdout.write(`${JSON.stringify({
+    method: 'error',
+    params: {
+      message: 'transient rate limit',
+      willRetry: true,
+    },
+  })}\n`);
+  await settle();
+
+  const events = ws.sent.map((item) => JSON.parse(item) as { t: string });
+  // Verify NO error or turn-end was emitted to the WebSocket client
+  assert.equal(events.some((e) => e.t === 'error'), false);
+  assert.equal(events.some((e) => e.t === 'turn-end'), false);
+
+  const runtime = session as unknown as { busy: boolean };
+  assert.equal(runtime.busy, true);
+  session.dispose();
+});
+
+test('Codex Session error with willRetry: false settles turn and ignores later completed event', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-codex-willretry-false-'));
+  runWithWindowId('willretry-false-window', () => setCurrentFolder(folder));
+  t.after(() => {
+    clearAgentRuntimeFailure('codex');
+    runWithWindowId('willretry-false-window', () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  const ws = new FakeWebSocket();
+  const native = catalogProcess();
+  const session = new CodexSession(
+    ws as unknown as WebSocket,
+    'willretry-false-window',
+    undefined, undefined, undefined, undefined, undefined,
+    () => native.proc as unknown as ChildProcessWithoutNullStreams,
+  );
+  session.begin();
+  await settle();
+
+  ws.emit('message', JSON.stringify({ t: 'prompt', text: 'hello' }));
+  await settle();
+
+  // Send terminal error with willRetry: false
+  native.proc.stdout.write(`${JSON.stringify({
+    method: 'error',
+    params: {
+      message: 'fatal crash',
+      willRetry: false,
+    },
+  })}\n`);
+  await settle();
+
+  const eventsAfterError = ws.sent.map((item) => JSON.parse(item) as { t: string; message?: string; isError?: boolean });
+  const errorEvent = eventsAfterError.find((e) => e.t === 'error');
+  assert.ok(errorEvent);
+  assert.equal(errorEvent.message, 'fatal crash');
+
+  const turnEndEvent = eventsAfterError.find((e) => e.t === 'turn-end');
+  assert.ok(turnEndEvent);
+  assert.equal(turnEndEvent.isError, true);
+
+  // Clear websocket sent history to verify no new events are sent
+  ws.sent = [];
+
+  // Now send subsequent turn/completed event (which Codex app-server might send on cleanup)
+  native.proc.stdout.write(`${JSON.stringify({
+    method: 'turn/completed',
+    params: {
+      turn: {
+        id: 'turn-1',
+        status: 'failed',
+        error: { message: 'fatal crash' },
+      },
+    },
+  })}\n`);
+  await settle();
+
+  const eventsAfterCompleted = ws.sent.map((item) => JSON.parse(item) as { t: string });
+  // Verify NO duplicate events were sent
+  assert.equal(eventsAfterCompleted.some((e) => e.t === 'error'), false);
+  assert.equal(eventsAfterCompleted.some((e) => e.t === 'turn-end'), false);
+
+  session.dispose();
+});
+
+test('Codex Session user cancellation returns isError: false and no red error', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-codex-cancel-'));
+  runWithWindowId('cancel-window', () => setCurrentFolder(folder));
+  t.after(() => {
+    clearAgentRuntimeFailure('codex');
+    runWithWindowId('cancel-window', () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  const ws = new FakeWebSocket();
+  const native = catalogProcess();
+  const session = new CodexSession(
+    ws as unknown as WebSocket,
+    'cancel-window',
+    undefined, undefined, undefined, undefined, undefined,
+    () => native.proc as unknown as ChildProcessWithoutNullStreams,
+  );
+  session.begin();
+  await settle();
+
+  ws.emit('message', JSON.stringify({ t: 'prompt', text: 'hello' }));
+  await settle();
+
+  // Simulate user stop/interrupt action
+  ws.emit('message', JSON.stringify({ t: 'interrupt' }));
+  await settle();
+
+  // Send turn completion representing cancelled turn
+  native.proc.stdout.write(`${JSON.stringify({
+    method: 'turn/completed',
+    params: {
+      turn: {
+        id: 'turn-1',
+        status: 'cancelled',
+      },
+    },
+  })}\n`);
+  await settle();
+
+  const events = ws.sent.map((item) => JSON.parse(item) as { t: string; message?: string; isError?: boolean });
+  // Verify client received turn-end with isError: false, and no error message
+  assert.equal(events.some((e) => e.t === 'error'), false);
+  const turnEndEvent = events.find((e) => e.t === 'turn-end');
+  assert.ok(turnEndEvent);
+  assert.equal(turnEndEvent.isError, false);
+
+  session.dispose();
+});

--- a/server/codex-session-runtime.ts
+++ b/server/codex-session-runtime.ts
@@ -731,10 +731,37 @@ export class CodexSession {
 
   private onTurnCompleted(params: JsonObject): void {
     const turn = params.turn as JsonObject | undefined;
+    const id = stringValue(turn?.id);
+
+    // 1. Suppress duplicate events if already settled or mismatching turn
+    if (!this.busy || !this.activeTurnId || id !== this.activeTurnId) {
+      return;
+    }
+
     const status = stringValue(turn?.status);
     const error = turn?.error as JsonObject | undefined;
-    const message = stringValue(error?.message);
-    if (message) this.send({ t: 'error', message });
+    let message = stringValue(error?.message);
+
+    // 2. Preserve user interruption/cancellation as non-error
+    const isCancelled = status === 'cancelled' || this.interruptRequested || (this.interruptingTurnId === id);
+    if (isCancelled) {
+      this.busy = false;
+      this.activeTurnId = null;
+      this.interruptRequested = false;
+      this.interruptingTurnId = null;
+      this.send({ t: 'turn-end', isError: false });
+      return;
+    }
+
+    // 3. Fallback error message if status is failed but no message exists
+    if (status === 'failed' && !message) {
+      message = 'Codex failed before completing the turn.';
+    }
+
+    if (message) {
+      this.send({ t: 'error', message });
+    }
+
     this.busy = false;
     this.activeTurnId = null;
     this.interruptRequested = false;
@@ -743,15 +770,21 @@ export class CodexSession {
   }
 
   private onErrorNotification(params: JsonObject): void {
+    // 1. Ignore retryable notifications on the UI side
+    if (params.willRetry === true) {
+      log.info(`Codex reported a retryable error: ${notificationMessage(params)}`);
+      return;
+    }
+
+    // 2. Process terminal notifications (willRetry: false or undefined)
     const message = notificationMessage(params) || 'Codex reported an error.';
     this.send({ t: 'error', message });
-    if (params.willRetry === false) {
-      this.busy = false;
-      this.activeTurnId = null;
-      this.interruptRequested = false;
-      this.interruptingTurnId = null;
-      this.send({ t: 'turn-end', isError: true });
-    }
+    
+    this.busy = false;
+    this.activeTurnId = null;
+    this.interruptRequested = false;
+    this.interruptingTurnId = null;
+    this.send({ t: 'turn-end', isError: true });
   }
 
   private onToolOutputDelta(params: JsonObject): void {


### PR DESCRIPTION
## Summary

Fixes #132. Normalizes Codex `turn/completed` events and `error` notifications inside the session runtime to guarantee robust error state rendering and prevent duplicate UI notifications.

## Problem

When a Codex turn failed or encountered errors, the session runtime fell back to behaviors that were either silent, premature, or duplicate:
1. **Silent Failed Turns**: When a `turn/completed` event returned `status: "failed"` without an explicit `error.message`, it emitted only `turn-end(isError: true)`. The renderer removed the busy spinner but rendered no error notice, leaving the user with no feedback.
2. **Premature Red Notices**: Transient warnings with `willRetry: true` immediately emitted an `error` event, rendering a permanent red error card in the client while the model was still active and retrying in the background.
3. **Duplicate Settlements**: When a terminal error occurred (`willRetry: false`), the adapter settled the turn immediately. If a subsequent `turn/completed` event arrived, the adapter emitted another `error` and `turn-end` event, creating duplicate red notices.

## Changes Made

- **Deduplication & Turn Matching**: Modified `onTurnCompleted` in `server/codex-session-runtime.ts` to verify the turn is active and matches `activeTurnId`. Duplicate or late completion events are safely ignored.
- **Fallback message**: Added fallback resolution when a failed turn lacks an error message, emitting a stable fallback: `"Codex failed before completing the turn."`.
- **Cancellation Handling**: Handled user cancellations/interruptions (indicated by `status === 'cancelled'` or `this.interruptRequested`) by ending the turn with `isError: false` and suppressing error messages.
- **Retry Filtering**: Updated `onErrorNotification` to log and filter out retry-in-progress warnings (`willRetry: true`), allowing only fatal terminal errors (`willRetry: false` or undefined) to settle the turn.
- **Engineering Contracts**: Added the Codex error and retry normalization invariants to the Design Rules of `code-review/agent-panel.md`.

## Unit Tests / Regression Coverage

Added 5 comprehensive test cases at the end of `server/__tests__/codex-agent.test.ts`:
- `Codex Session failed turn completed with message preserves it`
- `Codex Session failed turn completed without message uses fallback`
- `Codex Session error with willRetry: true does not settle turn`
- `Codex Session error with willRetry: false settles turn and ignores later completed event`
- `Codex Session user cancellation returns isError: false and no red error`

## Validation

- `pnpm typecheck` (Passed cleanly with 0 compilation errors)
- `pnpm test:agent` (62 tests passed, including all 5 new tests)
