### PR TITLE
fix(agent-panel): preserve Claude terminal failure details (#131)

### DIFF
--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -80,6 +80,7 @@ Community contributions can land as useful first iterations, but the long-term d
   prompt recover through a fresh native connection. Late events from the
   abandoned start must not enter the renderer; the server-side timeout and
   generation-fencing contract lives in [architecture.md](architecture.md).
+- Claude session error normalization must preserve execution failure details before emitting `turn-end`: trim and deduplicate SDK error lists to a joined message capped at 2,000 characters, resolve max-turn, max-budget, and structured-retry error subtypes to stable fallback copy, and treat transient api_retry warnings as retry-in-progress without ending the turn.
 - A discovered missing Agent CLI is a setup state, not a disabled launcher or a
   generic connection failure. Keep its install command copyable and let the
   user re-run discovery after installation; do not conflate it with an

--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -80,7 +80,13 @@ Community contributions can land as useful first iterations, but the long-term d
   prompt recover through a fresh native connection. Late events from the
   abandoned start must not enter the renderer; the server-side timeout and
   generation-fencing contract lives in [architecture.md](architecture.md).
-- Claude session error normalization must preserve execution failure details before emitting `turn-end`: trim and deduplicate SDK error lists to a joined message capped at 2,000 characters, resolve max-turn, max-budget, and structured-retry error subtypes to stable fallback copy, and treat transient api_retry warnings as retry-in-progress without ending the turn.
+- Claude session error normalization must preserve execution failure details
+  before emitting `turn-end`: trim and deduplicate SDK error lists to a joined
+  message capped at 2,000 characters, resolve max-turn, max-budget, and
+  structured-retry error subtypes to stable fallback copy, and treat transient
+  `api_retry` warnings as retry-in-progress without ending the turn. Settle
+  only the active turn once, ignore repeated or late results, and keep the
+  final result authoritative when the native interrupt request rejects.
 - Correlate every Codex error notification to the active turn through its
   protocol `turnId`. `willRetry: true` is retry-in-progress and must not settle
   the turn or emit a permanent error; `willRetry: false` may emit one error and

--- a/server/__tests__/agent.test.ts
+++ b/server/__tests__/agent.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import type { Query } from '@anthropic-ai/claude-agent-sdk';
+import type { Query, SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { WebSocket } from 'ws';
 import {
   AgentSession,
@@ -32,10 +32,16 @@ async function settle(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve));
 }
 
-function fakeClaudeQuery(failure?: Error): Query {
+function fakeClaudeQuery(failureOrMessages?: Error | SDKMessage[], failure?: Error): Query {
   return {
     async *[Symbol.asyncIterator]() {
-      if (failure) throw failure;
+      if (Array.isArray(failureOrMessages)) {
+        for (const msg of failureOrMessages) {
+          yield msg;
+        }
+      }
+      const err = failure ?? (failureOrMessages instanceof Error ? failureOrMessages : undefined);
+      if (err) throw err;
     },
     supportedModels: async () => [],
     supportedCommands: async () => [],
@@ -377,4 +383,333 @@ test('Claude startup failure puts its cause on the terminal exit', async (t) => 
   assert.equal(events.some((event) => event.t === 'ready'), false);
   assert.equal(events.some((event) => event.t === 'error'), false);
   assert.match(events.find((event) => event.t === 'exit')?.message ?? '', /Claude CLI not found/);
+});
+
+test('Claude Session final result with errors preserves and truncates messages', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-claude-err-preserve-'));
+  runWithWindowId('claude-err-preserve-window', () => setCurrentFolder(folder));
+  t.after(() => {
+    clearAgentRuntimeFailure('claude');
+    runWithWindowId('claude-err-preserve-window', () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  const ws = new FakeAgentWebSocket();
+  const mockMessages: SDKMessage[] = [
+    {
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      errors: ['Request timed out', 'Request timed out  ', 'Network unreachable'],
+      duration_ms: 100,
+      duration_api_ms: 50,
+      num_turns: 1,
+      stop_reason: 'error',
+      total_cost_usd: 0.01,
+      usage: { input_tokens: 10, output_tokens: 5 } as any,
+      modelUsage: {},
+      permission_denials: [],
+      uuid: 'msg-123' as any,
+      session_id: 'session-123',
+    },
+  ];
+
+  const session = new AgentSession(
+    ws as unknown as WebSocket,
+    'claude-err-preserve-window',
+    undefined,
+    undefined,
+    'default',
+    undefined,
+    undefined,
+    (() => fakeClaudeQuery(mockMessages)) as never,
+    () => '/fake/claude',
+  );
+  session.begin();
+  await settle();
+
+  const events = ws.sent.map((value) => JSON.parse(value) as { t: string; message?: string; isError?: boolean });
+  
+  // Verify error event contains deduplicated, joined message
+  const errorEvent = events.find((e) => e.t === 'error');
+  assert.ok(errorEvent);
+  assert.equal(errorEvent.message, 'Request timed out; Network unreachable');
+
+  // Verify turn-end event isError is true
+  const turnEndEvent = events.find((e) => e.t === 'turn-end');
+  assert.ok(turnEndEvent);
+  assert.equal(turnEndEvent.isError, true);
+});
+
+test('Claude Session final result with no error text uses subtype fallbacks', async (t) => {
+  const subtypes = [
+    'error_max_turns',
+    'error_max_budget_usd',
+    'error_max_structured_output_retries',
+    'error_during_execution',
+  ] as const;
+  const expectedMessages = [
+    'Claude stopped after reaching the maximum number of turns.',
+    'Claude stopped after reaching the configured budget.',
+    'Claude could not produce the requested structured response.',
+    'Claude failed before completing the turn.',
+  ];
+
+  for (let i = 0; i < subtypes.length; i++) {
+    const subtype = subtypes[i]!;
+    const expected = expectedMessages[i]!;
+
+    const folder = fs.mkdtempSync(path.join(os.tmpdir(), `stashbase-claude-fallback-${i}-`));
+    runWithWindowId(`claude-fallback-window-${i}`, () => setCurrentFolder(folder));
+    t.after(() => {
+      clearAgentRuntimeFailure('claude');
+      runWithWindowId(`claude-fallback-window-${i}`, () => clearCurrentFolder());
+      fs.rmSync(folder, { recursive: true, force: true });
+    });
+
+    const ws = new FakeAgentWebSocket();
+    const mockMessages: SDKMessage[] = [
+      {
+        type: 'result',
+        subtype,
+        is_error: true,
+        errors: [],
+        duration_ms: 100,
+        duration_api_ms: 50,
+        num_turns: 1,
+        stop_reason: 'error',
+        total_cost_usd: 0.01,
+        usage: { input_tokens: 10, output_tokens: 5 } as any,
+        modelUsage: {},
+        permission_denials: [],
+        uuid: 'msg-123' as any,
+        session_id: 'session-123',
+      },
+    ];
+
+    const session = new AgentSession(
+      ws as unknown as WebSocket,
+      `claude-fallback-window-${i}`,
+      undefined,
+      undefined,
+      'default',
+      undefined,
+      undefined,
+      (() => fakeClaudeQuery(mockMessages)) as never,
+      () => '/fake/claude',
+    );
+    session.begin();
+    await settle();
+
+    const events = ws.sent.map((value) => JSON.parse(value) as { t: string; message?: string });
+    const errorEvent = events.find((e) => e.t === 'error');
+    assert.ok(errorEvent, `Expected error event for subtype ${subtype}`);
+    assert.equal(errorEvent.message, expected);
+  }
+});
+
+test('Claude Session handles transient api_retry warnings without permanent errors', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-claude-retry-'));
+  runWithWindowId('claude-retry-window', () => setCurrentFolder(folder));
+  t.after(() => {
+    clearAgentRuntimeFailure('claude');
+    runWithWindowId('claude-retry-window', () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  const ws = new FakeAgentWebSocket();
+  const mockMessages: SDKMessage[] = [
+    {
+      type: 'system',
+      subtype: 'api_retry',
+      attempt: 1,
+      max_retries: 3,
+      retry_delay_ms: 1000,
+      error_status: null,
+      error: 'unknown',
+      uuid: 'retry-uuid' as any,
+      session_id: 'session-123',
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      duration_ms: 100,
+      duration_api_ms: 50,
+      num_turns: 1,
+      result: 'Hello output',
+      stop_reason: 'end_turn',
+      total_cost_usd: 0.01,
+      usage: { input_tokens: 10, output_tokens: 5 } as any,
+      modelUsage: {},
+      permission_denials: [],
+      uuid: 'msg-123' as any,
+      session_id: 'session-123',
+    },
+  ];
+
+  const session = new AgentSession(
+    ws as unknown as WebSocket,
+    'claude-retry-window',
+    undefined,
+    undefined,
+    'default',
+    undefined,
+    undefined,
+    (() => fakeClaudeQuery(mockMessages)) as never,
+    () => '/fake/claude',
+  );
+  session.begin();
+  await settle();
+
+  const events = ws.sent.map((value) => JSON.parse(value) as { t: string });
+  // Verify api_retry did not emit error to client, and turn finishes successfully
+  assert.equal(events.some((e) => e.t === 'error'), false);
+  const turnEndEvent = events.find((e) => e.t === 'turn-end');
+  assert.ok(turnEndEvent);
+  assert.equal((turnEndEvent as any).isError, false);
+});
+
+test('Claude Session handles api_retry followed by terminal failure', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-claude-retry-fail-'));
+  runWithWindowId('claude-retry-fail-window', () => setCurrentFolder(folder));
+  t.after(() => {
+    clearAgentRuntimeFailure('claude');
+    runWithWindowId('claude-retry-fail-window', () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  const ws = new FakeAgentWebSocket();
+  const mockMessages: SDKMessage[] = [
+    {
+      type: 'system',
+      subtype: 'api_retry',
+      attempt: 1,
+      max_retries: 3,
+      retry_delay_ms: 1000,
+      error_status: null,
+      error: 'unknown',
+      uuid: 'retry-uuid' as any,
+      session_id: 'session-123',
+    },
+    {
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      errors: ['Request timed out'],
+      duration_ms: 100,
+      duration_api_ms: 50,
+      num_turns: 1,
+      stop_reason: 'error',
+      total_cost_usd: 0.01,
+      usage: { input_tokens: 10, output_tokens: 5 } as any,
+      modelUsage: {},
+      permission_denials: [],
+      uuid: 'msg-123' as any,
+      session_id: 'session-123',
+    },
+  ];
+
+  const session = new AgentSession(
+    ws as unknown as WebSocket,
+    'claude-retry-fail-window',
+    undefined,
+    undefined,
+    'default',
+    undefined,
+    undefined,
+    (() => fakeClaudeQuery(mockMessages)) as never,
+    () => '/fake/claude',
+  );
+  session.begin();
+  await settle();
+
+  const events = ws.sent.map((value) => JSON.parse(value) as { t: string; message?: string; isError?: boolean });
+  // Verify only one final error message and a failed turn-end are emitted
+  const errorEvents = events.filter((e) => e.t === 'error');
+  assert.equal(errorEvents.length, 1);
+  assert.equal(errorEvents[0]?.message, 'Request timed out');
+
+  const turnEndEvent = events.find((e) => e.t === 'turn-end');
+  assert.ok(turnEndEvent);
+  assert.equal(turnEndEvent.isError, true);
+});
+
+test('Claude Session user cancellation returns non-red turn-end', async (t) => {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-claude-cancel-'));
+  runWithWindowId('claude-cancel-window', () => setCurrentFolder(folder));
+  t.after(() => {
+    clearAgentRuntimeFailure('claude');
+    runWithWindowId('claude-cancel-window', () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  const ws = new FakeAgentWebSocket();
+  let triggerResult: (() => void) | null = null;
+  const resultPromise = new Promise<void>((resolve) => {
+    triggerResult = resolve;
+  });
+
+  const queryFactory = () => {
+    return {
+      async *[Symbol.asyncIterator]() {
+        await resultPromise;
+        yield {
+          type: 'result',
+          subtype: 'error_during_execution',
+          is_error: true,
+          errors: ['Interrupted by user'],
+          duration_ms: 100,
+          duration_api_ms: 50,
+          num_turns: 1,
+          stop_reason: 'error',
+          total_cost_usd: 0.01,
+          usage: { input_tokens: 10, output_tokens: 5 } as any,
+          modelUsage: {},
+          permission_denials: [],
+          uuid: 'msg-123' as any,
+          session_id: 'session-123',
+        };
+      },
+      supportedModels: async () => [],
+      supportedCommands: async () => [],
+      setModel: async () => {},
+      setPermissionMode: async () => {},
+      interrupt: async () => {},
+    } as unknown as Query;
+  };
+
+  const session = new AgentSession(
+    ws as unknown as WebSocket,
+    'claude-cancel-window',
+    undefined,
+    undefined,
+    'default',
+    undefined,
+    undefined,
+    queryFactory as any,
+    () => '/fake/claude',
+  );
+  session.begin();
+  await settle();
+
+  // Send prompt
+  ws.emit('message', JSON.stringify({ t: 'prompt', text: 'run query' }));
+  await settle();
+
+  // Send interrupt client event
+  ws.emit('message', JSON.stringify({ t: 'interrupt' }));
+  await settle();
+
+  // Trigger the result
+  triggerResult!();
+  await settle();
+
+  const events = ws.sent.map((value) => JSON.parse(value) as { t: string; message?: string; isError?: boolean });
+  
+  // Verify client received turn-end with isError: false, and no error message
+  assert.equal(events.some((e) => e.t === 'error'), false);
+  const turnEndEvent = events.find((e) => e.t === 'turn-end');
+  assert.ok(turnEndEvent);
+  assert.equal(turnEndEvent.isError, false);
 });

--- a/server/__tests__/agent.test.ts
+++ b/server/__tests__/agent.test.ts
@@ -51,6 +51,130 @@ function fakeClaudeQuery(failureOrMessages?: Error | SDKMessage[], failure?: Err
   } as unknown as Query;
 }
 
+interface TurnEvent {
+  t: string;
+  message?: string;
+  isError?: boolean;
+}
+
+function claudeErrorResult(
+  subtype: 'error_during_execution' | 'error_max_turns' | 'error_max_budget_usd' | 'error_max_structured_output_retries',
+  errors: unknown,
+): SDKMessage {
+  return {
+    type: 'result',
+    subtype,
+    is_error: true,
+    errors,
+    duration_ms: 100,
+    duration_api_ms: 50,
+    num_turns: 1,
+    stop_reason: 'error',
+    total_cost_usd: 0.01,
+    usage: { input_tokens: 10, output_tokens: 5 },
+    modelUsage: {},
+    permission_denials: [],
+    uuid: 'test-result',
+    session_id: 'test-session',
+  } as unknown as SDKMessage;
+}
+
+function claudeSuccessResult(): SDKMessage {
+  return {
+    type: 'result',
+    subtype: 'success',
+    is_error: false,
+    duration_ms: 100,
+    duration_api_ms: 50,
+    num_turns: 1,
+    result: 'Finished',
+    stop_reason: 'end_turn',
+    total_cost_usd: 0.01,
+    usage: { input_tokens: 10, output_tokens: 5 },
+    modelUsage: {},
+    permission_denials: [],
+    uuid: 'test-result',
+    session_id: 'test-session',
+  } as unknown as SDKMessage;
+}
+
+function claudeRetryMessage(): SDKMessage {
+  return {
+    type: 'system',
+    subtype: 'api_retry',
+    attempt: 1,
+    max_retries: 3,
+    retry_delay_ms: 1000,
+    error_status: null,
+    error: 'unknown',
+    uuid: 'test-retry',
+    session_id: 'test-session',
+  } as unknown as SDKMessage;
+}
+
+async function startScriptedClaudeTurn(
+  t: { after(callback: () => void): void },
+  windowId: string,
+  messages: SDKMessage[],
+  interrupt: () => Promise<void> = async () => {},
+): Promise<{
+  ws: FakeAgentWebSocket;
+  releaseMessages(): void;
+  turnEvents(): TurnEvent[];
+}> {
+  const folder = fs.mkdtempSync(path.join(os.tmpdir(), `stashbase-${windowId}-`));
+  runWithWindowId(windowId, () => setCurrentFolder(folder));
+
+  let releaseMessages!: () => void;
+  const messageGate = new Promise<void>((resolve) => { releaseMessages = resolve; });
+  let finishStream!: () => void;
+  const streamGate = new Promise<void>((resolve) => { finishStream = resolve; });
+  const nativeQuery = {
+    async *[Symbol.asyncIterator]() {
+      await messageGate;
+      for (const message of messages) yield message;
+      await streamGate;
+    },
+    supportedModels: async () => [],
+    supportedCommands: async () => [],
+    setModel: async () => {},
+    setPermissionMode: async () => {},
+    interrupt,
+  } as unknown as Query;
+  const ws = new FakeAgentWebSocket();
+  const session = new AgentSession(
+    ws as unknown as WebSocket,
+    windowId,
+    undefined,
+    undefined,
+    'default',
+    undefined,
+    undefined,
+    (() => nativeQuery) as never,
+    () => '/fake/claude',
+  );
+  t.after(() => {
+    finishStream();
+    session.dispose();
+    clearAgentRuntimeFailure('claude');
+    runWithWindowId(windowId, () => clearCurrentFolder());
+    fs.rmSync(folder, { recursive: true, force: true });
+  });
+
+  session.begin();
+  await settle();
+  ws.emit('message', JSON.stringify({ t: 'prompt', text: 'run query' }));
+  await settle();
+
+  return {
+    ws,
+    releaseMessages,
+    turnEvents: () => ws.sent
+      .map((value) => JSON.parse(value) as TurnEvent)
+      .filter((event) => event.t === 'turn-start' || event.t === 'error' || event.t === 'turn-end'),
+  };
+}
+
 test('Claude adapter preserves supported Shared Agent Contract access modes', () => {
   assert.equal(claudePermissionMode('default'), 'default');
   assert.equal(claudePermissionMode('acceptEdits'), 'acceptEdits');
@@ -385,331 +509,130 @@ test('Claude startup failure puts its cause on the terminal exit', async (t) => 
   assert.match(events.find((event) => event.t === 'exit')?.message ?? '', /Claude CLI not found/);
 });
 
-test('Claude Session final result with errors preserves and truncates messages', async (t) => {
-  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-claude-err-preserve-'));
-  runWithWindowId('claude-err-preserve-window', () => setCurrentFolder(folder));
-  t.after(() => {
-    clearAgentRuntimeFailure('claude');
-    runWithWindowId('claude-err-preserve-window', () => clearCurrentFolder());
-    fs.rmSync(folder, { recursive: true, force: true });
-  });
+test('Claude final errors are normalized, bounded, and ordered before turn-end', async (t) => {
+  const oversized = 'x'.repeat(2100);
+  const expectedMessage = `Request timed out; ${oversized}`.slice(0, 2000);
+  const turn = await startScriptedClaudeTurn(t, 'claude-error-window', [
+    claudeErrorResult('error_during_execution', [
+      ' Request timed out ',
+      'Request timed out',
+      oversized,
+    ]),
+  ]);
 
-  const ws = new FakeAgentWebSocket();
-  const mockMessages: SDKMessage[] = [
-    {
-      type: 'result',
-      subtype: 'error_during_execution',
-      is_error: true,
-      errors: ['Request timed out', 'Request timed out  ', 'Network unreachable'],
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 1,
-      stop_reason: 'error',
-      total_cost_usd: 0.01,
-      usage: { input_tokens: 10, output_tokens: 5 } as any,
-      modelUsage: {},
-      permission_denials: [],
-      uuid: 'msg-123' as any,
-      session_id: 'session-123',
-    },
-  ];
-
-  const session = new AgentSession(
-    ws as unknown as WebSocket,
-    'claude-err-preserve-window',
-    undefined,
-    undefined,
-    'default',
-    undefined,
-    undefined,
-    (() => fakeClaudeQuery(mockMessages)) as never,
-    () => '/fake/claude',
-  );
-  session.begin();
+  turn.releaseMessages();
   await settle();
 
-  const events = ws.sent.map((value) => JSON.parse(value) as { t: string; message?: string; isError?: boolean });
-  
-  // Verify error event contains deduplicated, joined message
-  const errorEvent = events.find((e) => e.t === 'error');
-  assert.ok(errorEvent);
-  assert.equal(errorEvent.message, 'Request timed out; Network unreachable');
-
-  // Verify turn-end event isError is true
-  const turnEndEvent = events.find((e) => e.t === 'turn-end');
-  assert.ok(turnEndEvent);
-  assert.equal(turnEndEvent.isError, true);
+  assert.equal(expectedMessage.length, 2000);
+  assert.deepEqual(turn.turnEvents(), [
+    { t: 'turn-start' },
+    { t: 'error', message: expectedMessage },
+    { t: 'turn-end', isError: true },
+  ]);
 });
 
-test('Claude Session final result with no error text uses subtype fallbacks', async (t) => {
-  const subtypes = [
-    'error_max_turns',
-    'error_max_budget_usd',
-    'error_max_structured_output_retries',
-    'error_during_execution',
+test('Claude malformed or empty error lists use stable subtype fallbacks', async (t) => {
+  const cases = [
+    ['error_max_turns', null, 'Claude stopped after reaching the maximum number of turns.'],
+    ['error_max_budget_usd', 'not-an-array', 'Claude stopped after reaching the configured budget.'],
+    ['error_max_structured_output_retries', [null, '  '], 'Claude could not produce the requested structured response.'],
+    ['error_during_execution', undefined, 'Claude failed before completing the turn.'],
   ] as const;
-  const expectedMessages = [
-    'Claude stopped after reaching the maximum number of turns.',
-    'Claude stopped after reaching the configured budget.',
-    'Claude could not produce the requested structured response.',
-    'Claude failed before completing the turn.',
-  ];
 
-  for (let i = 0; i < subtypes.length; i++) {
-    const subtype = subtypes[i]!;
-    const expected = expectedMessages[i]!;
-
-    const folder = fs.mkdtempSync(path.join(os.tmpdir(), `stashbase-claude-fallback-${i}-`));
-    runWithWindowId(`claude-fallback-window-${i}`, () => setCurrentFolder(folder));
-    t.after(() => {
-      clearAgentRuntimeFailure('claude');
-      runWithWindowId(`claude-fallback-window-${i}`, () => clearCurrentFolder());
-      fs.rmSync(folder, { recursive: true, force: true });
-    });
-
-    const ws = new FakeAgentWebSocket();
-    const mockMessages: SDKMessage[] = [
-      {
-        type: 'result',
-        subtype,
-        is_error: true,
-        errors: [],
-        duration_ms: 100,
-        duration_api_ms: 50,
-        num_turns: 1,
-        stop_reason: 'error',
-        total_cost_usd: 0.01,
-        usage: { input_tokens: 10, output_tokens: 5 } as any,
-        modelUsage: {},
-        permission_denials: [],
-        uuid: 'msg-123' as any,
-        session_id: 'session-123',
-      },
-    ];
-
-    const session = new AgentSession(
-      ws as unknown as WebSocket,
-      `claude-fallback-window-${i}`,
-      undefined,
-      undefined,
-      'default',
-      undefined,
-      undefined,
-      (() => fakeClaudeQuery(mockMessages)) as never,
-      () => '/fake/claude',
-    );
-    session.begin();
+  for (const [index, [subtype, errors, expectedMessage]] of cases.entries()) {
+    const turn = await startScriptedClaudeTurn(t, `claude-fallback-window-${index}`, [
+      claudeErrorResult(subtype, errors),
+    ]);
+    turn.releaseMessages();
     await settle();
 
-    const events = ws.sent.map((value) => JSON.parse(value) as { t: string; message?: string });
-    const errorEvent = events.find((e) => e.t === 'error');
-    assert.ok(errorEvent, `Expected error event for subtype ${subtype}`);
-    assert.equal(errorEvent.message, expected);
+    assert.deepEqual(turn.turnEvents(), [
+      { t: 'turn-start' },
+      { t: 'error', message: expectedMessage },
+      { t: 'turn-end', isError: true },
+    ]);
   }
 });
 
-test('Claude Session handles transient api_retry warnings without permanent errors', async (t) => {
-  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-claude-retry-'));
-  runWithWindowId('claude-retry-window', () => setCurrentFolder(folder));
-  t.after(() => {
-    clearAgentRuntimeFailure('claude');
-    runWithWindowId('claude-retry-window', () => clearCurrentFolder());
-    fs.rmSync(folder, { recursive: true, force: true });
-  });
+test('Claude api_retry followed by success emits no permanent error', async (t) => {
+  const turn = await startScriptedClaudeTurn(t, 'claude-retry-window', [
+    claudeRetryMessage(),
+    claudeSuccessResult(),
+  ]);
 
-  const ws = new FakeAgentWebSocket();
-  const mockMessages: SDKMessage[] = [
-    {
-      type: 'system',
-      subtype: 'api_retry',
-      attempt: 1,
-      max_retries: 3,
-      retry_delay_ms: 1000,
-      error_status: null,
-      error: 'unknown',
-      uuid: 'retry-uuid' as any,
-      session_id: 'session-123',
-    },
-    {
-      type: 'result',
-      subtype: 'success',
-      is_error: false,
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 1,
-      result: 'Hello output',
-      stop_reason: 'end_turn',
-      total_cost_usd: 0.01,
-      usage: { input_tokens: 10, output_tokens: 5 } as any,
-      modelUsage: {},
-      permission_denials: [],
-      uuid: 'msg-123' as any,
-      session_id: 'session-123',
-    },
-  ];
-
-  const session = new AgentSession(
-    ws as unknown as WebSocket,
-    'claude-retry-window',
-    undefined,
-    undefined,
-    'default',
-    undefined,
-    undefined,
-    (() => fakeClaudeQuery(mockMessages)) as never,
-    () => '/fake/claude',
-  );
-  session.begin();
+  turn.releaseMessages();
   await settle();
 
-  const events = ws.sent.map((value) => JSON.parse(value) as { t: string });
-  // Verify api_retry did not emit error to client, and turn finishes successfully
-  assert.equal(events.some((e) => e.t === 'error'), false);
-  const turnEndEvent = events.find((e) => e.t === 'turn-end');
-  assert.ok(turnEndEvent);
-  assert.equal((turnEndEvent as any).isError, false);
+  assert.deepEqual(turn.turnEvents(), [
+    { t: 'turn-start' },
+    { t: 'turn-end', isError: false },
+  ]);
 });
 
-test('Claude Session handles api_retry followed by terminal failure', async (t) => {
-  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-claude-retry-fail-'));
-  runWithWindowId('claude-retry-fail-window', () => setCurrentFolder(folder));
-  t.after(() => {
-    clearAgentRuntimeFailure('claude');
-    runWithWindowId('claude-retry-fail-window', () => clearCurrentFolder());
-    fs.rmSync(folder, { recursive: true, force: true });
-  });
+test('Claude api_retry followed by failure emits one ordered terminal error', async (t) => {
+  const turn = await startScriptedClaudeTurn(t, 'claude-retry-fail-window', [
+    claudeRetryMessage(),
+    claudeErrorResult('error_during_execution', ['Request timed out']),
+  ]);
 
-  const ws = new FakeAgentWebSocket();
-  const mockMessages: SDKMessage[] = [
-    {
-      type: 'system',
-      subtype: 'api_retry',
-      attempt: 1,
-      max_retries: 3,
-      retry_delay_ms: 1000,
-      error_status: null,
-      error: 'unknown',
-      uuid: 'retry-uuid' as any,
-      session_id: 'session-123',
-    },
-    {
-      type: 'result',
-      subtype: 'error_during_execution',
-      is_error: true,
-      errors: ['Request timed out'],
-      duration_ms: 100,
-      duration_api_ms: 50,
-      num_turns: 1,
-      stop_reason: 'error',
-      total_cost_usd: 0.01,
-      usage: { input_tokens: 10, output_tokens: 5 } as any,
-      modelUsage: {},
-      permission_denials: [],
-      uuid: 'msg-123' as any,
-      session_id: 'session-123',
-    },
-  ];
-
-  const session = new AgentSession(
-    ws as unknown as WebSocket,
-    'claude-retry-fail-window',
-    undefined,
-    undefined,
-    'default',
-    undefined,
-    undefined,
-    (() => fakeClaudeQuery(mockMessages)) as never,
-    () => '/fake/claude',
-  );
-  session.begin();
+  turn.releaseMessages();
   await settle();
 
-  const events = ws.sent.map((value) => JSON.parse(value) as { t: string; message?: string; isError?: boolean });
-  // Verify only one final error message and a failed turn-end are emitted
-  const errorEvents = events.filter((e) => e.t === 'error');
-  assert.equal(errorEvents.length, 1);
-  assert.equal(errorEvents[0]?.message, 'Request timed out');
-
-  const turnEndEvent = events.find((e) => e.t === 'turn-end');
-  assert.ok(turnEndEvent);
-  assert.equal(turnEndEvent.isError, true);
+  assert.deepEqual(turn.turnEvents(), [
+    { t: 'turn-start' },
+    { t: 'error', message: 'Request timed out' },
+    { t: 'turn-end', isError: true },
+  ]);
 });
 
-test('Claude Session user cancellation returns non-red turn-end', async (t) => {
-  const folder = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-claude-cancel-'));
-  runWithWindowId('claude-cancel-window', () => setCurrentFolder(folder));
-  t.after(() => {
-    clearAgentRuntimeFailure('claude');
-    runWithWindowId('claude-cancel-window', () => clearCurrentFolder());
-    fs.rmSync(folder, { recursive: true, force: true });
-  });
+test('Claude ignores repeated terminal results for an already settled turn', async (t) => {
+  const failure = claudeErrorResult('error_during_execution', ['Request timed out']);
+  const turn = await startScriptedClaudeTurn(t, 'claude-duplicate-result-window', [failure, failure]);
 
-  const ws = new FakeAgentWebSocket();
-  let triggerResult: (() => void) | null = null;
-  const resultPromise = new Promise<void>((resolve) => {
-    triggerResult = resolve;
-  });
+  turn.releaseMessages();
+  await settle();
 
-  const queryFactory = () => {
-    return {
-      async *[Symbol.asyncIterator]() {
-        await resultPromise;
-        yield {
-          type: 'result',
-          subtype: 'error_during_execution',
-          is_error: true,
-          errors: ['Interrupted by user'],
-          duration_ms: 100,
-          duration_api_ms: 50,
-          num_turns: 1,
-          stop_reason: 'error',
-          total_cost_usd: 0.01,
-          usage: { input_tokens: 10, output_tokens: 5 } as any,
-          modelUsage: {},
-          permission_denials: [],
-          uuid: 'msg-123' as any,
-          session_id: 'session-123',
-        };
-      },
-      supportedModels: async () => [],
-      supportedCommands: async () => [],
-      setModel: async () => {},
-      setPermissionMode: async () => {},
-      interrupt: async () => {},
-    } as unknown as Query;
-  };
+  assert.deepEqual(turn.turnEvents(), [
+    { t: 'turn-start' },
+    { t: 'error', message: 'Request timed out' },
+    { t: 'turn-end', isError: true },
+  ]);
+});
 
-  const session = new AgentSession(
-    ws as unknown as WebSocket,
-    'claude-cancel-window',
-    undefined,
-    undefined,
-    'default',
-    undefined,
-    undefined,
-    queryFactory as any,
-    () => '/fake/claude',
+test('Claude user cancellation stays non-red when its terminal result repeats', async (t) => {
+  const interrupted = claudeErrorResult('error_during_execution', ['Interrupted by user']);
+  const turn = await startScriptedClaudeTurn(t, 'claude-cancel-window', [interrupted, interrupted]);
+
+  turn.ws.emit('message', JSON.stringify({ t: 'interrupt' }));
+  await settle();
+  turn.releaseMessages();
+  await settle();
+
+  assert.deepEqual(turn.turnEvents(), [
+    { t: 'turn-start' },
+    { t: 'turn-end', isError: false },
+  ]);
+});
+
+test('Claude interrupt rejection does not hide a later execution failure', async (t) => {
+  let rejectInterrupt!: (error: Error) => void;
+  const interruptResult = new Promise<void>((_resolve, reject) => { rejectInterrupt = reject; });
+  const turn = await startScriptedClaudeTurn(
+    t,
+    'claude-interrupt-failure-window',
+    [claudeErrorResult('error_during_execution', ['Request timed out'])],
+    () => interruptResult,
   );
-  session.begin();
+
+  turn.ws.emit('message', JSON.stringify({ t: 'interrupt' }));
+  turn.releaseMessages();
+  await settle();
+  rejectInterrupt(new Error('interrupt unavailable'));
   await settle();
 
-  // Send prompt
-  ws.emit('message', JSON.stringify({ t: 'prompt', text: 'run query' }));
-  await settle();
-
-  // Send interrupt client event
-  ws.emit('message', JSON.stringify({ t: 'interrupt' }));
-  await settle();
-
-  // Trigger the result
-  triggerResult!();
-  await settle();
-
-  const events = ws.sent.map((value) => JSON.parse(value) as { t: string; message?: string; isError?: boolean });
-  
-  // Verify client received turn-end with isError: false, and no error message
-  assert.equal(events.some((e) => e.t === 'error'), false);
-  const turnEndEvent = events.find((e) => e.t === 'turn-end');
-  assert.ok(turnEndEvent);
-  assert.equal(turnEndEvent.isError, false);
+  assert.deepEqual(turn.turnEvents(), [
+    { t: 'turn-start' },
+    { t: 'error', message: 'Request timed out' },
+    { t: 'turn-end', isError: true },
+  ]);
 });

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -251,6 +251,7 @@ export class AgentSession {
   private q: Query | null = null;
   private pending = new Map<string, Pending>();
   private closed = false;
+  private interruptRequested = false;
   private nativeDerivedReadRedirected = new Set<string>();
   /** The SDK session_id, captured from the init message. Sent to the
    *  client so the history dropdown can mark this session active. */
@@ -449,6 +450,10 @@ export class AgentSession {
       this.send(claudeActiveModelEvent(this.models, msg.model));
     }
     if (msg.type === 'system' && msg.subtype === 'commands_changed') this.publishSkillCommands(msg.commands);
+    if (msg.type === 'system' && msg.subtype === 'api_retry') {
+      log.info(`Claude SDK is retrying: attempt ${msg.attempt} of ${msg.max_retries} (delay ${msg.retry_delay_ms}ms)`);
+      return;
+    }
     switch (msg.type) {
       case 'stream_event': {
         // Partial deltas → typewriter streaming for text + thinking.
@@ -495,7 +500,43 @@ export class AgentSession {
         break;
       }
       case 'result': {
-        this.send({ t: 'turn-end', isError: msg.is_error === true });
+        const isError = msg.is_error === true;
+        const wasCancelled = this.interruptRequested;
+
+        if (isError && !wasCancelled) {
+          const errorsField = (msg as any).errors;
+          const rawErrors = (Array.isArray(errorsField) ? errorsField : [])
+            .map((e: any) => typeof e === 'string' ? e.trim() : '')
+            .filter((e: string) => e.length > 0);
+
+          const uniqueErrors = Array.from(new Set(rawErrors));
+          let finalMessage = '';
+
+          if (uniqueErrors.length > 0) {
+            finalMessage = uniqueErrors.join('; ');
+            if (finalMessage.length > 2000) {
+              finalMessage = finalMessage.slice(0, 2000);
+            }
+          } else {
+            const subtype = msg.subtype;
+            if (subtype === 'error_max_turns') {
+              finalMessage = 'Claude stopped after reaching the maximum number of turns.';
+            } else if (subtype === 'error_max_budget_usd') {
+              finalMessage = 'Claude stopped after reaching the configured budget.';
+            } else if (subtype === 'error_max_structured_output_retries') {
+              finalMessage = 'Claude could not produce the requested structured response.';
+            } else {
+              finalMessage = 'Claude failed before completing the turn.';
+            }
+          }
+
+          if (finalMessage) {
+            this.send({ t: 'error', message: finalMessage });
+          }
+        }
+
+        this.send({ t: 'turn-end', isError: isError && !wasCancelled });
+        this.interruptRequested = false;
         break;
       }
       default:
@@ -547,6 +588,7 @@ export class AgentSession {
         if (skill && !this.skills.has(skill)) { this.send({ t: 'error', message: 'That skill is no longer available. Type / to choose another.' }); return; }
         if (!body.trim() && !skill) return;
         this.send({ t: 'turn-start' });
+        this.interruptRequested = false;
         this.input.push({
           type: 'user',
           message: { role: 'user', content: claudeSkillPrompt(body, skill) },
@@ -584,6 +626,7 @@ export class AgentSession {
         break;
       }
       case 'interrupt':
+        this.interruptRequested = true;
         void this.q?.interrupt().catch(() => { /* not streaming yet */ });
         break;
       case 'close':

--- a/server/agent.ts
+++ b/server/agent.ts
@@ -60,6 +60,7 @@ import { detectViewerFormat } from './format.ts';
 import { isAgentReadableDerivedTextReady } from './library-file-reader.ts';
 
 type ClaudeSkillCommand = { name: string; description: string; argumentHint: string };
+type ClaudeResultMessage = Extract<SDKMessage, { type: 'result' }>;
 
 export function claudeSkillCatalogEvent(commands: readonly ClaudeSkillCommand[]): Extract<AgentServerEvent, { t: 'skills' }> {
   const skills: AgentSkill[] = commands.filter((command) => Boolean(command.name)).map((command) => ({ id: command.name, label: command.name, ...(command.description ? { description: command.description } : {}), ...(command.argumentHint ? { argumentHint: command.argumentHint } : {}) }));
@@ -251,7 +252,10 @@ export class AgentSession {
   private q: Query | null = null;
   private pending = new Map<string, Pending>();
   private closed = false;
+  private turnActive = false;
+  private turnGeneration = 0;
   private interruptRequested = false;
+  private interruptTask: Promise<void> | null = null;
   private nativeDerivedReadRedirected = new Set<string>();
   /** The SDK session_id, captured from the init message. Sent to the
    *  client so the history dropdown can mark this session active. */
@@ -500,48 +504,70 @@ export class AgentSession {
         break;
       }
       case 'result': {
-        const isError = msg.is_error === true;
-        const wasCancelled = this.interruptRequested;
-
-        if (isError && !wasCancelled) {
-          const errorsField = (msg as any).errors;
-          const rawErrors = (Array.isArray(errorsField) ? errorsField : [])
-            .map((e: any) => typeof e === 'string' ? e.trim() : '')
-            .filter((e: string) => e.length > 0);
-
-          const uniqueErrors = Array.from(new Set(rawErrors));
-          let finalMessage = '';
-
-          if (uniqueErrors.length > 0) {
-            finalMessage = uniqueErrors.join('; ');
-            if (finalMessage.length > 2000) {
-              finalMessage = finalMessage.slice(0, 2000);
-            }
-          } else {
-            const subtype = msg.subtype;
-            if (subtype === 'error_max_turns') {
-              finalMessage = 'Claude stopped after reaching the maximum number of turns.';
-            } else if (subtype === 'error_max_budget_usd') {
-              finalMessage = 'Claude stopped after reaching the configured budget.';
-            } else if (subtype === 'error_max_structured_output_retries') {
-              finalMessage = 'Claude could not produce the requested structured response.';
-            } else {
-              finalMessage = 'Claude failed before completing the turn.';
-            }
-          }
-
-          if (finalMessage) {
-            this.send({ t: 'error', message: finalMessage });
-          }
+        const pendingInterrupt = this.interruptTask;
+        if (pendingInterrupt) {
+          const resultGeneration = this.turnGeneration;
+          void pendingInterrupt.then(() => {
+            if (this.turnGeneration === resultGeneration) this.onClaudeResult(msg);
+          });
+        } else {
+          this.onClaudeResult(msg);
         }
-
-        this.send({ t: 'turn-end', isError: isError && !wasCancelled });
-        this.interruptRequested = false;
         break;
       }
       default:
         break;
     }
+  }
+
+  private onClaudeResult(msg: ClaudeResultMessage): void {
+    // The SDK result is terminal authority for one active turn. Ignore
+    // duplicate or late terminal messages before they can append another
+    // persistent error or settle a queued follow-up twice.
+    if (!this.turnActive) return;
+    const isError = msg.is_error === true;
+    const wasCancelled = this.interruptRequested;
+    this.turnActive = false;
+    this.interruptRequested = false;
+    this.interruptTask = null;
+
+    if (isError && !wasCancelled) {
+      const errorsField = (msg as { errors?: unknown }).errors;
+      const rawErrors = Array.isArray(errorsField)
+        ? errorsField.flatMap((entry: unknown) => {
+            if (typeof entry !== 'string') return [];
+            const trimmed = entry.trim();
+            return trimmed ? [trimmed] : [];
+          })
+        : [];
+
+      const uniqueErrors = Array.from(new Set(rawErrors));
+      let finalMessage = '';
+
+      if (uniqueErrors.length > 0) {
+        finalMessage = uniqueErrors.join('; ');
+        if (finalMessage.length > 2000) {
+          finalMessage = finalMessage.slice(0, 2000);
+        }
+      } else {
+        const subtype = msg.subtype;
+        if (subtype === 'error_max_turns') {
+          finalMessage = 'Claude stopped after reaching the maximum number of turns.';
+        } else if (subtype === 'error_max_budget_usd') {
+          finalMessage = 'Claude stopped after reaching the configured budget.';
+        } else if (subtype === 'error_max_structured_output_retries') {
+          finalMessage = 'Claude could not produce the requested structured response.';
+        } else {
+          finalMessage = 'Claude failed before completing the turn.';
+        }
+      }
+
+      if (finalMessage) {
+        this.send({ t: 'error', message: finalMessage });
+      }
+    }
+
+    this.send({ t: 'turn-end', isError: isError && !wasCancelled });
   }
 
   /** SDK permission callback. Auto-allow reads; round-trip writes/exec to
@@ -587,8 +613,14 @@ export class AgentSession {
         const skill = typeof msg.skill === 'string' ? msg.skill : undefined;
         if (skill && !this.skills.has(skill)) { this.send({ t: 'error', message: 'That skill is no longer available. Type / to choose another.' }); return; }
         if (!body.trim() && !skill) return;
-        this.send({ t: 'turn-start' });
+        // The renderer queues follow-ups and sends them only after the active
+        // terminal event. Refuse an out-of-contract concurrent prompt rather
+        // than letting one SDK result settle the wrong turn.
+        if (this.turnActive) return;
+        this.turnActive = true;
+        this.turnGeneration += 1;
         this.interruptRequested = false;
+        this.send({ t: 'turn-start' });
         this.input.push({
           type: 'user',
           message: { role: 'user', content: claudeSkillPrompt(body, skill) },
@@ -625,10 +657,35 @@ export class AgentSession {
         }
         break;
       }
-      case 'interrupt':
+      case 'interrupt': {
+        if (!this.turnActive || !this.q || this.interruptRequested) break;
+        const interruptedGeneration = this.turnGeneration;
+        let nativeInterrupt: Promise<void>;
+        try {
+          nativeInterrupt = this.q.interrupt();
+        } catch (err: unknown) {
+          log.debug(`Claude interrupt request failed: ${errorMessage(err)}`);
+          break;
+        }
         this.interruptRequested = true;
-        void this.q?.interrupt().catch(() => { /* not streaming yet */ });
+        const trackedInterrupt = nativeInterrupt.then(
+          () => {
+            if (this.interruptTask === trackedInterrupt) this.interruptTask = null;
+          },
+          (err: unknown) => {
+            // A rejected native interrupt did not cancel the turn. Clear only
+            // the matching active generation so a late rejection cannot alter
+            // a later prompt's cancellation state.
+            if (this.interruptTask === trackedInterrupt) this.interruptTask = null;
+            if (this.turnActive && this.turnGeneration === interruptedGeneration) {
+              this.interruptRequested = false;
+            }
+            log.debug(`Claude interrupt request failed: ${errorMessage(err)}`);
+          },
+        );
+        this.interruptTask = trackedInterrupt;
         break;
+      }
       case 'close':
         this.dispose();
         break;


### PR DESCRIPTION
## Summary

Fixes #131. Normalizes Claude turn results and error notifications in the session runtime to preserve execution failure details, handle retry warnings, and treat user-initiated stops cleanly.

## Problem

Under the previous implementation, when a Claude turn failed or encountered warnings:
1. **Silent Failed Turns**: Final error results (`is_error: true`) only emitted `turn-end(isError: true)` to the client, dropping the SDK's `errors[]` array and subtype details entirely. This hid the reason for the failure from the user.
2. **Untracked Retries**: Transient network warnings like `system/api_retry` were not explicitly separated or handled as retry-in-progress, risking incorrect error state transitions.
3. **Interrupt Banners**: A deliberate user interrupt/stop triggered a red failure box rather than finishing as a clean, non-red cancellation.

## Changes Made

- **Error Normalization**: Processed SDK `result` error events in `server/agent.ts` to filter, trim, deduplicate, and join the `errors` list into a single message capped at 2,000 characters.
- **Subtype Fallback mapping**: Mapped empty/missing error arrays to stable user-friendly subtype copies (max turns, budget limits, structured output failure, generic execution error).
- **Transient Retry Interception**: Intercepted `system/api_retry` messages to log them as progress markers without settling the active turn or showing permanent errors.
- **User Interrupt Integration**: Introduced an `interruptRequested` flag in `AgentSession` to catch client-initiated stops, yielding `{ t: 'turn-end', isError: false }` and suppressing the red error notice on cancellation.
- **Engineering Contracts**: Added the Claude normalization rules to the Design Rules section of `code-review/agent-panel.md`.
- **Unit Tests**: Added 5 unit tests inside `server/__tests__/agent.test.ts` validating error list formatting, subtype fallback mappings, api_retry warnings, fatal retries, and user interrupts.

## Validation

- `pnpm typecheck` (Passed cleanly with 0 compilation errors)
- `pnpm test:agent` (62/62 tests passed successfully)
