### PR TITLE
fix(search): gate large semantic indexing workloads

### DIFF
--- a/code-review/architecture.md
+++ b/code-review/architecture.md
@@ -53,6 +53,10 @@ The **Node process** owns application logic, file operations, conversion orchest
 
 The **Python daemon** owns chunking, embedding, storage, and search through MFS/Milvus Lite. It does not know how to convert PDFs, images, or HTML; those decisions stay in StashBase.
 
+The Node reconcile owner also owns semantic-workload preflight and the durable
+per-folder continue/defer decision. Renderer surfaces display its summary and
+send decisions; they never duplicate scanning, hashing, or freshness rules.
+
 The **MCP server** is a Node process. It exposes retrieval, reindexing, and bounded file access to AI clients while the StashBase app is running.
 
 ---

--- a/code-review/data-layer.md
+++ b/code-review/data-layer.md
@@ -199,6 +199,24 @@ For each folder, reconcile checks:
 
 Only changed content should be embedded. A no-op reconcile should not spend embedding tokens. When no OpenAI key is configured, reconcile still discovers PDF/image/DOCX/audio work and keeps keyword-searchable derived text fresh; semantic indexing is skipped and reported as disabled. Audio without the selected local model is not queued and does not become a durable failure.
 
+Large-workload preflight consumes the same authoritative content-hash diff.
+Added and modified indexable sources count; hash-reused renames and no-op scans
+do not. Reconcile invalidates every known-stale modified row before publishing
+an awaiting or paused state. Invalidation failure or unavailable durable state
+falls back to normal indexing; it must never expose an unsafe or invisible
+pause. Known current prepared text contributes its byte size through bounded,
+asynchronous metadata reads, then the same format-specific completion,
+extractable-text, transcript-manifest, source-hash, and compatibility checks
+used by reconcile; mtime alone is never preparation truth. Preflight must not
+synchronously stat a large folder on the Node thread. Resume is serialized behind older folder reconcile
+work and clears the decision inside that queue entry. While paused, an upsert retains a row whose source hash is unchanged and
+invalidates a row whose hash changed. Conversion completion follows the same
+rule. Semantic retrieval additionally excludes daemon-pending identities for
+paused folders, so even a failed delete cannot publish known-stale evidence.
+Explicit Start indexing is the only operation that clears a durable pause.
+Every valid new convertible source counts before preparation exists; only its
+known-text byte contribution waits for a current validated representation.
+
 External writes are not immediately searchable. Editors, Git, cloud sync, terminal commands, and external Agents change the filesystem outside StashBase's write path. They become searchable after reconcile. StashBase-owned file helper writes should schedule or perform index maintenance as part of the write when possible.
 
 ---
@@ -329,6 +347,7 @@ Review invariants:
 - Auxiliary classifiers have a fixed capacity and share task cancellation ownership.
 - Extractor cancellation owns the whole descendant tree: POSIX signals the detached process group, while Windows uses `taskkill /T /F` (`server/extractor-process.ts:38-79`).
 - A stale final artifact is unavailable for the entire queued interval; resumable PDF batches and audio checkpoints never count as final artifacts.
+- Semantic workload estimation treats the daemon's content-hash `modified` set as stronger than derived timestamps: modified convertible sources count toward the source threshold but their pre-existing prepared bytes never count. Added-source prepared volume is accepted only through asynchronous format-specific completion validation; large DOCX analysis and audio JSON/schema validation run in a bounded worker-thread lane, so neither filesystem reads nor CPU parsing monopolise the server event loop.
 - Folder removal, source delete/rename, and shutdown consult the scheduler so queued or native work is not invisible.
 - File/folder rename and delete validate the requested mutation before cancelling work, then cancel queued/running source and preview tasks and await handle/lane release before touching disk. Successful operations clean stale derived ownership and rediscover convertible sources at new paths in both the active-folder and library/MCP surfaces (`server/file-operation-guard.ts:1-8`, `server/routes/file-mutations.ts:35-209`, `server/library-file-mutations.ts:78-198`, `server/routes/folders.ts:58-173`, `server/conversion-dispatch.ts:15-51`). Library mutations retain their own folder context and version checks when no window has that folder open; the cross-platform integration gate exercises this through MCP, the library HTTP routes, and the mutation service with isolated application-data roots (`server/library-file-mutations.test.ts:16-155`).
 - Disk-backed imports never perform a potentially multi-gigabyte copy or an oversized whole-text read on the Node event loop; disconnect cancellation removes the unpublished same-directory temporary, final publication cannot replace a concurrently created destination, startup reclaims dead staging and identity-proven incomplete fallback reservations, and the 8 MiB indexing budget never changes whether publication itself succeeded.

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -60,6 +60,9 @@ user-visible source file.
   editing, and keyword retrieval remain available.
 - Incomplete, stale, or partial derived output is never current truth.
 - Reconcile and reindex bring external file changes back into the library.
+- Reconcile estimates new or changed semantic work before embedding. Large
+  workloads pause per folder for an explicit decision without delaying folder
+  navigation, preparation, editing, or keyword retrieval.
 
 ## Liveness And Recovery
 

--- a/design-docs/design/library.md
+++ b/design-docs/design/library.md
@@ -42,10 +42,15 @@ to migrate them into a StashBase-specific storage model.
 - Search results and agent file links return users to those source files.
 - Root-level `AGENTS.md` and optional `CLAUDE.md` bridge files are visible,
   editable user files. StashBase only creates missing defaults.
+- Opening a folder starts changed-content indexing checks in the background.
+  When the pending semantic workload is unusually large, a persistent,
+  non-blocking notice lets the user start it or leave it paused for that folder.
 
 ## Experience Contract
 
 - Opening a folder should feel like navigation, not a long preparation task.
+- Deferring semantic indexing must not block browsing, editing, preparation, or
+  keyword search, and the decision must remain recoverable after restart.
 - Opening or closing one window must not switch or close another window's
   folder context.
 - Window lifecycle shortcuts must not be interpreted as document-tab commands.

--- a/design-docs/design/search.md
+++ b/design-docs/design/search.md
@@ -20,6 +20,11 @@ as the result identity.
   scores have no absolute meaning.
 - Prepared PDF, image, DOCX, and media transcript text can be evidence, but
   opening a result returns to the original source file.
+- Search distinguishes disabled, preparing, partially ready, paused, failed,
+  and ready semantic states. A paused folder keeps a persistent Start indexing
+  action while keyword search remains usable.
+- A sync failure is diagnostic and does not replace an awaiting or paused
+  decision; its recovery action remains visible alongside failure guidance.
 - MCP offers orientation, search with the same file-type categories as the
   app, read, reindex, and bounded file operations to authorized Agent clients.
 
@@ -31,6 +36,8 @@ as the result identity.
 - Scope and access restrictions apply equally to app and MCP retrieval.
 - Readiness should be understandable: missing results may be caused by
   preparation, indexing, scope, or search mode.
+- Known-stale vectors are removed before a large changed-content workload is
+  paused; still-current indexed files may continue to provide partial results.
 - Embedding credentials need access only to the configured embedding model;
   provider model-list access is not required.
 - MCP is context infrastructure, not unrestricted host-filesystem access.

--- a/design-docs/use-cases.md
+++ b/design-docs/use-cases.md
@@ -148,6 +148,11 @@ them into a new storage model. PDFs, DOCX files, images, audio, and video gain
 searchable representations while the original files remain visible in their
 existing locations.
 
+For a large new or changed archive, the folder remains immediately usable and
+StashBase explains the pending semantic workload before consuming embedding
+quota. The user can defer it, continue with files and keyword search, and start
+semantic indexing later from the persistent notice.
+
 The user can search for “Why did this project reject PostgreSQL?” or “Which
 papers compared these two methods?” without remembering the original wording.
 Results point back to the source files, making it easy to check the surrounding

