### PR TITLE
fix(agent): preserve immediate stream deltas

### DIFF
--- a/code-review/agent-panel.md
+++ b/code-review/agent-panel.md
@@ -394,6 +394,10 @@ Electron journey covering new chat, folder binding, command approval,
 transcript completion, a window-folder switch, and interruption. The fixture
 is selected through the shipping `STASHBASE_CODEX_BIN` override and uses no
 developer credentials, real CLI account, user CLI history, or network output.
+Its streamed-math journey deliberately sends consecutive text deltas followed
+immediately by turn completion. Queued React state updates must use the stream
+boundary captured when each protocol event arrived; completion or tool events
+must not retroactively change how an earlier delta is accumulated.
 
 A credentialed real-CLI Agent turn, clipboard-image attachment, and packaged
 runtime discovery remain in the residual

--- a/e2e/visual/document.spec.ts
+++ b/e2e/visual/document.spec.ts
@@ -20,9 +20,10 @@ test('Markdown reading, writing, and valid JSON keep distinct document surfaces'
 
     await openFixtureFile(page, 'Welcome.md');
     const markdown = activeDocument(page);
+    const markdownShell = markdown.locator('.crepe-shell');
     const readingToggle = page.getByRole('button', { name: 'Switch to Reading View' });
     if (await readingToggle.isVisible()) await readingToggle.click();
-    await expect(markdown).toHaveClass(/crepe-readonly/);
+    await expect(markdownShell).toHaveClass(/crepe-readonly/);
     await expect(markdown.getByRole('heading', { name: 'Welcome to Project Alpha' })).toBeVisible();
     await expect(page.getByRole('navigation', { name: 'Document outline' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Switch to Live Editing' })).toBeVisible();
@@ -30,7 +31,7 @@ test('Markdown reading, writing, and valid JSON keep distinct document surfaces'
 
     await setTheme(page, 'dark');
     await page.getByRole('button', { name: 'Switch to Live Editing' }).click();
-    await expect(markdown).not.toHaveClass(/crepe-readonly/);
+    await expect(markdownShell).not.toHaveClass(/crepe-readonly/);
     await expect(markdown.locator('.ProseMirror')).toHaveAttribute('contenteditable', 'true');
     await expect(page.getByRole('button', { name: 'Switch to Reading View' })).toBeVisible();
     await expectLinuxScreenshot(page, 'markdown-writing-dark.png');

--- a/web-src/src/__tests__/agent-view-lifecycle.test.ts
+++ b/web-src/src/__tests__/agent-view-lifecycle.test.ts
@@ -154,6 +154,14 @@ test('mounted AgentView ready → raw close renders recovery and reconnects with
     first.event({ t: 'ready' });
     first.event({ t: 'session-id', id: 'thread-123' });
     first.event({ t: 'turn-start' });
+    first.event({ t: 'text', delta: String.raw`Streamed formula: \(x^2` });
+    first.event({ t: 'text', delta: String.raw` + 1\).` });
+    first.event({ t: 'turn-end', isError: false });
+  });
+  assert.match(renderedText(renderer!), /Streamed formula:.*x\^2.*1/);
+
+  await act(async () => {
+    first.event({ t: 'turn-start' });
     first.event({ t: 'text', delta: 'Partial answer survives.' });
     first.event({ t: 'tool', id: 'tool-1', name: 'Bash', input: {} });
   });

--- a/web-src/src/components/AgentView.tsx
+++ b/web-src/src/components/AgentView.tsx
@@ -763,14 +763,20 @@ export function AgentView({
   }
 
   function appendStream(kind: 'assistant' | 'thinking', delta: string) {
+    // Capture the stream boundary before scheduling React state. Several WS
+    // messages can arrive in one task, and turn-end/tool handling mutates the
+    // ref synchronously while React is still batching these updaters. Reading
+    // the ref inside the updater can therefore discard or split an earlier
+    // delta when completion follows immediately after it.
+    const appendToOpenBlock = openKind.current === kind;
+    openKind.current = kind;
     setBlocks((bs) => {
       const last = bs[bs.length - 1];
-      if (openKind.current === kind && last && (last.kind === 'assistant' || last.kind === 'thinking')) {
+      if (appendToOpenBlock && last?.kind === kind) {
         const next = bs.slice();
         next[next.length - 1] = { ...last, text: last.text + delta };
         return next;
       }
-      openKind.current = kind;
       return [...bs, { kind, id: nextId(), text: delta }];
     });
   }


### PR DESCRIPTION
## Summary

Agent replies now retain streamed text when a completion or tool event arrives in the same React batch. This prevents valid streamed Markdown, including KaTeX math, from being truncated to its final delta.

## What changed

- Capture the stream boundary before scheduling the React state update, so later protocol events cannot reclassify an earlier text delta.
- Add a renderer regression test for consecutive math deltas followed immediately by `turn-end`.
- Correct the visual Markdown journey to assert the read-only state on the shipping `.crepe-shell` element rather than its outer document container.
- Document the immediate-stream completion invariant in the Agent panel review contract.

## Validation

- [x] `pnpm typecheck`
- [x] Focused tests for the affected behavior (`pnpm test:renderer`; Agent functional journey)
- [x] Renderer build or E2E coverage, when the change affects the UI (`pnpm build:web`; targeted visual journey)
- [x] Full source-build matrix and UI smoke passed on the first PR run.

## UI and visual baselines

- [ ] This PR changes a rendered UI surface or visual state.
- [ ] This fork PR allows maintainer edits if a reviewed Linux visual baseline update is needed.
- [x] This PR does not change a visual surface, or existing visual baselines remain valid.

The first Linux visual run failed before screenshot comparison because its selector targeted the wrong element. The correction passed locally without generated actual/expected/diff images; rerun CI is authoritative.

## Documentation

- [x] Updated the relevant `design-docs/` and `code-review/` contract, when this changes documented behavior or invariants.
- [ ] No documentation update is needed.