--- a/server/audio-transcription.ts
+++ b/server/audio-transcription.ts
@@ -21,6 +21,7 @@ import {
 import { getTranscriptionPreferences } from './app-config.ts';
 import { isAudioFile } from './format.ts';
 import {
+  derivedIsFresh,
   discoverNewSources,
   getScheduledConversion,
   indexFreshDerived,
@@ -38,6 +39,7 @@ import { isPendingOrFailed, markCancelled } from './conversion-status.ts';
 import { filesystemPath } from './filesystem-path.ts';
 import { isCloudPlaceholderName, isIndexExcludedDirName } from './indexable.ts';
 import { blake3File } from './file-hash.ts';
+import { validatePreparedAudioTranscript } from './prepared-validation.ts';
 import {
   getTranscriptionProvider,
   type TranscriptionModelRef,
@@ -375,6 +377,19 @@ export function configuredTranscriptionBlock(): ConfiguredTranscriptionBlock | n
 
 export function derivedTranscriptPathForAudio(sourceAbs: string): string {
   return derivedTranscriptFor(sourceAbs);
+}
+
+export function currentDerivedTextPathForAudio(sourceAbs: string, known?: { sourceMtimeMs: number; derivedMtimeMs: number }): string | null {
+  return derivedIsFresh(AUDIO_FRESHNESS_POLICY, sourceAbs, known) ? derivedNoteFor(sourceAbs) : null;
+}
+
+export async function currentDerivedTextPathForAudioAsync(
+  sourceAbs: string,
+  known: { sourceMtimeMs: number; derivedMtimeMs: number },
+): Promise<string | null> {
+  if (known.derivedMtimeMs < known.sourceMtimeMs) return null;
+  return await readCurrentAudioTranscriptAsync(sourceAbs, derivedNoteFor(sourceAbs))
+    ? derivedNoteFor(sourceAbs) : null;
 }
 
 export function readAudioTranscript(sourceAbs: string): AudioTranscript | null {
@@ -732,14 +747,12 @@ async function readCurrentAudioTranscriptAsync(sourceAbs: string, notePath: stri
     };
     const note = await fs.promises.stat(notePath);
     if (note.mtimeMs < source.mtimeMs || !(await fileTailContains(notePath, AUDIO_COMPLETE_MARKER))) return null;
-    const raw = await fs.promises.readFile(derivedTranscriptFor(sourceAbs), 'utf8');
-    // Parsing can still be CPU work for very long transcripts; yield between
-    // files so one first-time scan cannot monopolise the server turn.
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    const transcript = parseAudioTranscript(JSON.parse(raw));
-    return sameAudioSourceIdentity(transcript.source, source) && nonEmptyString(transcript.source.contentHash)
-      ? transcript
-      : null;
+    const raw = await fs.promises.readFile(derivedTranscriptFor(sourceAbs));
+    const transcriptSource = await validatePreparedAudioTranscript(raw);
+    if (!sameAudioSourceIdentity(transcriptSource, source) || !nonEmptyString(transcriptSource.contentHash)) return null;
+    // Callers of the asynchronous freshness guard only need validity and
+    // source binding. Keep the large segment array inside the worker.
+    return { source: transcriptSource } as AudioTranscript;
   } catch {
     return null;
   }

--- a/server/conversion-dispatch.ts
+++ b/server/conversion-dispatch.ts
@@ -7,6 +7,9 @@
 import fs from 'node:fs';
 import {
   configuredTranscriptionBlock,
+  currentDerivedTextPathForAudio,
+  currentDerivedTextPathForAudioAsync,
+  derivedTranscriptPathForAudio,
   discoverNewAudio,
   indexFreshAudio,
   maybeConvertAudio,
@@ -14,11 +17,11 @@ import {
 } from './audio-transcription.ts';
 import { promoteConversion } from './conversion.ts';
 import { clearRecord } from './conversion-status.ts';
-import { derivedHtmlPathForDocx, discoverNewDocx, indexFreshDocx, maybeConvertDocx } from './docx.ts';
+import { currentDerivedTextPathForDocx, currentDerivedTextPathForDocxAsync, derivedHtmlPathForDocx, discoverNewDocx, indexFreshDocx, maybeConvertDocx } from './docx.ts';
 import { filesystemPath } from './filesystem-path.ts';
 import { isAudioFile, isDocxFile, isImageFile } from './format.ts';
-import { derivedNotePathForImage, discoverNewImages, indexFreshImage, maybeConvertImage } from './image.ts';
-import { derivedPathsForPdf, discoverNewPdfs, indexFreshPdf, maybeConvertPdf } from './pdf.ts';
+import { currentDerivedTextPathForImage, currentDerivedTextPathForImageAsync, derivedNotePathForImage, discoverNewImages, indexFreshImage, maybeConvertImage } from './image.ts';
+import { currentDerivedTextPathForPdf, currentDerivedTextPathForPdfAsync, derivedPathsForPdf, discoverNewPdfs, indexFreshPdf, maybeConvertPdf } from './pdf.ts';
 import type { ConfiguredTranscriptionBlock } from '../shared/transcription.ts';
 
 export interface ConvertibleOptions {
@@ -39,6 +42,9 @@ interface ConvertibleFormatAdapter {
   reset(sourceAbs: string): void;
   interactive: boolean;
   reprocessBlock?(): ConfiguredTranscriptionBlock | null;
+  currentTextPath(sourceAbs: string, known?: { sourceMtimeMs: number; derivedMtimeMs: number }): string | null;
+  currentTextPathAsync(sourceAbs: string, known: { sourceMtimeMs: number; derivedMtimeMs: number }): Promise<string | null>;
+  textCandidatePath(sourceAbs: string): string;
 }
 
 const FORMATS: readonly ConvertibleFormatAdapter[] = [
@@ -53,6 +59,9 @@ const FORMATS: readonly ConvertibleFormatAdapter[] = [
       fs.rmSync(bundleDir, { recursive: true, force: true });
     },
     interactive: false,
+    currentTextPath: currentDerivedTextPathForPdf,
+    currentTextPathAsync: currentDerivedTextPathForPdfAsync,
+    textCandidatePath: (source) => derivedPathsForPdf(source).notePath,
   },
   {
     matches: isImageFile,
@@ -61,6 +70,9 @@ const FORMATS: readonly ConvertibleFormatAdapter[] = [
     indexFresh: indexFreshImage,
     reset: (sourceAbs) => fs.rmSync(derivedNotePathForImage(sourceAbs), { force: true }),
     interactive: false,
+    currentTextPath: currentDerivedTextPathForImage,
+    currentTextPathAsync: currentDerivedTextPathForImageAsync,
+    textCandidatePath: derivedNotePathForImage,
   },
   {
     matches: isDocxFile,
@@ -69,6 +81,9 @@ const FORMATS: readonly ConvertibleFormatAdapter[] = [
     indexFresh: indexFreshDocx,
     reset: (sourceAbs) => fs.rmSync(derivedHtmlPathForDocx(sourceAbs), { force: true }),
     interactive: true,
+    currentTextPath: currentDerivedTextPathForDocx,
+    currentTextPathAsync: currentDerivedTextPathForDocxAsync,
+    textCandidatePath: derivedHtmlPathForDocx,
   },
   {
     matches: isAudioFile,
@@ -77,6 +92,9 @@ const FORMATS: readonly ConvertibleFormatAdapter[] = [
     indexFresh: indexFreshAudio,
     reset: resetAudioTranscription,
     interactive: true,
+    currentTextPath: currentDerivedTextPathForAudio,
+    currentTextPathAsync: currentDerivedTextPathForAudioAsync,
+    textCandidatePath: derivedTranscriptPathForAudio,
     reprocessBlock: configuredTranscriptionBlock,
   },
 ];
@@ -123,6 +141,26 @@ export function discoverConvertibleSources(folderAbs: string): void {
 
 export function indexFreshConvertibleSource(sourceAbs: string, displayName = sourceAbs): Promise<boolean> {
   return findFormat(displayName)?.indexFresh(sourceAbs) ?? Promise.resolve(false);
+}
+
+export function currentPreparedTextPath(
+  sourceAbs: string,
+  displayName = sourceAbs,
+  known?: { sourceMtimeMs: number; derivedMtimeMs: number },
+): string | null {
+  return findFormat(displayName)?.currentTextPath(sourceAbs, known) ?? null;
+}
+
+export function currentPreparedTextPathAsync(
+  sourceAbs: string,
+  displayName: string,
+  known: { sourceMtimeMs: number; derivedMtimeMs: number },
+): Promise<string | null> {
+  return findFormat(displayName)?.currentTextPathAsync(sourceAbs, known) ?? Promise.resolve(null);
+}
+
+export function preparedTextCandidatePath(sourceAbs: string, displayName = sourceAbs): string | null {
+  return findFormat(displayName)?.textCandidatePath(sourceAbs) ?? null;
 }
 
 function findFormat(candidate: string): ConvertibleFormatAdapter | null {

--- a/server/conversion.ts
+++ b/server/conversion.ts
@@ -130,11 +130,15 @@ export function setDerivedNoteIndexer(
  *  old derived text → re-convert. This is the change-detection signal now
  *  that the derived text lives in app data (path-hash keyed, so its
  *  location doesn't change when the source content changes). */
-function derivedIsFresh(spec: DerivedFreshnessSpec, absPath: string): boolean {
+export function derivedIsFresh(
+  spec: DerivedFreshnessSpec,
+  absPath: string,
+  known?: { sourceMtimeMs: number; derivedMtimeMs: number },
+): boolean {
   try {
     const derivedAbs = spec.derivedNote(absPath);
-    const derivedMtime = fs.statSync(derivedAbs).mtimeMs;
-    const sourceMtime = fs.statSync(absPath).mtimeMs;
+    const derivedMtime = known?.derivedMtimeMs ?? fs.statSync(derivedAbs).mtimeMs;
+    const sourceMtime = known?.sourceMtimeMs ?? fs.statSync(absPath).mtimeMs;
     return derivedMtime >= sourceMtime && (spec.derivedReady?.(absPath, derivedAbs) ?? true);
   } catch {
     return false; // derived missing (or source gone) → not fresh

--- a/server/docx.ts
+++ b/server/docx.ts
@@ -7,7 +7,7 @@
  * search, Agent text reads, and semantic indexing under the original `.docx`
  * path.
  */
-import { closeSync, mkdirSync, openSync, readSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import fs, { closeSync, mkdirSync, openSync, readSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -15,6 +15,7 @@ import { Worker } from 'node:worker_threads';
 import { isDocxFile } from './format.ts';
 import { derivedDir, derivedHtmlFor } from './derived-store.ts';
 import {
+  derivedIsFresh,
   discoverNewSources,
   indexFreshDerived,
   maybeConvert,
@@ -23,6 +24,7 @@ import {
 } from './conversion.ts';
 import { logger } from './log.ts';
 import { hasNoExtractableText } from './indexable.ts';
+import { validatePreparedDocxText } from './prepared-validation.ts';
 import { docxSanitizePolicy } from '../shared/html-sanitization.ts';
 
 const log = logger('docx');
@@ -70,6 +72,25 @@ const DOCX_WORKER_SOURCE = [
 
 export function derivedHtmlPathForDocx(docxAbsPath: string): string {
   return derivedHtmlFor(docxAbsPath);
+}
+
+export function currentDerivedTextPathForDocx(sourceAbs: string, known?: { sourceMtimeMs: number; derivedMtimeMs: number }): string | null {
+  return derivedIsFresh(DOCX_SPEC, sourceAbs, known) ? derivedHtmlPathForDocx(sourceAbs) : null;
+}
+
+export async function currentDerivedTextPathForDocxAsync(
+  sourceAbs: string,
+  known: { sourceMtimeMs: number; derivedMtimeMs: number },
+): Promise<string | null> {
+  if (known.derivedMtimeMs < known.sourceMtimeMs) return null;
+  const htmlPath = derivedHtmlPathForDocx(sourceAbs);
+  try {
+    const html = await fs.promises.readFile(htmlPath);
+    if (!html.subarray(Math.max(0, html.length - 2048)).toString('utf8').includes(DOCX_COMPLETE_MARKER)) return null;
+    return await validatePreparedDocxText(html) ? htmlPath : null;
+  } catch {
+    return null;
+  }
 }
 
 function cleanupDerivedDocx(docxAbsPath: string): void {

--- a/server/image.ts
+++ b/server/image.ts
@@ -15,11 +15,11 @@
  * failures cover images and PDFs through one path.
  */
 import { spawn } from 'node:child_process';
-import { closeSync, mkdirSync, openSync, readSync, rmSync, statSync } from 'node:fs';
+import fs, { closeSync, mkdirSync, openSync, readSync, rmSync, statSync } from 'node:fs';
 import { isImageFile } from './format.ts';
 import { derivedNoteFor, derivedDir } from './derived-store.ts';
 import { extractorSpawn } from './python-host.ts';
-import { discoverNewSources, indexFreshDerived, maybeConvert, TransientConversionError, type ConversionSpec } from './conversion.ts';
+import { derivedIsFresh, discoverNewSources, indexFreshDerived, maybeConvert, TransientConversionError, type ConversionSpec } from './conversion.ts';
 import { lowerExtractorPriority, spawnOptionsForExtractor, terminateExtractorTree } from './extractor-process.ts';
 
 const OCR_COMPLETE_MARKER = '<!-- stashbase-ocr-conversion: complete -->';
@@ -28,6 +28,31 @@ const OCR_COMPLETE_MARKER = '<!-- stashbase-ocr-conversion: complete -->';
  *  the user's opened folder (see `derived-store.ts`). No image bundle. */
 export function derivedNotePathForImage(imageAbsPath: string): string {
   return derivedNoteFor(imageAbsPath);
+}
+
+export function currentDerivedTextPathForImage(sourceAbs: string, known?: { sourceMtimeMs: number; derivedMtimeMs: number }): string | null {
+  return derivedIsFresh(IMAGE_SPEC, sourceAbs, known) ? derivedNotePathForImage(sourceAbs) : null;
+}
+
+export async function currentDerivedTextPathForImageAsync(
+  sourceAbs: string,
+  known: { sourceMtimeMs: number; derivedMtimeMs: number },
+): Promise<string | null> {
+  const notePath = derivedNotePathForImage(sourceAbs);
+  if (known.derivedMtimeMs < known.sourceMtimeMs) return null;
+  let handle: fs.promises.FileHandle | null = null;
+  try {
+    handle = await fs.promises.open(notePath, 'r');
+    const stat = await handle.stat();
+    const length = Math.min(stat.size, 2048);
+    const buffer = Buffer.alloc(length);
+    await handle.read(buffer, 0, length, Math.max(0, stat.size - length));
+    return buffer.toString('utf8').includes(OCR_COMPLETE_MARKER) ? notePath : null;
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
 }
 
 function cleanupDerivedImage(imageAbsPath: string): void {

--- a/server/index-status.test.ts
+++ b/server/index-status.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import {
   conversionProgressForFolder,
   conversionVersionsForFolder,
+  semanticIndexingState,
 } from './index-status.ts';
 
 test('index status conversion maps are scoped and folder-relative', () => {
@@ -30,4 +31,14 @@ test('index status conversion maps are scoped and folder-relative', () => {
   assert.deepEqual(conversionVersionsForFolder(root, snapshot as any), {
     'docs/paper.pdf': 11,
   });
+});
+
+test('semantic status distinguishes disabled, partial, paused, ready, and failed', () => {
+  assert.equal(semanticIndexingState({ enabled: false, decision: null, indexed: 0, pending: 3, failed: false }), 'disabled');
+  assert.equal(semanticIndexingState({ enabled: true, decision: 'awaiting-decision', indexed: 2, pending: 3, failed: false }), 'awaiting-decision');
+  assert.equal(semanticIndexingState({ enabled: true, decision: 'paused', indexed: 2, pending: 3, failed: false }), 'partial-paused');
+  assert.equal(semanticIndexingState({ enabled: true, decision: 'paused', indexed: 2, pending: 3, failed: true }), 'partial-paused');
+  assert.equal(semanticIndexingState({ enabled: true, decision: null, indexed: 2, pending: 3, failed: false }), 'partial-indexing');
+  assert.equal(semanticIndexingState({ enabled: true, decision: null, indexed: 2, pending: 0, failed: false }), 'ready');
+  assert.equal(semanticIndexingState({ enabled: true, decision: null, indexed: 2, pending: 0, failed: true }), 'failed');
 });

--- a/server/index-status.ts
+++ b/server/index-status.ts
@@ -7,7 +7,7 @@ import { filesystemPath } from './filesystem-path.ts';
 import { hasNoExtractableText, shouldIndexFilePath } from './indexable.ts';
 import { displayPathForHit } from './pdf.ts';
 import { getFsChangeCounter } from './watcher.ts';
-import { getIndexWarning, indexer } from './state.ts';
+import { getIndexWarning, getSemanticIndexingState, indexer } from './state.ts';
 
 type SchedulerSnapshot = ReturnType<typeof getConversionSchedulerSnapshot>;
 
@@ -16,6 +16,21 @@ export interface PreparationFailure {
   lastError: string;
   attempts: number;
   status: 'failed' | 'cancelled';
+}
+
+export function semanticIndexingState(input: {
+  enabled: boolean;
+  decision: 'awaiting-decision' | 'paused' | null;
+  indexed: number;
+  pending: number;
+  failed: boolean;
+}): string {
+  if (!input.enabled) return 'disabled';
+  if (input.decision === 'awaiting-decision') return 'awaiting-decision';
+  if (input.decision === 'paused') return input.indexed > 0 ? 'partial-paused' : 'paused';
+  if (input.failed) return 'failed';
+  if (input.pending > 0) return input.indexed > 0 ? 'partial-indexing' : 'indexing';
+  return 'ready';
 }
 
 export async function buildIndexStatus(folderRoot: string): Promise<Record<string, unknown>> {
@@ -28,6 +43,15 @@ export async function buildIndexStatus(folderRoot: string): Promise<Record<strin
     .map((p) => filesystemPath.relative(curRoot, p))
     .filter((p): p is string => p != null);
   const schedulerSnapshot = getConversionSchedulerSnapshot();
+  const semanticDecision = semanticEnabled ? getSemanticIndexingState(curRoot) : null;
+  const indexWarning = getIndexWarning(curRoot);
+  const semanticState = semanticIndexingState({
+    enabled: semanticEnabled,
+    decision: semanticDecision?.decision ?? null,
+    indexed: status.indexed,
+    pending: pending.length,
+    failed: indexWarning != null,
+  });
 
   return {
     folder: curRoot,
@@ -38,7 +62,14 @@ export async function buildIndexStatus(folderRoot: string): Promise<Record<strin
     pendingCount: pending.length,
     orphaned,
     orphanedCount: orphaned.length,
-    visibleIndexingSettled: !semanticEnabled || pending.length === 0,
+    visibleIndexingSettled: !semanticEnabled || semanticDecision != null || pending.length === 0,
+    semanticIndexing: {
+      state: semanticState,
+      ...(semanticDecision ? {
+        sourceCount: semanticDecision.sourceCount,
+        estimatedBytes: semanticDecision.estimatedBytes,
+      } : {}),
+    },
     pendingConversions: getInFlightConversions(curRoot),
     blockedConversions: await blockedAudioSourcesForFolder(curRoot, treeVersion),
     conversionProgress: conversionProgressForFolder(curRoot, schedulerSnapshot),
@@ -46,7 +77,7 @@ export async function buildIndexStatus(folderRoot: string): Promise<Record<strin
     conversionVersions: conversionVersionsForFolder(curRoot, schedulerSnapshot),
     preparationFailures: preparationFailuresForFolder(curRoot),
     treeVersion,
-    indexWarning: getIndexWarning(curRoot),
+    indexWarning,
   };
 }
 

--- a/server/indexer.mfs.ts
+++ b/server/indexer.mfs.ts
@@ -23,6 +23,7 @@ import { logger } from './log.ts';
 import { getDaemon } from './mfs-daemon.ts';
 import { filesystemPath } from './filesystem-path.ts';
 import type { FilesystemPathModule } from './filesystem-path.ts';
+import { getSemanticIndexingDecision } from './state-db.ts';
 import type {
   EmbedderRuntimeConfig,
   Indexer,
@@ -32,6 +33,21 @@ import type {
 } from './indexer.ts';
 
 const log = logger('index');
+
+export function pausedWriteDisposition(
+  indexedHash: string | null | undefined,
+  nextHash: string,
+): 'index' | 'retain' | 'invalidate' {
+  if (indexedHash === undefined) return 'index';
+  return indexedHash === nextHash ? 'retain' : 'invalidate';
+}
+
+export function excludePausedPendingHits<T extends { fileName: string }>(
+  hits: T[],
+  pending: ReadonlySet<string>,
+): T[] {
+  return hits.filter((hit) => !pending.has(filesystemPath.identity(hit.fileName)));
+}
 
 // The daemon keys its single global collection by **absolute POSIX path**
 // and binds absolute folder roots. Under the Folder model every caller
@@ -117,6 +133,15 @@ export class MfsIndexer implements Indexer {
   private legacySources: Map<string, string> | null = null;
   private legacySourceGeneration = -1;
 
+  private async pausedIndexedHash(sourcePath: string): Promise<string | null | undefined> {
+    for (const folder of getDaemon().knownBindings().keys()) {
+      if (!filesystemPath.contains(folder, sourcePath) || !getSemanticIndexingDecision(folder)) continue;
+      const indexed = await this.listFiles(folder);
+      return indexed[normalizeDaemonPath(sourcePath)] ?? null;
+    }
+    return undefined;
+  }
+
   async bindFolder(folder: string, cfg: EmbedderRuntimeConfig): Promise<void> {
     const daemon = getDaemon();
     const source = normalizeDaemonPath(folder);
@@ -167,6 +192,13 @@ export class MfsIndexer implements Indexer {
       return 0;
     }
     const { text, ext, fileHash } = prepareForIndex(filePath, content);
+    const pausedHash = await this.pausedIndexedHash(filePath);
+    const pausedDisposition = pausedWriteDisposition(pausedHash, fileHash);
+    if (pausedDisposition !== 'index') {
+      if (pausedDisposition === 'retain') return 1;
+      await getDaemon().call('delete', { path: normalizeDaemonPath(filePath) });
+      return 0;
+    }
     // Covers truly empty files AND files whose extractable text is empty
     // (bundler-format HTML that is one giant <script>, whitespace-only
     // notes) — embedding either would store 0 chunks, so skip the
@@ -196,6 +228,13 @@ export class MfsIndexer implements Indexer {
   }
 
   async upsertConvertedFile(sourceAbs: string, derivedContent: string, sourceHash: string, derivedExt = '.md'): Promise<number> {
+    const pausedHash = await this.pausedIndexedHash(sourceAbs);
+    const pausedDisposition = pausedWriteDisposition(pausedHash, sourceHash);
+    if (pausedDisposition !== 'index') {
+      if (pausedDisposition === 'retain') return 1;
+      await getDaemon().call('delete', { path: normalizeDaemonPath(sourceAbs) });
+      return 0;
+    }
     // Convertible sources: the searchable text is stored in AppData, but
     // indexed UNDER the source's own path so folder-scoped search finds it
     // and daemon source-file hash diff matches. HTML-derived DOCX content is
@@ -322,7 +361,7 @@ export class MfsIndexer implements Indexer {
     if (pathPrefix) args.path_prefix = normalizeDaemonPath(pathPrefix);
     if (extensions && extensions.length > 0) args.extensions = extensions;
     const res = await getDaemon().call<{ hits: DaemonHit[] }>('search', args);
-    return res.hits.map((h) => ({
+    const hits = res.hits.map((h) => ({
       fileName: normalizeDaemonPath(h.path),
       chunkIndex: h.chunk_index,
       content: h.chunk_text,
@@ -336,6 +375,14 @@ export class MfsIndexer implements Indexer {
       endLine: h.end_line,
       score: h.score,
     }));
+    const pending = new Set<string>();
+    const candidateFolders = folder ? [folder] : [...getDaemon().knownBindings().keys()];
+    for (const candidate of candidateFolders) {
+      if (!getSemanticIndexingDecision(candidate)) continue;
+      const status = await this.status(candidate);
+      for (const source of status.pending) pending.add(filesystemPath.identity(source));
+    }
+    return pending.size > 0 ? excludePausedPendingHits(hits, pending) : hits;
   }
 
   async status(folder?: string): Promise<IndexStatus> {

--- a/server/pdf.ts
+++ b/server/pdf.ts
@@ -13,13 +13,14 @@
  * to plain PyMuPDF text extraction when the richer layout pass fails.
  */
 import { spawn } from 'node:child_process';
-import { closeSync, existsSync, mkdirSync, openSync, readSync, rmSync, statSync } from 'node:fs';
+import fs, { closeSync, existsSync, mkdirSync, openSync, readSync, rmSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { isDerivedNoteName, matchDerivedNote, NOTE_EXTS } from './format.ts';
 import { derivedNoteFor, derivedBundleFor, derivedBatchesFor, derivedDir } from './derived-store.ts';
 import { extractorSpawn } from './python-host.ts';
 import {
   discoverNewSources,
+  derivedIsFresh,
   indexFreshDerived,
   maybeConvert,
   TransientConversionError,
@@ -58,6 +59,35 @@ export function derivedPathsForPdf(pdfAbsPath: string): { notePath: string; bund
     notePath: derivedNoteFor(pdfAbsPath),
     bundleDir: derivedBundleFor(pdfAbsPath),
   };
+}
+
+export function currentDerivedTextPathForPdf(sourceAbs: string, known?: { sourceMtimeMs: number; derivedMtimeMs: number }): string | null {
+  return derivedIsFresh(PDF_SPEC, sourceAbs, known) ? derivedPathsForPdf(sourceAbs).notePath : null;
+}
+
+export async function currentDerivedTextPathForPdfAsync(
+  sourceAbs: string,
+  known: { sourceMtimeMs: number; derivedMtimeMs: number },
+): Promise<string | null> {
+  const notePath = derivedPathsForPdf(sourceAbs).notePath;
+  return known.derivedMtimeMs >= known.sourceMtimeMs
+    && await derivedTailContains(notePath, PDF_COMPLETE_MARKER, 4096) ? notePath : null;
+}
+
+async function derivedTailContains(file: string, marker: string, tailBytes: number): Promise<boolean> {
+  let handle: fs.promises.FileHandle | null = null;
+  try {
+    handle = await fs.promises.open(file, 'r');
+    const stat = await handle.stat();
+    const length = Math.min(stat.size, tailBytes);
+    const buffer = Buffer.alloc(length);
+    await handle.read(buffer, 0, length, Math.max(0, stat.size - length));
+    return buffer.toString('utf8').includes(marker);
+  } catch {
+    return false;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
 }
 
 function cleanupDerivedPdf(pdfAbsPath: string): void {

--- a/server/prepared-validation.ts
+++ b/server/prepared-validation.ts
@@ -1,0 +1,80 @@
+import { Worker } from 'node:worker_threads';
+
+type Task = { kind: 'docx' | 'audio'; bytes: Uint8Array };
+export type AudioPreparedIdentity = { size: number; mtimeMs: number; statIdentity: string; contentHash: string };
+
+const WORKER_SOURCE = String.raw`
+const { parentPort, workerData } = require('node:worker_threads');
+const record = v => typeof v === 'object' && v !== null && !Array.isArray(v);
+const nonEmpty = v => typeof v === 'string' && v.trim().length > 0;
+const nonNegative = v => typeof v === 'number' && Number.isFinite(v) && v >= 0;
+const positive = v => typeof v === 'number' && Number.isFinite(v) && v > 0;
+function docxHasText(html) {
+  const text = html.replace(/<(script|style|noscript|template)\b[\s\S]*?<\/\1\s*>/gi, ' ')
+    .replace(/<\s*br\s*\/?>/gi, '\n').replace(/<\/\s*(p|div|section|article|li|tr|h[1-6])\s*>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ').replace(/&nbsp;/gi, ' ').replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<').replace(/&gt;/gi, '>').replace(/&quot;/gi, '"').replace(/&#39;|&apos;/gi, "'")
+    .replace(/&#(\d+);/g, (_, n) => { try { return String.fromCodePoint(Number(n)); } catch { return ''; } })
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => { try { return String.fromCodePoint(Number.parseInt(n, 16)); } catch { return ''; } });
+  return text.trim().length > 0;
+}
+function audioIdentity(text) {
+  const value = JSON.parse(text), source = value && value.source, provider = value && value.provider;
+  const segments = value && value.segments;
+  if (!record(value) || value.schemaVersion !== 1 || !record(source) || !positive(source.durationMs)
+    || !nonNegative(source.size) || !nonNegative(source.mtimeMs) || !nonEmpty(source.statIdentity)
+    || typeof source.contentHash !== 'string' || !/^[a-f0-9]{64}$/i.test(source.contentHash)
+    || !record(provider) || !nonEmpty(provider.id) || !nonEmpty(provider.version) || !nonEmpty(provider.model)
+    || !nonEmpty(value.language) || !nonEmpty(value.createdAt) || !Number.isFinite(Date.parse(value.createdAt))
+    || !Array.isArray(segments)) throw new Error('invalid audio transcript');
+  let previousStartMs = -1;
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index];
+    if (!record(segment) || segment.id !== index + 1 || !Number.isInteger(segment.id)
+      || !nonNegative(segment.startMs) || !nonNegative(segment.endMs) || segment.endMs < segment.startMs
+      || segment.endMs > source.durationMs || segment.startMs < previousStartMs || !nonEmpty(segment.text))
+      throw new Error('invalid audio transcript');
+    previousStartMs = segment.startMs;
+  }
+  return { size: source.size, mtimeMs: source.mtimeMs, statIdentity: source.statIdentity, contentHash: source.contentHash };
+}
+try {
+  const text = Buffer.from(workerData.bytes).toString('utf8');
+  parentPort.postMessage({ ok: true, value: workerData.kind === 'docx' ? docxHasText(text) : audioIdentity(text) });
+}
+catch (error) { parentPort.postMessage({ ok: false, error: error && error.message ? error.message : String(error) }); }
+`;
+
+const MAX_WORKERS = 2;
+let active = 0;
+const waiters: Array<() => void> = [];
+
+async function run<T>(task: Task): Promise<T> {
+  if (active >= MAX_WORKERS) await new Promise<void>((resolve) => waiters.push(resolve));
+  active += 1;
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      const worker = new Worker(WORKER_SOURCE, {
+        eval: true,
+        workerData: task,
+        transferList: [task.bytes.buffer as ArrayBuffer],
+      });
+      let settled = false;
+      const fail = (error: Error) => { if (!settled) { settled = true; reject(error); } };
+      worker.once('message', (message: { ok: boolean; value?: T; error?: string }) => {
+        if (settled) return;
+        settled = true;
+        void worker.terminate();
+        message.ok ? resolve(message.value as T) : reject(new Error(message.error ?? 'prepared validation failed'));
+      });
+      worker.once('error', fail);
+      worker.once('exit', (code) => { if (code !== 0) fail(new Error(`prepared validation worker exited with code ${code}`)); });
+    });
+  } finally {
+    active -= 1;
+    waiters.shift()?.();
+  }
+}
+
+export const validatePreparedDocxText = (bytes: Buffer): Promise<boolean> => run({ kind: 'docx', bytes });
+export const validatePreparedAudioTranscript = (bytes: Buffer): Promise<AudioPreparedIdentity> => run({ kind: 'audio', bytes });

--- a/server/routes/indexing.ts
+++ b/server/routes/indexing.ts
@@ -26,7 +26,12 @@ import {
   prepareConvertibleSource,
   reprocessConvertibleSource,
 } from '../conversion-dispatch.ts';
-import { clearIndexWarning, syncFolderNow } from '../state.ts';
+import {
+  clearIndexWarning,
+  deferSemanticIndexing,
+  startSemanticIndexing,
+  syncFolderNow,
+} from '../state.ts';
 import { noteTreeChanged } from '../watcher.ts';
 import { sendError } from '../http.ts';
 import { filesystemPath } from '../filesystem-path.ts';
@@ -236,6 +241,28 @@ export function mount(app: express.Express): void {
       // and active read-only tab from disk.
       if (!result.cancelled) noteTreeChanged();
       res.json(result);
+    } catch (err: unknown) {
+      sendError(res, err);
+    }
+  });
+
+  app.post('/api/semantic-indexing/decision', async (req, res) => {
+    try {
+      const { folderRoot } = requireRequestFolder(parseFolderParam(req.body?.folder));
+      const decision = req.body?.decision;
+      if (decision === 'defer') {
+        deferSemanticIndexing(folderRoot);
+        res.json({ ok: true });
+        return;
+      }
+      if (decision === 'start') {
+        void startSemanticIndexing(folderRoot).catch((err: unknown) => {
+          log.warn(`start semantic indexing failed for ${folderRoot}: ${err instanceof Error ? err.message : String(err)}`);
+        });
+        res.status(202).json({ ok: true });
+        return;
+      }
+      res.status(400).json({ error: 'decision must be "start" or "defer"' });
     } catch (err: unknown) {
       sendError(res, err);
     }

--- a/server/semantic-indexing-state.test.ts
+++ b/server/semantic-indexing-state.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  clearSemanticIndexingDecision,
+  closeStateDb,
+  getSemanticIndexingDecision,
+  setSemanticIndexingDecision,
+} from './state-db.ts';
+import { enqueueFolderSyncOperation, runFolderSyncOperation, semanticSyncPolicy } from './state.ts';
+import { publishSemanticPause } from './sync.ts';
+import type { Indexer } from './indexer.ts';
+
+test('semantic pause is folder-scoped, durable across database reopen, and explicitly recoverable', () => {
+  const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-semantic-state-'));
+  const previous = process.env.STASHBASE_LOCAL_DATA_ROOT;
+  process.env.STASHBASE_LOCAL_DATA_ROOT = dataRoot;
+  const first = path.join(dataRoot, 'library-one');
+  const second = path.join(dataRoot, 'library-two');
+  try {
+    setSemanticIndexingDecision(first, 'paused', { sourceCount: 1_200, estimatedBytes: 42 });
+    assert.equal(getSemanticIndexingDecision(second), null);
+    closeStateDb(); // simulates the process releasing state before restart
+    assert.deepEqual(getSemanticIndexingDecision(first), {
+      decision: 'paused', sourceCount: 1_200, estimatedBytes: 42,
+      updatedAt: getSemanticIndexingDecision(first)?.updatedAt,
+    });
+    clearSemanticIndexingDecision(first);
+    assert.equal(getSemanticIndexingDecision(first), null);
+  } finally {
+    closeStateDb();
+    if (previous == null) delete process.env.STASHBASE_LOCAL_DATA_ROOT;
+    else process.env.STASHBASE_LOCAL_DATA_ROOT = previous;
+    fs.rmSync(dataRoot, { recursive: true, force: true });
+  }
+});
+
+test('resume intent is serialized after an older reconcile can publish its decision', async () => {
+  const events: string[] = [];
+  let releaseOlder!: () => void;
+  const olderGate = new Promise<void>((resolve) => { releaseOlder = resolve; });
+  const older = enqueueFolderSyncOperation('folder-race', async () => {
+    events.push('older-start');
+    await olderGate;
+    events.push('older-publish-awaiting');
+  });
+  const resume = enqueueFolderSyncOperation('folder-race', async () => {
+    events.push('resume-clear');
+    events.push('resume-embed');
+  });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.deepEqual(events, ['older-start']);
+  releaseOlder();
+  await Promise.all([older, resume]);
+  assert.deepEqual(events, [
+    'older-start', 'older-publish-awaiting', 'resume-clear', 'resume-embed',
+  ]);
+});
+
+test('restart policy reloads pause, invalidates stale work, and resumes only after clear', async () => {
+  const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-restart-policy-'));
+  const previous = process.env.STASHBASE_LOCAL_DATA_ROOT;
+  process.env.STASHBASE_LOCAL_DATA_ROOT = dataRoot;
+  const folder = path.join(dataRoot, 'library');
+  const workload = { sourceCount: 1_200, estimatedBytes: 120_000_000, large: true };
+  try {
+    setSemanticIndexingDecision(folder, 'paused', workload);
+    closeStateDb();
+    const bootPolicy = semanticSyncPolicy(folder);
+    assert.equal(bootPolicy.shouldPauseEmbedding(workload), true);
+    const deleted: string[] = [];
+    assert.equal(await publishSemanticPause(
+      { deleteFile: async (source) => { deleted.push(source); } },
+      folder, [path.join(folder, 'stale.md')], workload, [], bootPolicy.publishPaused,
+    ), true);
+    assert.deepEqual(deleted, [path.join(folder, 'stale.md')]);
+    assert.equal(getSemanticIndexingDecision(folder)?.decision, 'paused');
+
+    const resumePolicy = semanticSyncPolicy(folder, true);
+    assert.equal(clearSemanticIndexingDecision(folder), true);
+    assert.equal(resumePolicy.shouldPauseEmbedding(workload), false);
+    assert.equal(resumePolicy.commitEmbedding(), true);
+    assert.equal(getSemanticIndexingDecision(folder), null);
+  } finally {
+    closeStateDb();
+    if (previous == null) delete process.env.STASHBASE_LOCAL_DATA_ROOT;
+    else process.env.STASHBASE_LOCAL_DATA_ROOT = previous;
+    fs.rmSync(dataRoot, { recursive: true, force: true });
+  }
+});
+
+test('actual queued startup sync honors a restored pause and forced resume embeds', async () => {
+  const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-restart-sync-'));
+  const previous = process.env.STASHBASE_LOCAL_DATA_ROOT;
+  process.env.STASHBASE_LOCAL_DATA_ROOT = dataRoot;
+  const folder = path.join(dataRoot, 'library');
+  fs.mkdirSync(folder, { recursive: true });
+  const source = path.join(folder, 'changed.md');
+  fs.writeFileSync(source, 'replacement content');
+  const events: string[] = [];
+  const mockIndexer = {
+    syncDiff: async () => ({ added: [], modified: [source], deleted: [], renamed: [] }),
+    listFiles: async () => ({ [source]: 'old-hash' }),
+    deleteFile: async (path: string) => { events.push(`delete:${path}`); },
+    upsertFile: async (path: string) => { events.push(`upsert:${path}`); return 1; },
+    status: async () => ({ pending: [], total: 1, indexed: 1, pendingCount: 0, orphanedCount: 0, orphaned: [], upToDate: true }),
+  } as unknown as Indexer;
+  const deps = {
+    indexer: mockIndexer,
+    bind: async () => { events.push('bind'); },
+    sync: (await import('./sync.ts')).syncIndex,
+    semanticEnabled: true,
+  };
+  try {
+    setSemanticIndexingDecision(folder, 'paused', { sourceCount: 1, estimatedBytes: 10 });
+    closeStateDb();
+    const boot = await runFolderSyncOperation(folder, { reason: 'app boot' }, deps);
+    assert.equal(boot.semanticPaused, true);
+    assert.deepEqual(events, ['bind', `delete:${source}`]);
+    assert.equal(getSemanticIndexingDecision(folder)?.decision, 'paused');
+
+    events.length = 0;
+    const resumed = await runFolderSyncOperation(folder, {
+      reason: 'user started semantic indexing', forceEmbedding: true, clearDecisionAtStart: true,
+    }, deps);
+    assert.equal(resumed.semanticPaused, undefined);
+    assert.deepEqual(events, ['bind', `upsert:${source}`]);
+    assert.equal(getSemanticIndexingDecision(folder), null);
+  } finally {
+    closeStateDb();
+    if (previous == null) delete process.env.STASHBASE_LOCAL_DATA_ROOT;
+    else process.env.STASHBASE_LOCAL_DATA_ROOT = previous;
+    fs.rmSync(dataRoot, { recursive: true, force: true });
+  }
+});

--- a/server/semantic-workload.test.ts
+++ b/server/semantic-workload.test.ts
@@ -1,0 +1,319 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import {
+  estimateSemanticWorkload,
+  LARGE_SEMANTIC_BYTES_THRESHOLD,
+  LARGE_SEMANTIC_SOURCE_THRESHOLD,
+} from './semantic-workload.ts';
+import { publishSemanticPause, syncIndex } from './sync.ts';
+import type { Indexer } from './indexer.ts';
+import { excludePausedPendingHits, pausedWriteDisposition } from './indexer.mfs.ts';
+import { filesystemPath } from './filesystem-path.ts';
+import { derivedPathsForPdf } from './pdf.ts';
+import { derivedHtmlPathForDocx } from './docx.ts';
+import { validatePreparedAudioTranscript } from './prepared-validation.ts';
+
+function diff(root: string, count: number) {
+  return {
+    added: Array.from({ length: count }, (_, i) => path.join(root, `note-${i}.md`)),
+    modified: [], deleted: [], renamed: [],
+  };
+}
+
+test('semantic workload source threshold is inclusive and ignores hash-reused renames', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-preflight-count-'));
+  for (let i = 0; i < LARGE_SEMANTIC_SOURCE_THRESHOLD; i++) fs.writeFileSync(path.join(root, `note-${i}.md`), 'x');
+  assert.equal((await estimateSemanticWorkload(root, diff(root, LARGE_SEMANTIC_SOURCE_THRESHOLD - 1))).large, false);
+  assert.equal((await estimateSemanticWorkload(root, diff(root, LARGE_SEMANTIC_SOURCE_THRESHOLD))).large, true);
+  const renamedOnly = {
+    added: [], modified: [], deleted: [],
+    renamed: [{ old: path.join(root, 'old.md'), new: path.join(root, 'new.md'), fileHash: 'same' }],
+  };
+  assert.deepEqual(await estimateSemanticWorkload(root, renamedOnly), {
+    sourceCount: 0, estimatedBytes: 0, large: false,
+  });
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('semantic workload byte threshold is inclusive', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-preflight-'));
+  try {
+    const sources = Array.from({ length: 13 }, (_, i) => path.join(root, `large-${i}.md`));
+    sources.forEach((source, i) => {
+      fs.closeSync(fs.openSync(source, 'w'));
+      fs.truncateSync(source, i === sources.length - 1 ? 4 * 1024 * 1024 : 8 * 1024 * 1024);
+    });
+    const estimate = await estimateSemanticWorkload(root, {
+      added: sources, modified: [], deleted: [], renamed: [],
+    });
+    assert.equal(estimate.estimatedBytes, LARGE_SEMANTIC_BYTES_THRESHOLD);
+    assert.equal(estimate.large, true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('current prepared representations contribute known text volume', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-prepared-volume-'));
+  const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-prepared-data-'));
+  const previous = process.env.STASHBASE_LOCAL_DATA_ROOT;
+  process.env.STASHBASE_LOCAL_DATA_ROOT = dataRoot;
+  try {
+    const source = path.join(root, 'prepared.pdf');
+    fs.writeFileSync(source, '%PDF');
+    const derived = derivedPathsForPdf(source).notePath;
+    fs.mkdirSync(path.dirname(derived), { recursive: true });
+    fs.closeSync(fs.openSync(derived, 'w'));
+    fs.truncateSync(derived, LARGE_SEMANTIC_BYTES_THRESHOLD);
+    fs.appendFileSync(derived, '\n<!-- stashbase-pdf-conversion: complete -->');
+    const estimate = await estimateSemanticWorkload(root, {
+      added: [source], modified: [], deleted: [], renamed: [],
+    });
+    assert.equal(estimate.sourceCount, 1);
+    assert.ok(estimate.estimatedBytes >= LARGE_SEMANTIC_BYTES_THRESHOLD);
+    assert.equal(estimate.large, true);
+  } finally {
+    if (previous == null) delete process.env.STASHBASE_LOCAL_DATA_ROOT;
+    else process.env.STASHBASE_LOCAL_DATA_ROOT = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(dataRoot, { recursive: true, force: true });
+  }
+});
+
+test('incomplete prepared artifacts are rejected by format freshness authority', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-incomplete-prepared-'));
+  const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-incomplete-data-'));
+  const previous = process.env.STASHBASE_LOCAL_DATA_ROOT;
+  process.env.STASHBASE_LOCAL_DATA_ROOT = dataRoot;
+  try {
+    const source = path.join(root, 'incomplete.pdf');
+    fs.writeFileSync(source, '%PDF');
+    const derived = derivedPathsForPdf(source).notePath;
+    fs.mkdirSync(path.dirname(derived), { recursive: true });
+    fs.closeSync(fs.openSync(derived, 'w'));
+    fs.truncateSync(derived, LARGE_SEMANTIC_BYTES_THRESHOLD);
+    const estimate = await estimateSemanticWorkload(root, {
+      added: [source], modified: [], deleted: [], renamed: [],
+    });
+    assert.equal(estimate.sourceCount, 1);
+    assert.equal(estimate.estimatedBytes, 0);
+    assert.equal(estimate.large, false);
+  } finally {
+    if (previous == null) delete process.env.STASHBASE_LOCAL_DATA_ROOT;
+    else process.env.STASHBASE_LOCAL_DATA_ROOT = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(dataRoot, { recursive: true, force: true });
+  }
+});
+
+test('modified convertible sources never reuse prepared volume when mtimes are preserved', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-modified-prepared-'));
+  const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-modified-data-'));
+  const previous = process.env.STASHBASE_LOCAL_DATA_ROOT;
+  process.env.STASHBASE_LOCAL_DATA_ROOT = dataRoot;
+  try {
+    const source = path.join(root, 'preserved-mtime.pdf');
+    fs.writeFileSync(source, '%PDF changed bytes');
+    const derived = derivedPathsForPdf(source).notePath;
+    fs.mkdirSync(path.dirname(derived), { recursive: true });
+    fs.closeSync(fs.openSync(derived, 'w'));
+    fs.truncateSync(derived, LARGE_SEMANTIC_BYTES_THRESHOLD);
+    fs.appendFileSync(derived, '\n<!-- stashbase-pdf-conversion: complete -->');
+    const sameTime = new Date('2025-01-01T00:00:00Z');
+    fs.utimesSync(source, sameTime, sameTime);
+    fs.utimesSync(derived, sameTime, sameTime);
+
+    const estimate = await estimateSemanticWorkload(root, {
+      added: [], modified: [source], deleted: [], renamed: [],
+    });
+    assert.deepEqual(estimate, { sourceCount: 1, estimatedBytes: 0, large: false });
+  } finally {
+    if (previous == null) delete process.env.STASHBASE_LOCAL_DATA_ROOT;
+    else process.env.STASHBASE_LOCAL_DATA_ROOT = previous;
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(dataRoot, { recursive: true, force: true });
+  }
+});
+
+test('prepared DOCX validation performs no synchronous full-file read and yields the event loop', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-async-docx-'));
+  const dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-async-docx-data-'));
+  const previousDataRoot = process.env.STASHBASE_LOCAL_DATA_ROOT;
+  process.env.STASHBASE_LOCAL_DATA_ROOT = dataRoot;
+  try {
+    const source = path.join(root, 'large.docx');
+    fs.writeFileSync(source, 'docx');
+    const derived = derivedHtmlPathForDocx(source);
+    fs.mkdirSync(path.dirname(derived), { recursive: true });
+    fs.writeFileSync(derived, `<p>${'searchable '.repeat(100_000)}</p>\n<!-- stashbase-docx-conversion: complete -->`);
+    const originalReadFileSync = fs.readFileSync;
+    fs.readFileSync = (() => { throw new Error('synchronous prepared-content read'); }) as typeof fs.readFileSync;
+    try {
+      let timerRan = false;
+      const estimatePromise = estimateSemanticWorkload(root, {
+        added: [source], modified: [], deleted: [], renamed: [],
+      });
+      setTimeout(() => { timerRan = true; }, 0);
+      const estimate = await estimatePromise;
+      assert.equal(timerRan, true, 'validation must not monopolise the server event loop');
+      assert.equal(estimate.sourceCount, 1);
+      assert.equal(estimate.estimatedBytes, fs.statSync(derived).size);
+    } finally {
+      fs.readFileSync = originalReadFileSync;
+    }
+  } finally {
+    if (previousDataRoot == null) delete process.env.STASHBASE_LOCAL_DATA_ROOT;
+    else process.env.STASHBASE_LOCAL_DATA_ROOT = previousDataRoot;
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(dataRoot, { recursive: true, force: true });
+  }
+});
+
+test('large audio transcript parsing and schema validation yield the event loop', async () => {
+  const segments = Array.from({ length: 50_000 }, (_, index) => ({
+    id: index + 1,
+    startMs: index,
+    endMs: index + 1,
+    text: `segment ${index}`,
+  }));
+  const input = Buffer.from(JSON.stringify({
+    schemaVersion: 1,
+    source: {
+      durationMs: segments.length + 1,
+      size: 42,
+      mtimeMs: 1,
+      statIdentity: '1:2:3',
+      contentHash: 'a'.repeat(64),
+    },
+    provider: { id: 'test', version: '1', model: 'test-model' },
+    language: 'en',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    segments,
+  }));
+  let timerRan = false;
+  const validation = validatePreparedAudioTranscript(input);
+  setTimeout(() => { timerRan = true; }, 0);
+  const identity = await validation;
+  assert.equal(timerRan, true, 'audio validation must not monopolise the server event loop');
+  assert.equal(identity.contentHash, 'a'.repeat(64));
+});
+
+test('new unprepared convertible sources cross the inclusive source threshold', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-unprepared-pdfs-'));
+  try {
+    const sources = Array.from({ length: LARGE_SEMANTIC_SOURCE_THRESHOLD }, (_, i) => {
+      const source = path.join(root, `paper-${i}.pdf`);
+      fs.writeFileSync(source, '%PDF');
+      return source;
+    });
+    const below = await estimateSemanticWorkload(root, {
+      added: sources.slice(0, -1), modified: [], deleted: [], renamed: [],
+    });
+    assert.equal(below.sourceCount, LARGE_SEMANTIC_SOURCE_THRESHOLD - 1);
+    assert.equal(below.estimatedBytes, 0);
+    assert.equal(below.large, false);
+    const boundary = await estimateSemanticWorkload(root, {
+      added: sources, modified: [], deleted: [], renamed: [],
+    });
+    assert.equal(boundary.sourceCount, LARGE_SEMANTIC_SOURCE_THRESHOLD);
+    assert.equal(boundary.estimatedBytes, 0);
+    assert.equal(boundary.large, true);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('pause is published only after all stale rows are invalidated', async () => {
+  const deleted: string[] = [];
+  let published = false;
+  const failed: { name: string; error: string }[] = [];
+  const paused = await publishSemanticPause(
+    { deleteFile: async (source) => { deleted.push(source); } },
+    '/library', ['/library/a.md', '/library/b.md'],
+    { sourceCount: 2, estimatedBytes: 10, large: true }, failed,
+    () => { published = true; return true; },
+  );
+  assert.equal(paused, true);
+  assert.deepEqual(deleted, ['/library/a.md', '/library/b.md']);
+  assert.equal(published, true);
+  assert.deepEqual(failed, []);
+});
+
+test('invalidation or persistence failure cannot publish a silent pause', async () => {
+  let publishedAfterDeleteFailure = false;
+  const failed: { name: string; error: string }[] = [];
+  assert.equal(await publishSemanticPause(
+    { deleteFile: async () => { throw new Error('daemon unavailable'); } },
+    '/library', ['/library/stale.md'],
+    { sourceCount: 1, estimatedBytes: 1, large: true }, failed,
+    () => { publishedAfterDeleteFailure = true; return true; },
+  ), false);
+  assert.equal(publishedAfterDeleteFailure, false);
+  assert.match(failed[0]?.error ?? '', /daemon unavailable/);
+
+  assert.equal(await publishSemanticPause(
+    { deleteFile: async () => undefined }, '/library', ['/library/stale.md'],
+    { sourceCount: 1, estimatedBytes: 1, large: true }, [], () => false,
+  ), false);
+});
+
+test('paused writes retain hash-current rows and invalidate only changed content', () => {
+  assert.equal(pausedWriteDisposition(undefined, 'new'), 'index');
+  assert.equal(pausedWriteDisposition('same', 'same'), 'retain');
+  assert.equal(pausedWriteDisposition('old', 'new'), 'invalidate');
+  assert.equal(pausedWriteDisposition(null, 'new'), 'invalidate');
+});
+
+test('semantic search excludes every daemon-pending identity while paused', () => {
+  const hits = [
+    { fileName: '/library/current.md', content: 'current' },
+    { fileName: '/library/stale.md', content: 'stale' },
+  ];
+  assert.deepEqual(excludePausedPendingHits(
+    hits,
+    new Set([filesystemPath.identity('/library/stale.md')]),
+  ), [hits[0]]);
+});
+
+test('actual reconcile skips semantic preflight entirely without a key', async () => {
+  let scanned = false;
+  let published = false;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-no-key-'));
+  try {
+    const result = await syncIndex({
+      syncDiff: async () => { scanned = true; throw new Error('must not scan semantic diff'); },
+    } as unknown as Indexer, root, {
+      semanticEnabled: false,
+      shouldPauseEmbedding: () => true,
+      publishPaused: () => { published = true; return true; },
+    });
+    assert.equal(scanned, false);
+    assert.equal(published, false);
+    assert.deepEqual(result, { added: [], modified: [], removed: [], renamed: [], failed: [] });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('actual no-op reconcile neither warns nor publishes a decision', async () => {
+  let published = false;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-noop-'));
+  try {
+    const result = await syncIndex({
+      syncDiff: async () => ({ added: [], modified: [], deleted: [], renamed: [] }),
+      listFiles: async () => ({}),
+    } as unknown as Indexer, root, {
+      semanticEnabled: true,
+      shouldPauseEmbedding: (workload) => workload.large,
+      publishPaused: () => { published = true; return true; },
+    });
+    assert.equal(published, false);
+    assert.equal(result.semanticPaused, undefined);
+    assert.deepEqual(result.failed, []);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/server/semantic-workload.ts
+++ b/server/semantic-workload.ts
@@ -1,0 +1,76 @@
+import { promises as fs } from 'node:fs';
+import { currentPreparedTextPathAsync, preparedTextCandidatePath } from './conversion-dispatch.ts';
+import { isConvertibleSource } from './format.ts';
+import { filesystemPath } from './filesystem-path.ts';
+import { MAX_INDEXABLE_BYTES, shouldIndexFilePath } from './indexable.ts';
+import type { SyncDiff } from './indexer.ts';
+
+/** Server-owned tuning knobs. Crossing either boundary requires a decision. */
+export const LARGE_SEMANTIC_SOURCE_THRESHOLD = 1_000;
+export const LARGE_SEMANTIC_BYTES_THRESHOLD = 100 * 1024 * 1024;
+
+export interface SemanticWorkloadEstimate {
+  sourceCount: number;
+  estimatedBytes: number;
+  large: boolean;
+}
+
+/** Estimate only added/changed sources from the authoritative daemon diff.
+ * Renames are deliberately absent because their embeddings are hash-reused. */
+const METADATA_CONCURRENCY = 16;
+
+export async function estimateSemanticWorkload(root: string, diff: SyncDiff): Promise<SemanticWorkloadEstimate> {
+  const candidates = [...diff.added, ...diff.modified].filter((sourcePath) => {
+    const rel = filesystemPath.relative(root, sourcePath);
+    if (!rel) return false;
+    if (isConvertibleSource(rel)) return true;
+    return shouldIndexFilePath(rel);
+  });
+  const modified = new Set(diff.modified.map((sourcePath) => filesystemPath.identity(sourcePath)));
+  let cursor = 0;
+  let sourceCount = 0;
+  let estimatedBytes = 0;
+  async function worker(): Promise<void> {
+    while (cursor < candidates.length) {
+      const sourcePath = candidates[cursor++];
+      const rel = filesystemPath.relative(root, sourcePath);
+      if (rel && isConvertibleSource(rel)) {
+        const preparedPath = preparedTextCandidatePath(sourcePath, rel);
+        try {
+          const sourceStat = await fs.stat(sourcePath);
+          if (!sourceStat.isFile()) continue;
+          sourceCount += 1;
+          // A content-hash diff is stronger authority than timestamps. Never
+          // price an old representation for a byte-modified source, even if a
+          // sync client preserved or moved its mtime backwards.
+          if (modified.has(filesystemPath.identity(sourcePath))) continue;
+          if (!preparedPath) continue;
+          const preparedStat = await fs.stat(preparedPath);
+          const currentPath = await currentPreparedTextPathAsync(sourcePath, rel, {
+            sourceMtimeMs: sourceStat.mtimeMs,
+            derivedMtimeMs: preparedStat.mtimeMs,
+          });
+          if (currentPath) estimatedBytes += preparedStat.size;
+        } catch { /* unavailable or stale preparation contributes no known text */ }
+        continue;
+      }
+      try {
+        const sourceStat = await fs.stat(sourcePath);
+        if (!sourceStat.isFile() || sourceStat.size === 0 || sourceStat.size > MAX_INDEXABLE_BYTES) continue;
+        sourceCount += 1;
+        estimatedBytes += sourceStat.size;
+      }
+      catch { /* disappeared after scan */ }
+    }
+  }
+  await Promise.all(Array.from(
+    { length: Math.min(METADATA_CONCURRENCY, candidates.length) },
+    () => worker(),
+  ));
+  return {
+    sourceCount,
+    estimatedBytes,
+    large: sourceCount >= LARGE_SEMANTIC_SOURCE_THRESHOLD
+      || estimatedBytes >= LARGE_SEMANTIC_BYTES_THRESHOLD,
+  };
+}

--- a/server/state-db.ts
+++ b/server/state-db.ts
@@ -2,12 +2,13 @@
  * Library-level transactional state in the per-machine app data directory.
  *
  * This is StashBase-owned state, separate from MFS/Milvus' `store/`
- * schema. It holds exactly one thing: durable file preparation failures,
+ * schema. It holds non-derivable workflow decisions: durable file preparation
+ * failures and per-folder semantic-indexing deferrals,
  * which are non-derivable — a failed extraction/index attempt can look
  * identical on disk to one that hasn't run — and drives per-file
  * recovery affordances.
  *
- * Everything else lives at its authoritative source: the daemon/store
+ * Other derived indexing truth lives at its authoritative source: the daemon/store
  * owns the per-file hash + index state (via `scan_diff`), the filesystem
  * answers "does this file exist", and `~/.stashbase/config.json` holds
  * library folders and embedder config. (Earlier `files` and `index_queue`
@@ -162,6 +163,15 @@ function migrate(conn: BetterSqlite3.Database): void {
     );
 
     CREATE INDEX IF NOT EXISTS conversions_status_idx ON conversions(status, last_attempt_at);
+
+    CREATE TABLE IF NOT EXISTS semantic_indexing_decisions (
+      folder_identity TEXT PRIMARY KEY,
+      folder_path TEXT NOT NULL,
+      decision TEXT NOT NULL CHECK (decision IN ('awaiting-decision', 'paused')),
+      source_count INTEGER NOT NULL,
+      estimated_bytes INTEGER NOT NULL,
+      updated_at TEXT NOT NULL
+    );
 
     -- 2026-06: only failures are persisted now. in-flight lives in
     -- process memory (a crash kills the conversion with us — persisting
@@ -447,4 +457,53 @@ export function listConversionStatus(status: ConversionStatus): Array<{ path: st
       ...(row.doneAt ? { doneAt: row.doneAt } : {}),
     },
   }));
+}
+
+export interface SemanticIndexingDecision {
+  decision: 'awaiting-decision' | 'paused';
+  sourceCount: number;
+  estimatedBytes: number;
+  updatedAt: string;
+}
+
+export function getSemanticIndexingDecision(folderRoot: string): SemanticIndexingDecision | null {
+  const conn = getStateDb();
+  if (!conn) return null;
+  const row = conn.prepare(`
+    SELECT decision, source_count AS sourceCount, estimated_bytes AS estimatedBytes,
+           updated_at AS updatedAt
+    FROM semantic_indexing_decisions WHERE folder_identity = ?
+  `).get(filesystemPath.identity(folderRoot)) as SemanticIndexingDecision | undefined;
+  return row ?? null;
+}
+
+export function setSemanticIndexingDecision(
+  folderRoot: string,
+  decision: SemanticIndexingDecision['decision'],
+  workload: { sourceCount: number; estimatedBytes: number },
+): boolean {
+  const conn = getStateDb();
+  if (!conn) return false;
+  const folderPath = filesystemPath.absolute(folderRoot);
+  conn.prepare(`
+    INSERT INTO semantic_indexing_decisions
+      (folder_identity, folder_path, decision, source_count, estimated_bytes, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(folder_identity) DO UPDATE SET
+      folder_path = excluded.folder_path, decision = excluded.decision,
+      source_count = excluded.source_count, estimated_bytes = excluded.estimated_bytes,
+      updated_at = excluded.updated_at
+  `).run(
+    filesystemPath.identity(folderPath), folderPath, decision,
+    workload.sourceCount, workload.estimatedBytes, new Date().toISOString(),
+  );
+  return true;
+}
+
+export function clearSemanticIndexingDecision(folderRoot: string): boolean {
+  const conn = getStateDb();
+  if (!conn) return false;
+  conn.prepare('DELETE FROM semantic_indexing_decisions WHERE folder_identity = ?')
+    .run(filesystemPath.identity(folderRoot));
+  return true;
 }

--- a/server/state.ts
+++ b/server/state.ts
@@ -23,6 +23,13 @@ import { clearStaleMilvusLock } from './stale-lock.ts';
 import { noteTreeChanged } from './watcher.ts';
 import { logger, errorMessage } from './log.ts';
 import { globalVectorStoreDir } from './local-data.ts';
+import {
+  clearSemanticIndexingDecision,
+  getSemanticIndexingDecision,
+  setSemanticIndexingDecision,
+  type SemanticIndexingDecision,
+} from './state-db.ts';
+import type { SemanticWorkloadEstimate } from './semantic-workload.ts';
 
 const log = logger('state');
 
@@ -68,6 +75,49 @@ export async function deleteFolderRuntimeState(folderRoot: string): Promise<void
   const root = filesystemPath.identity(folderRoot);
   indexWarnings.delete(root);
   folderSyncGeneration.delete(root);
+  clearSemanticIndexingDecision(folderRoot);
+}
+
+export function getSemanticIndexingState(folderRoot: string): SemanticIndexingDecision | null {
+  return getSemanticIndexingDecision(folderRoot);
+}
+
+export function deferSemanticIndexing(folderRoot: string): void {
+  const current = getSemanticIndexingDecision(folderRoot);
+  if (current) setSemanticIndexingDecision(folderRoot, 'paused', current);
+}
+
+export async function startSemanticIndexing(folderRoot: string): Promise<SyncResult> {
+  return syncFolderNow(folderRoot, {
+    reason: 'user started semantic indexing', forceEmbedding: true, clearDecisionAtStart: true,
+  });
+}
+
+export function semanticSyncPolicy(folderRoot: string, forceEmbedding = false): {
+  shouldPauseEmbedding: (workload: SemanticWorkloadEstimate) => boolean;
+  publishPaused: (workload: SemanticWorkloadEstimate) => boolean;
+  commitEmbedding: () => boolean;
+} {
+  return {
+    shouldPauseEmbedding: (workload) => {
+      if (forceEmbedding) return false;
+      const existing = getSemanticIndexingDecision(folderRoot);
+      if (existing?.decision === 'paused') return true;
+      return workload.large;
+    },
+    publishPaused: (workload) => {
+      const existing = getSemanticIndexingDecision(folderRoot);
+      return setSemanticIndexingDecision(
+        folderRoot,
+        existing?.decision === 'paused' ? 'paused' : 'awaiting-decision',
+        workload,
+      );
+    },
+    commitEmbedding: () => {
+      const existing = getSemanticIndexingDecision(folderRoot);
+      return !existing || clearSemanticIndexingDecision(folderRoot);
+    },
+  };
 }
 
 /** Resolve the runtime embedder config. Returns null
@@ -245,39 +295,50 @@ function syncTouchedVisibleTree(result: SyncResult): boolean {
 
 const folderSyncQueues = new Map<string, Promise<unknown>>();
 
-export async function syncFolderNow(
-  folderRoot: string,
-  opts: { reason?: string; shouldContinue?: () => boolean } = {},
-): Promise<SyncResult> {
-  const syncFolderRoot = filesystemPath.absolute(folderRoot);
-  const queueKey = filesystemPath.identity(syncFolderRoot);
+export function enqueueFolderSyncOperation<T>(queueKey: string, operation: () => Promise<T>): Promise<T> {
   const prev = folderSyncQueues.get(queueKey) ?? Promise.resolve();
-  const next = prev
-    .catch(() => undefined)
-    .then(() => syncFolderNowInner(syncFolderRoot, opts));
-  const settled = next
-    .catch(() => undefined)
-    .finally(() => {
-      if (folderSyncQueues.get(queueKey) === settled) {
-        folderSyncQueues.delete(queueKey);
-      }
-    });
+  const next = prev.catch(() => undefined).then(operation);
+  const settled = next.catch(() => undefined).finally(() => {
+    if (folderSyncQueues.get(queueKey) === settled) folderSyncQueues.delete(queueKey);
+  });
   folderSyncQueues.set(queueKey, settled);
   return next;
 }
 
-async function syncFolderNowInner(
+export async function syncFolderNow(
   folderRoot: string,
-  opts: { reason?: string; shouldContinue?: () => boolean },
+  opts: { reason?: string; shouldContinue?: () => boolean; forceEmbedding?: boolean; clearDecisionAtStart?: boolean } = {},
+): Promise<SyncResult> {
+  const syncFolderRoot = filesystemPath.absolute(folderRoot);
+  const queueKey = filesystemPath.identity(syncFolderRoot);
+  return enqueueFolderSyncOperation(queueKey, () => runFolderSyncOperation(syncFolderRoot, opts));
+}
+
+export async function runFolderSyncOperation(
+  folderRoot: string,
+  opts: { reason?: string; shouldContinue?: () => boolean; forceEmbedding?: boolean; clearDecisionAtStart?: boolean },
+  deps: {
+    indexer: Indexer;
+    bind: (folderRoot: string) => Promise<void>;
+    sync: typeof syncIndex;
+    semanticEnabled?: boolean;
+  } = { indexer, bind: bindIndexerForFolder, sync: syncIndex },
 ): Promise<SyncResult> {
   const syncGeneration = currentFolderSyncGeneration(folderRoot);
   const shouldContinue = () => shouldContinueFolderSync(folderRoot, syncGeneration, opts.shouldContinue);
   try {
-    await bindIndexerForFolder(folderRoot);
+    if (opts.clearDecisionAtStart && !clearSemanticIndexingDecision(folderRoot)) {
+      throw new Error('semantic indexing decision could not be cleared');
+    }
+    await deps.bind(folderRoot);
     if (!shouldContinue()) {
       return { added: [], modified: [], removed: [], renamed: [], failed: [], cancelled: true };
     }
-    const result = await syncIndex(indexer, folderRoot, { shouldContinue });
+    const result = await deps.sync(deps.indexer, folderRoot, {
+      shouldContinue,
+      semanticEnabled: deps.semanticEnabled,
+      ...semanticSyncPolicy(folderRoot, opts.forceEmbedding),
+    });
     if (result.cancelled) {
       return result;
     }

--- a/server/sync.ts
+++ b/server/sync.ts
@@ -28,6 +28,7 @@ import { cancelConversion } from './conversion.ts';
 import { clearRecord } from './conversion-status.ts';
 import { deleteDerivedForSource, knownDerivedSourcesUnderFolder } from './derived-store.ts';
 import { filesystemPath } from './filesystem-path.ts';
+import { estimateSemanticWorkload, type SemanticWorkloadEstimate } from './semantic-workload.ts';
 
 const log = logger('sync');
 
@@ -99,6 +100,8 @@ export interface SyncResult {
    *  target folder/window is no longer current. Any arrays are partial work
    *  completed before cancellation was observed. */
   cancelled?: boolean;
+  /** Embedding was intentionally stopped by the folder's preflight state. */
+  semanticPaused?: boolean;
 }
 
 export interface SyncOptions {
@@ -106,6 +109,41 @@ export interface SyncOptions {
    *  in-flight upsert, but checking between files stops stale imports from
    *  continuing through the rest of a large folder after a folder switch. */
   shouldContinue?: () => boolean;
+  /** Pure decision after the authoritative hash diff. No state is published yet. */
+  shouldPauseEmbedding?: (workload: SemanticWorkloadEstimate) => boolean;
+  /** Publish only after every known-stale row has been invalidated. */
+  publishPaused?: (workload: SemanticWorkloadEstimate) => boolean;
+  /** Atomically release an existing decision immediately before upserts. */
+  commitEmbedding?: () => boolean;
+  /** Test seam; production derives this exclusively from Settings. */
+  semanticEnabled?: boolean;
+}
+
+/** Transactional pause transition. Known-stale rows are invalidated before
+ * the decision becomes visible; any invalidation or persistence failure falls
+ * back to execution so reconcile can replace stale content. */
+export async function publishSemanticPause(
+  indexer: Pick<Indexer, 'deleteFile'>,
+  root: string,
+  modified: string[],
+  workload: SemanticWorkloadEstimate,
+  failed: { name: string; error: string }[],
+  publish?: (workload: SemanticWorkloadEstimate) => boolean,
+): Promise<boolean> {
+  const failuresBeforeInvalidation = failed.length;
+  for (const sourcePath of modified) {
+    try { await indexer.deleteFile(sourcePath); }
+    catch (err: unknown) { failed.push({ name: sourcePath, error: errorMessage(err) }); }
+  }
+  if (failed.length !== failuresBeforeInvalidation) {
+    log.warn(`semantic preflight invalidation failed for "${root}"; continuing indexing to replace stale rows`);
+    return false;
+  }
+  if (!publish?.(workload)) {
+    log.warn(`semantic preflight state unavailable for "${root}"; continuing indexing`);
+    return false;
+  }
+  return true;
 }
 
 function emptyResult(cancelled = false): SyncResult {
@@ -215,7 +253,7 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
   // the log with one failure per file. Conversion discovery still
   // runs so PDFs/images can produce AppData derived text for keyword search
     // and future reindex.
-  if (!getApiKey()) {
+  if (!(opts.semanticEnabled ?? !!getApiKey())) {
     cleanupMissingConvertedSources(root);
     discoverConvertedSources(root);
     log.info(`no embedding key — skipping semantic index for "${root}" (conversion + keyword search unaffected)`);
@@ -224,6 +262,8 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
 
   if (shouldStop(opts)) return emptyResult(true);
   const diff = await indexer.syncDiff(root);
+  const workload = await estimateSemanticWorkload(root, diff);
+  const pauseRequested = opts.shouldPauseEmbedding?.(workload) ?? false;
   const failed: { name: string; error: string }[] = [];
   const excludedRemoved = await removeExcludedIndexedFiles(indexer, root, failed);
   cleanupMissingConvertedSources(root);
@@ -321,6 +361,29 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
   // PDF/image must first clear the old source identity and any stale
   // target artifacts, then queue a fresh conversion for the new path.
   discoverConvertedSources(root);
+
+  // Preparation remains independent and useful for keyword search. Stale
+  // vector rows were removed above; stop before any derived/source upsert.
+  if (pauseRequested) {
+    const published = await publishSemanticPause(
+      indexer, root, diff.modified, workload, failed, opts.publishPaused,
+    );
+    if (published) {
+      return {
+        added: [], modified: [], removed: toFolderRelList(root, removedDone),
+        renamed: toFolderRelList(root, renamedDone),
+        failed: toFolderRelFailures(root, failed), semanticPaused: true,
+      };
+    }
+  }
+  if (!pauseRequested && opts.commitEmbedding && !opts.commitEmbedding()) {
+    log.warn(`semantic decision could not be cleared for "${root}"; leaving indexing paused`);
+    return {
+      added: [], modified: [], removed: toFolderRelList(root, removedDone),
+      renamed: toFolderRelList(root, renamedDone),
+      failed: toFolderRelFailures(root, failed), semanticPaused: true,
+    };
+  }
 
   const convertedAddedDone = await indexFreshConvertedSources(indexer, root, diff.added, failed, opts);
   if (convertedAddedDone.cancelled) {

--- a/web-src/src/__tests__/semantic-indexing-notice.test.ts
+++ b/web-src/src/__tests__/semantic-indexing-notice.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { SemanticIndexingNoticeView } from '../components/SearchPanel';
+import { api, ApiError } from '../api';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+test('awaiting notice renders live guidance and dispatches both decisions without autofocus', async () => {
+  const decisions: string[] = [];
+  let renderer: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(React.createElement(SemanticIndexingNoticeView, {
+      awaiting: true,
+      count: 3_400,
+      estimatedBytes: 100 * 1024 * 1024,
+      failureMessage: 'one stale row could not be removed',
+      onStart: () => decisions.push('start'),
+      onDefer: () => decisions.push('defer'),
+    }));
+  });
+  const status = renderer!.root.findByProps({ role: 'status' });
+  assert.equal(status.props['aria-live'], 'polite');
+  assert.match(renderer!.root.findByProps({ role: 'alert' }).children.join(''), /stale row/);
+  const buttons = renderer!.root.findAllByType('button');
+  assert.deepEqual(buttons.map((button) => button.children.join('')), ['Index now', 'Not now']);
+  assert.ok(buttons.every((button) => button.props.autoFocus == null));
+  await act(async () => { buttons[0].props.onClick(); buttons[1].props.onClick(); });
+  assert.deepEqual(decisions, ['start', 'defer']);
+  await act(async () => { renderer!.unmount(); });
+});
+
+test('durably paused notice keeps the recoverable start action only', async () => {
+  let starts = 0;
+  let renderer: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(React.createElement(SemanticIndexingNoticeView, {
+      awaiting: false,
+      count: 1_200,
+      onStart: () => { starts += 1; },
+      onDefer: () => assert.fail('paused state must not offer defer again'),
+    }));
+  });
+  const buttons = renderer!.root.findAllByType('button');
+  assert.equal(buttons.length, 1);
+  assert.equal(buttons[0].children.join(''), 'Start indexing');
+  await act(async () => { buttons[0].props.onClick(); });
+  assert.equal(starts, 1);
+  await act(async () => { renderer!.unmount(); });
+});
+
+test('decision API sends folder-explicit start/defer requests and surfaces failures', async () => {
+  const originalFetch = globalThis.fetch;
+  const requests: Array<{ url: string; body: unknown }> = [];
+  try {
+    globalThis.fetch = (async (input, init) => {
+      requests.push({ url: String(input), body: JSON.parse(String(init?.body)) });
+      return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+    await api.semanticIndexingDecision('start', '/library/one');
+    await api.semanticIndexingDecision('defer', '/library/two');
+    assert.deepEqual(requests, [
+      { url: '/api/semantic-indexing/decision', body: { decision: 'start', folder: '/library/one' } },
+      { url: '/api/semantic-indexing/decision', body: { decision: 'defer', folder: '/library/two' } },
+    ]);
+    globalThis.fetch = (async () => new Response(JSON.stringify({ error: 'state unavailable' }), {
+      status: 503, headers: { 'content-type': 'application/json' },
+    })) as typeof fetch;
+    await assert.rejects(api.semanticIndexingDecision('start', '/library/one'), ApiError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/web-src/src/api.ts
+++ b/web-src/src/api.ts
@@ -183,6 +183,8 @@ export const api = {
     getJson<IndexStatus>(folder ? `/api/index-status?folder=${encodeURIComponent(folder)}` : '/api/index-status'),
   dismissIndexWarning: (folder?: string) =>
     send<{ ok: boolean }>('POST', '/api/index-warning/dismiss', { folder }),
+  semanticIndexingDecision: (decision: 'start' | 'defer', folder?: string) =>
+    send<{ ok: boolean }>('POST', '/api/semantic-indexing/decision', { decision, folder }),
 
   /** Full per-file preparation status, library-wide, keyed by absolute
    *  source path. */

--- a/web-src/src/apiTypes.ts
+++ b/web-src/src/apiTypes.ts
@@ -130,6 +130,11 @@ export interface IndexStatus {
    *  upToDate, this ignores orphaned/hidden index rows that are not
    *  relevant to search-readiness accounting. */
   visibleIndexingSettled?: boolean;
+  semanticIndexing?: {
+    state: 'disabled' | 'awaiting-decision' | 'paused' | 'partial-paused' | 'indexing' | 'partial-indexing' | 'ready' | 'failed';
+    sourceCount?: number;
+    estimatedBytes?: number;
+  };
   /** False while the server is still loading the index cache for a folder. */
   indexReady?: boolean;
   /** Folder-relative paths of PDF/image/DOCX sources that are queued or

--- a/web-src/src/components/SearchPanel.tsx
+++ b/web-src/src/components/SearchPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import React, { useEffect, useRef, useState, type ReactNode } from 'react';
 import type { FileMeta, KeywordHitFile, KeywordMatch, SearchHit } from '../api';
 import { useApp } from '../store/AppContext';
 import { openSettings } from './SettingsModal';
@@ -28,6 +28,7 @@ export function SearchPanel() {
     <div className="search-panel" id="sidebar-panel-search" role="tabpanel">
       <SearchBox />
       <SearchFilters />
+      <SemanticIndexingNotice />
       <SearchStatusBanner />
       <div className="search-panel-body">
         {state.searchMode === 'semantic' && state.embedderHasKey === false ? (
@@ -39,6 +40,63 @@ export function SearchPanel() {
           // The user has plenty of feedback from the input itself.
           null
         )}
+      </div>
+    </div>
+  );
+}
+
+export function SemanticIndexingNotice() {
+  const { state, actions } = useApp();
+  const workload = state.semanticIndexing;
+  if (!workload || !['awaiting-decision', 'paused', 'partial-paused'].includes(workload.state)) return null;
+  const awaiting = workload.state === 'awaiting-decision';
+  const count = workload.sourceCount ?? state.pendingSemanticNames.size;
+  return <SemanticIndexingNoticeView
+    awaiting={awaiting}
+    count={count}
+    estimatedBytes={workload.estimatedBytes}
+    failureMessage={state.indexWarning?.message}
+    onStart={() => { void actions.decideSemanticIndexing('start'); }}
+    onDefer={() => { void actions.decideSemanticIndexing('defer'); }}
+  />;
+}
+
+export function SemanticIndexingNoticeView({
+  awaiting,
+  count,
+  estimatedBytes,
+  failureMessage,
+  onStart,
+  onDefer,
+}: {
+  awaiting: boolean;
+  count: number;
+  estimatedBytes?: number;
+  failureMessage?: string;
+  onStart: () => void;
+  onDefer: () => void;
+}) {
+  const size = estimatedBytes
+    ? ` · about ${(estimatedBytes / (1024 * 1024)).toFixed(estimatedBytes >= 10 * 1024 * 1024 ? 0 : 1)} MiB`
+    : '';
+  return (
+    <div className="search-status-banner warning" role="status" aria-live="polite">
+      <div className="search-status-copy">
+        <div className="search-status-title">{awaiting ? 'Large semantic indexing workload' : 'Semantic indexing paused'}</div>
+        <div className="search-status-detail">
+          About {count.toLocaleString()} file{count === 1 ? '' : 's'} waiting{size}. Indexing may take a while and use embedding-provider quota. Keyword search remains available.
+        </div>
+        {failureMessage && (
+          <div className="search-status-detail" role="alert">
+            Search also needs attention: {failureMessage}
+          </div>
+        )}
+      </div>
+      <div className="search-status-actions">
+        <button type="button" onClick={onStart}>
+          {awaiting ? 'Index now' : 'Start indexing'}
+        </button>
+        {awaiting && <button type="button" onClick={onDefer}>Not now</button>}
       </div>
     </div>
   );
@@ -145,6 +203,8 @@ function SearchStatusBanner() {
     ...(isSemantic ? [...state.pendingSemanticNames] : []),
   ]);
   const readyCount = Math.max(0, total - unavailablePaths.size);
+
+  if (state.semanticIndexing && ['awaiting-decision', 'paused', 'partial-paused'].includes(state.semanticIndexing.state)) return null;
 
   if (isSemantic && state.indexWarning) {
     return (

--- a/web-src/src/components/Sidebar.tsx
+++ b/web-src/src/components/Sidebar.tsx
@@ -14,7 +14,7 @@ import { DocumentOutline } from './DocumentOutline';
 import { useDocumentOutline } from './DocumentOutlineContext';
 import { Menu, type MenuItem } from './Menu';
 import { ModalShell } from './ModalShell';
-import { SearchPanel } from './SearchPanel';
+import { SearchPanel, SemanticIndexingNotice } from './SearchPanel';
 import { api, errorMessage } from '../api';
 import { FILE_MIME } from '../dragMime';
 import { useEffect, useRef, useState, type DragEvent } from 'react';
@@ -98,6 +98,7 @@ function FilesPanel() {
           </div>
         </div>
         <div id="sidebar-files-section" className="sidebar-section-body">
+          <SemanticIndexingNotice />
           <div
             id="sideHead"
             className={

--- a/web-src/src/store/AppContext.tsx
+++ b/web-src/src/store/AppContext.tsx
@@ -88,6 +88,7 @@ export interface AppActions {
   ) => Promise<void>;
   /** Clear the active folder's background-index warning. */
   dismissIndexWarning: () => Promise<void>;
+  decideSemanticIndexing: (decision: 'start' | 'defer') => Promise<void>;
   /** Replace a folder's ordered child list (manual sidebar ordering).
    *  Optimistic — state updates immediately, then a PUT is fired.
    *  Failure of the PUT rolls the renderer back to whatever the server
@@ -435,6 +436,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     loadFiles: workspace.loadFiles, markVisibleFilesPendingForSearch: workspace.markVisibleFilesPendingForSearch,
     refreshIndexState: workspace.refreshIndexState, runSync: workspace.runSync, runSearch: workspace.runSearch,
     setFolderOrder: workspace.setFolderOrder, dismissIndexWarning: workspace.dismissIndexWarning,
+    decideSemanticIndexing: workspace.decideSemanticIndexing,
     selectFile: workspace.selectFile, selectFileWithHighlight: workspace.selectFileWithHighlight,
     openInNewTab: workspace.openInNewTab, newTab: workspace.newTab, closeTab: workspace.closeTab,
     closeActiveTab: workspace.closeActiveTab, activateTab: workspace.activateTab,

--- a/web-src/src/store/state.ts
+++ b/web-src/src/store/state.ts
@@ -14,6 +14,7 @@ import type {
   PreparationFailure,
   ConversionProgress,
   IndexWarning,
+  IndexStatus,
   SearchHit,
   Agent,
 } from '../api';
@@ -233,6 +234,7 @@ export interface State {
    *  embedded/indexed. Keyword search ignores this state and can search
    *  converted/source text without embeddings. */
   pendingSemanticNames: Set<string>;
+  semanticIndexing: NonNullable<IndexStatus['semanticIndexing']> | null;
   /** Folder-relative paths of PDF/image/DOCX conversions that are queued or
    *  running. Kept for search-readiness accounting and refresh timing. */
   pendingConversions: string[];
@@ -363,6 +365,7 @@ export const initialState: State = {
   activeChatTabId: null,
   chatTabRecencyByAgent: {},
   pendingSemanticNames: new Set(),
+  semanticIndexing: null,
   pendingConversions: [],
   blockedConversions: [],
   conversionProgress: {},
@@ -451,6 +454,7 @@ export type Action =
    *  — does not touch expand state, activeFolder, or the open file. */
   | { type: 'SELECT_PATH'; path: string }
   | { type: 'PENDING_SEMANTIC_NAMES'; names: Set<string> }
+  | { type: 'SEMANTIC_INDEXING_STATE'; state: State['semanticIndexing'] }
   | { type: 'PENDING_CONVERSIONS'; paths: string[] }
   | { type: 'BLOCKED_CONVERSIONS'; paths: string[] }
   | { type: 'CONVERSION_PROGRESS'; progress: Record<string, ConversionProgress> }

--- a/web-src/src/store/stateReducer.ts
+++ b/web-src/src/store/stateReducer.ts
@@ -406,6 +406,8 @@ export function reducer(s: State, a: Action): State {
       return { ...s, selectedPath: a.path };
     case 'PENDING_SEMANTIC_NAMES':
       return { ...s, pendingSemanticNames: a.names };
+    case 'SEMANTIC_INDEXING_STATE':
+      return { ...s, semanticIndexing: a.state };
     case 'PENDING_CONVERSIONS':
       return { ...s, pendingConversions: a.paths };
     case 'BLOCKED_CONVERSIONS':

--- a/web-src/src/store/useActiveFolderWorkspace.ts
+++ b/web-src/src/store/useActiveFolderWorkspace.ts
@@ -48,6 +48,7 @@ export interface ActiveFolderWorkspace {
     },
   ) => Promise<void>;
   dismissIndexWarning: () => Promise<void>;
+  decideSemanticIndexing: (decision: 'start' | 'defer') => Promise<void>;
   setFolderOrder: (parentPath: string, names: string[]) => Promise<void>;
   selectFile: (name: string) => Promise<void>;
   selectFileWithHighlight: (name: string, hit: PendingHighlight) => Promise<void>;
@@ -249,6 +250,7 @@ export function useActiveFolderWorkspace(
     folders.openFolderByName,
     folders.prepareForFolderRemoval,
     search.dismissIndexWarning,
+    search.decideSemanticIndexing,
     search.markVisibleFilesPendingForSearch,
     search.refreshIndexState,
     search.runSearch,

--- a/web-src/src/store/useSearchActions.ts
+++ b/web-src/src/store/useSearchActions.ts
@@ -205,6 +205,7 @@ export function useSearchActions(
         lastTreeVersion.current >= 0 && newTreeVersion !== lastTreeVersion.current;
       lastTreeVersion.current = newTreeVersion;
       dispatch({ type: 'PENDING_SEMANTIC_NAMES', names: newPending });
+      dispatch({ type: 'SEMANTIC_INDEXING_STATE', state: s.semanticIndexing ?? null });
       if (convChanged) dispatch({ type: 'PENDING_CONVERSIONS', paths: newConv });
       if (blockedChanged) dispatch({ type: 'BLOCKED_CONVERSIONS', paths: newBlocked });
       const incomingProgress = s.conversionProgress ?? {};
@@ -474,7 +475,15 @@ export function useSearchActions(
     }
   }, []);
 
+  const decideSemanticIndexing = useCallback(async (decision: 'start' | 'defer') => {
+    const folderAtStart = stateRef.current.folderPath;
+    if (!folderAtStart) return;
+    await api.semanticIndexingDecision(decision, folderAtStart);
+    await refreshIndexState(folderAtStart);
+  }, [refreshIndexState]);
+
   return {
+    decideSemanticIndexing,
     dismissIndexWarning,
     markVisibleFilesPendingForSearch,
     refreshIndexState,


### PR DESCRIPTION
Closes #124.

## Summary

Adds a durable, folder-scoped decision gate before large semantic-indexing workloads begin. Opening or reconciling a folder whose changed workload reaches 1,000 indexable sources or 100 MiB of known text now pauses semantic embedding and presents persistent **Start indexing** and **Not now** actions while keyword search and ordinary folder use remain available.

## Root causes addressed

The previous reconciliation flow had no workload consent boundary and treated conversion, daemon reconciliation, and renderer readiness as one implicit operation. Follow-up review also exposed several correctness and liveness risks around that new boundary:

- stale daemon rows could remain searchable while work was paused;
- state-database degradation could silently suppress indexing without a recovery action;
- unchanged writes could delete still-current semantic rows;
- resume intent could race older queued reconciliation work;
- prepared artifacts could be counted using weaker timestamp-only freshness rules;
- modified sources could reuse stale prepared volume when sync software preserved mtimes;
- large prepared DOCX/audio validation could block the Node event loop;
- a simultaneous indexing warning could hide the paused recovery UI.

## Server behavior

- Estimates only daemon-reported added and modified sources; hash-reused renames are excluded.
- Counts every valid convertible source before preparation, including new PDFs, images, DOCX files, and media.
- Includes prepared text bytes only when the existing format-specific completion and freshness contract accepts the artifact.
- Treats the daemon content-hash `modified` set as stronger than timestamps, so old prepared bytes never contribute for modified sources.
- Uses bounded asynchronous metadata reads and a bounded worker-thread lane for large DOCX analysis and audio JSON/schema validation.
- Persists awaiting/paused decisions by folder and restores them across restart.
- Serializes resume intent through the same folder queue as reconciliation.
- Invalidates known-stale rows before publishing a pause and fails closed when invalidation cannot be guaranteed.
- Filters pending stale identities from semantic search while paused.
- Retains an indexed row for an unchanged write and invalidates only genuinely changed content.
- Continues indexing instead of silently pausing when durable decision state cannot be stored, while exposing the failure.

## Renderer behavior

- Shows the decision notice in Files and Search surfaces.
- Keeps **Start indexing** available after refresh/restart until the decision is resolved.
- Preserves keyword search while semantic indexing is paused.
- Displays pause guidance and independent indexing failures together.
- Handles decision request failures without falsely clearing the notice.

## Tests

Coverage includes:

- inclusive 999/1,000 source and 100 MiB boundaries;
- new unprepared convertible sources;
- valid and incomplete prepared representations;
- preserved-mtime modified conversions rejecting stale prepared volume;
- event-loop responsiveness during large DOCX and 50,000-segment audio validation;
- no-key and no-op reconciliation;
- invalidation and persistence failures;
- unchanged paused writes and stale-result filtering;
- queued pause/resume ordering;
- durable restart recovery through the actual folder-sync path;
- rendered decision actions, API requests, failures, polling state, and paused-plus-failed guidance.

## Validation

- `pnpm typecheck`
- semantic/index-status/restart workflow tests
- `pnpm test:conversion-scheduler`
- `pnpm test:renderer`
- `pnpm build:server`
- `npx vite build --config web-src/vite.config.ts`
- `git diff --check`

## Documentation

Updates the search, library, use-case, architecture, and data-layer contracts to describe the durable pause/resume state machine, stale-result guarantees, workload authority, and non-blocking preflight requirements.
