### PR TITLE
feat(account): add hosted allowance and secure OAuth return

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Test macOS recovery installer
         run: pnpm test:macos-recovery-installer
 
+      - name: Test application config and hosted account
+        run: pnpm test:config
+
       - name: Test renderer
         run: pnpm test:renderer
 
@@ -73,6 +76,9 @@ jobs:
 
       - name: Test library file transactions
         run: pnpm test:library-files
+
+      - name: Test retrieval
+        run: pnpm test:retrieval
 
       - name: Test agent adapters
         run: pnpm test:agent

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For a portable build, download `StashBase-*-linux-*.AppImage`, make it executabl
 When you open StashBase for the first time:
 
 1. **Open a folder**: Click the folder icon to choose a local folder containing files you want to search
-2. **(Optional) Set up AI Index**: To search by meaning and give Agents better retrieval, sign in with a verified email for the included monthly allowance, or add an OpenAI/OpenRouter key in **Settings → AI Index**. An OpenAI restricted key needs access only to embeddings with `text-embedding-3-small`; model-list access is not required.
+2. **(Optional) Set up AI Index**: To search by meaning and give Agents better retrieval, sign in through Supabase with Google for the included monthly allowance, or add an OpenAI/OpenRouter key in **Settings → AI Index**. An OpenAI restricted key needs access only to embeddings with `text-embedding-3-small`; model-list access is not required.
 3. **(Optional) Set up transcription**: To transcribe audio or video, download a speech model from **Settings → Transcription**. Small (465 MiB) is the default; Tiny (74 MiB) and Base (141 MiB) are lighter options. Transcription runs entirely on your machine, with no API cost, and you can cancel or rerun it while viewing the file
 4. **(Optional) Connect to Claude/Codex**: From **Settings → MCP**, connect external AI tools to access your searchable library
 5. **Start in Chat**: Chat is already open with one reusable blank session.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For a portable build, download `StashBase-*-linux-*.AppImage`, make it executabl
 When you open StashBase for the first time:
 
 1. **Open a folder**: Click the folder icon to choose a local folder containing files you want to search
-2. **(Optional) Set up AI Index**: To search by meaning and give Agents better retrieval, add an OpenAI or OpenRouter API key in **Settings → AI Index**. An OpenAI restricted key needs access only to embeddings with `text-embedding-3-small`; model-list access is not required.
+2. **(Optional) Set up AI Index**: To search by meaning and give Agents better retrieval, sign in with a verified email for the included monthly allowance, or add an OpenAI/OpenRouter key in **Settings → AI Index**. An OpenAI restricted key needs access only to embeddings with `text-embedding-3-small`; model-list access is not required.
 3. **(Optional) Set up transcription**: To transcribe audio or video, download a speech model from **Settings → Transcription**. Small (465 MiB) is the default; Tiny (74 MiB) and Base (141 MiB) are lighter options. Transcription runs entirely on your machine, with no API cost, and you can cancel or rerun it while viewing the file
 4. **(Optional) Connect to Claude/Codex**: From **Settings → MCP**, connect external AI tools to access your searchable library
 5. **Start in Chat**: Chat is already open with one reusable blank session.
@@ -87,7 +87,7 @@ When you open StashBase for the first time:
 
 Your library is **opt-in**: only folders you open in StashBase are indexed. You can remove a folder at any time; StashBase clears its index but never deletes your files from disk.
 
-> Haven't set up AI Index? In-app exact text search still works. Join our [Discord](https://discord.gg/zsRZH4PTq9) to ask about evaluation access.
+> Haven't set up AI Index, or used the hosted allowance? In-app exact text search still works.
 
 ### Updating and Uninstalling
 
@@ -164,6 +164,10 @@ StashBase builds its AI Index and exact text search over:
 - timestamped transcripts from audio and video
 
 Search results point back to the user-visible source file, not hidden app data.
+
+Hosted indexing and meaning-based queries share one monthly token allowance.
+The avatar menu shows the remaining percentage and reset date. If the hosted
+allowance runs out, Exact search and all local file workflows keep working.
 
 Background preparation is intentionally quiet. Browsing a folder should feel like browsing files, not watching an indexing job. If preparation fails, StashBase shows a lightweight failure marker and lets you retry. Readiness matters most when you search, so that is where StashBase shows how much of your content is ready.
 

--- a/code-review/architecture.md
+++ b/code-review/architecture.md
@@ -13,10 +13,14 @@ Electron renderer windows
 Node application server
   ├─ local file operations and preparation orchestration
   ├─ built-in Agent bridge
-  └─ MCP transports and library operations
+  ├─ MCP transports and library operations
+  └─ Supabase session and loopback embedding broker
         │
         ▼
 Python indexing daemon → one local Milvus Lite store
+        │ hosted source only: process-ephemeral localhost credential
+        ▼
+StashBase hosted embedding API
 ```
 
 One application session may own several renderer windows. They share the Node
@@ -31,7 +35,11 @@ presentation, and Agent tabs.
   reconcile orchestration, Settings writes, MCP, and Agent adapters.
 - The Python daemon owns chunking, embeddings, vector storage, and semantic
   retrieval. It receives text and source identity; it never decides how a
-  source format is converted.
+  source format is converted. For hosted embeddings it calls a Node-owned
+  OpenAI-compatible loopback broker and never receives Supabase tokens.
+- The Node server alone stores and refreshes the optional account session. It
+  assigns hosted request idempotency keys, labels index versus query purpose,
+  and exposes only display/quota state to renderer windows.
 - Renderer state is presentation and request coordination, not durable data
   truth. It cannot define preparation completion, index currency, file
   versions, or library membership.
@@ -87,6 +95,9 @@ surface.
   context.
 - Application quit is an authenticated owner-to-server shutdown handshake.
   Signals are timeout fallbacks, not the normal cleanup path.
+- The shutdown ladder closes hosted-broker listening, active, and idle sockets
+  independently of MCP, Agent-install, conversion, database, and indexer
+  cleanup failures.
 - Static renderer serving must bypass every API and asset route before serving
   the web bundle.
 
@@ -121,7 +132,7 @@ The main ownership seams are intentionally narrower than this map:
 | Data lifecycle Interfaces | `server/conversion-dispatch.ts`, `server/conversion-scheduler.ts`, `server/indexer.ts`, `server/mfs-daemon.ts` |
 | Library/MCP Interface | `LibraryOperations` in `server/library-operations/index.ts` |
 | Agent Interface | `AgentAdapter` and normalized events in `server/agent-contract.ts` |
-| Process Adapters | Electron preload/HTTP, MCP stdio/HTTP, Agent native protocols, and the Python daemon protocol |
+| Process Adapters | Electron preload/HTTP, MCP stdio/HTTP, Agent native protocols, the Python daemon protocol, and the hosted embedding loopback broker |
 
 This map names ownership Seams, not every runtime file. Follow the focused
 contract before reading an owner Module's internals.

--- a/code-review/architecture.md
+++ b/code-review/architecture.md
@@ -43,9 +43,11 @@ presentation, and Agent tabs.
 - Renderer state is presentation and request coordination, not durable data
   truth. It cannot define preparation completion, index currency, file
   versions, or library membership.
-- Settings is the only product surface for credentials. Environment variables
-  may select isolated test/runtime seams but are never the user's credential
-  source of truth.
+- Settings is the only product surface for BYOK credentials. Account OAuth may
+  start from explicit setup, Settings, or account-menu Sign in actions; its
+  refreshable session remains Node-owned. Environment variables may select
+  isolated test/runtime seams but are never the user's credential source of
+  truth.
 - Settings persistence remains atomic and fails closed when its path is not
   writable. The application reports the failure but never repairs filesystem
   ownership, flags, or ACLs on the user's behalf.

--- a/code-review/data-lifecycle.md
+++ b/code-review/data-lifecycle.md
@@ -79,6 +79,10 @@ embedding source resets and rebinds the single daemon so stale runtime
 credentials cannot survive. Compatible vectors remain reusable. Hosted index
 and query calls carry distinct purpose labels but consume one quota ledger;
 quota exhaustion disables only hosted semantic work and never exact retrieval.
+The availability gate is checked before and between embedding calls so one
+quota response stops the remainder of a batch. Pending work remains
+reconcilable and resumes after a quota refresh/reset or an available source
+switch.
 
 Large semantic workloads use the same authoritative content-hash diff. Known
 stale rows become unavailable before a durable awaiting/paused decision is

--- a/code-review/data-lifecycle.md
+++ b/code-review/data-lifecycle.md
@@ -74,6 +74,12 @@ For one folder it must:
 No-op reconcile spends no embedding work. Without an embedding source it still
 maintains prepared text and exact retrieval.
 
+Adding or removing a BYOK key, signing in or out, or explicitly switching the
+embedding source resets and rebinds the single daemon so stale runtime
+credentials cannot survive. Compatible vectors remain reusable. Hosted index
+and query calls carry distinct purpose labels but consume one quota ledger;
+quota exhaustion disables only hosted semantic work and never exact retrieval.
+
 Large semantic workloads use the same authoritative content-hash diff. Known
 stale rows become unavailable before a durable awaiting/paused decision is
 published. A pause never delays browsing, preparation, editing, or exact

--- a/code-review/release-pipeline.md
+++ b/code-review/release-pipeline.md
@@ -22,8 +22,8 @@ or timed-out CI.
 ## Source CI
 
 - The macOS, Windows, and Linux source matrix covers type/build gates plus
-  scheduler, cancellation, renderer, server, MCP, Python, and real Electron
-  lifecycle behavior.
+  config/account, scheduler, cancellation, retrieval, renderer, server, MCP,
+  Python, and real Electron lifecycle behavior.
 - Ubuntu Playwright adds smoke, deterministic functional journeys, and reviewed
   visual baselines without replacing the three-platform source matrix.
 - Linux source Electron may use `--no-sandbox` under hosted Xvfb. Packaged apps

--- a/code-review/settings-config.md
+++ b/code-review/settings-config.md
@@ -39,13 +39,13 @@ their clients and are updated only through explicit MCP setup actions.
 - Browser provider login uses PKCE. Node generates and retains the verifier,
   accepts the short-lived authorization code only on a loopback callback, and
   exposes an opaque flow id plus pending/complete/error state to the renderer.
-  After observing `complete`, the renderer may request native focus through a
-  narrow IPC channel; no provider code or account token crosses that channel,
-  and the browser callback page remains the fallback. Its app-return deep link
-  is a fixed, data-free action and never carries a flow id, provider code, or
-  account token. The callback page treats only a Node-side acknowledgement
-  from that exact Electron handler as a successful handoff; browser blur or
-  visibility changes are not proof that the app opened.
+  Renderer polling updates account state but never steals focus from the
+  callback page. The callback's app-return deep link is a fixed, data-free
+  action and never carries a flow id, provider code, or account token. The
+  exact Electron handler focuses the app and authenticates its Node-side
+  acknowledgement with a random per-launch child-process token; browser blur,
+  visibility changes, and unauthenticated loopback requests are not proof that
+  the app opened.
 - Read-modify-write helpers preserve unrelated config domains. Concurrent MCP
   listener transitions serialize and roll active exposure back if persistence
   fails.

--- a/code-review/settings-config.md
+++ b/code-review/settings-config.md
@@ -43,7 +43,9 @@ their clients and are updated only through explicit MCP setup actions.
   narrow IPC channel; no provider code or account token crosses that channel,
   and the browser callback page remains the fallback. Its app-return deep link
   is a fixed, data-free action and never carries a flow id, provider code, or
-  account token.
+  account token. The callback page treats only a Node-side acknowledgement
+  from that exact Electron handler as a successful handoff; browser blur or
+  visibility changes are not proof that the app opened.
 - Read-modify-write helpers preserve unrelated config domains. Concurrent MCP
   listener transitions serialize and roll active exposure back if persistence
   fails.

--- a/code-review/settings-config.md
+++ b/code-review/settings-config.md
@@ -28,6 +28,12 @@ their clients and are updated only through explicit MCP setup actions.
 - Credentials are accepted and persisted only through Settings. Environment
   variables may isolate automated tests or select runtime plumbing, but are
   never the product credential source of truth.
+- BYOK credentials, the refreshable Supabase account session, and the active
+  embedding source persist independently. Switching sources retains the
+  inactive credential and never silently falls back after a hosted failure.
+- Account access and refresh tokens are Node-only configuration. They never
+  cross renderer HTTP responses or the Node/Python boundary; Python receives a
+  random per-process loopback bearer credential instead.
 - Read-modify-write helpers preserve unrelated config domains. Concurrent MCP
   listener transitions serialize and roll active exposure back if persistence
   fails.
@@ -43,11 +49,11 @@ their clients and are updated only through explicit MCP setup actions.
 | Role | Stable entry points |
 |---|---|
 | Persistent Interface | strict/fallback read and write plus domain getters/setters in `server/app-config.ts` |
-| Domain owners | `server/mcp-http-settings.ts`, embedding and transcription configuration Modules |
-| HTTP Adapters | `server/routes/appearance.ts`, `onboarding.ts`, `embedder.ts`, `transcription.ts`, `mcp.ts` |
+| Domain owners | `server/mcp-http-settings.ts`, `server/hosted-account.ts`, `server/hosted-embedding-broker.ts`, embedding and transcription configuration Modules |
+| HTTP Adapters | `server/routes/appearance.ts`, `onboarding.ts`, `account.ts`, `embedder.ts`, `transcription.ts`, `mcp.ts` |
 | Renderer Adapters | `web-src/src/components/SettingsModal.tsx`, `components/settings/AppearancePanel.tsx`, `EmbeddingPanel.tsx`, `TranscriptionPanel.tsx`, `McpClientsPanel.tsx`, `AgentRuntimePanel.tsx` |
 | Appearance Adapter | `web-src/src/appearance.ts` |
-| Focused evidence | `server/app-config.test.ts`, `server/__tests__/mcp-http-settings.test.ts`, `web-src/src/__tests__/appearance.test.ts`, `e2e/smoke/settings.spec.ts` |
+| Focused evidence | `server/app-config.test.ts`, `server/hosted-account.test.ts`, `server/__tests__/mcp-http-settings.test.ts`, `web-src/src/__tests__/appearance.test.ts`, `web-src/src/__tests__/embedding-auth.test.ts`, `e2e/smoke/settings.spec.ts` |
 
 ## Validation
 

--- a/code-review/settings-config.md
+++ b/code-review/settings-config.md
@@ -39,13 +39,15 @@ their clients and are updated only through explicit MCP setup actions.
 - Browser provider login uses PKCE. Node generates and retains the verifier,
   accepts the short-lived authorization code only on a loopback callback, and
   exposes an opaque flow id plus pending/complete/error state to the renderer.
-  Renderer polling updates account state but never steals focus from the
-  callback page. The callback's app-return deep link is a fixed, data-free
-  action and never carries a flow id, provider code, or account token. The
-  exact Electron handler focuses the app and authenticates its Node-side
-  acknowledgement with a random per-launch child-process token; browser blur,
-  visibility changes, and unauthenticated loopback requests are not proof that
-  the app opened.
+  Node associates that flow with the initiating window identity. Renderer
+  polling updates account state but never steals focus from the callback page.
+  Before opening the app, the page records return intent against its opaque
+  local flow; the app-return deep link itself remains a fixed, data-free action
+  and never carries a flow id, provider code, or account token. The exact
+  Electron handler focuses the associated live window and authenticates its
+  Node-side acknowledgement with a random per-launch child-process token;
+  browser blur, visibility changes, and unauthenticated loopback requests are
+  not proof that the app opened.
 - Read-modify-write helpers preserve unrelated config domains. Concurrent MCP
   listener transitions serialize and roll active exposure back if persistence
   fails.

--- a/code-review/settings-config.md
+++ b/code-review/settings-config.md
@@ -25,7 +25,9 @@ their clients and are updated only through explicit MCP setup actions.
 - The app never changes user-managed filesystem ownership, flags, or ACLs to
   repair an unwritable config directory. Errors name the user-actionable config
   location without leaking atomic temporary paths.
-- Credentials are accepted and persisted only through Settings. Environment
+- BYOK credentials are accepted and persisted only through Settings. Account
+  OAuth may start from explicit setup, Settings, or account-menu Sign in
+  actions, but only the Node server persists its session. Environment
   variables may isolate automated tests or select runtime plumbing, but are
   never the product credential source of truth.
 - BYOK credentials, the refreshable Supabase account session, and the active
@@ -34,6 +36,14 @@ their clients and are updated only through explicit MCP setup actions.
 - Account access and refresh tokens are Node-only configuration. They never
   cross renderer HTTP responses or the Node/Python boundary; Python receives a
   random per-process loopback bearer credential instead.
+- Browser provider login uses PKCE. Node generates and retains the verifier,
+  accepts the short-lived authorization code only on a loopback callback, and
+  exposes an opaque flow id plus pending/complete/error state to the renderer.
+  After observing `complete`, the renderer may request native focus through a
+  narrow IPC channel; no provider code or account token crosses that channel,
+  and the browser callback page remains the fallback. Its app-return deep link
+  is a fixed, data-free action and never carries a flow id, provider code, or
+  account token.
 - Read-modify-write helpers preserve unrelated config domains. Concurrent MCP
   listener transitions serialize and roll active exposure back if persistence
   fails.

--- a/code-review/window-lifecycle.md
+++ b/code-review/window-lifecycle.md
@@ -36,6 +36,13 @@ after readiness, a save failure or timeout keeps the window open.
   membership still contains the folder.
 - A single-flight initial-window operation plus the single-instance lock
   prevents startup races from creating duplicate windows.
+- Browser-owned OAuth may return focus only to the live main window whose
+  renderer requests it. The focus channel restores, shows, and focuses that
+  same sender window; it never accepts an arbitrary identity or creates or
+  revives a window. The packaged `stashbase://` handler accepts only the exact
+  data-free `oauth-complete` authority. macOS `open-url`, Windows/Linux second
+  instances, and cold-start arguments converge on the same bounded focus path;
+  all other protocol URLs are inert.
 - macOS may remain alive without a window and recreate one on activation.
   Windows and Linux quit after the final window closes. Platform window
   accelerators never masquerade as document-tab commands.

--- a/code-review/window-lifecycle.md
+++ b/code-review/window-lifecycle.md
@@ -39,10 +39,13 @@ after readiness, a save failure or timeout keeps the window open.
 - Browser-owned OAuth returns focus only through the packaged `stashbase://`
   handler, which accepts the exact data-free `oauth-complete` authority.
   Renderer polling updates account state without racing that browser-owned
-  handoff. macOS `open-url`, Windows/Linux second instances, and cold-start
-  arguments converge on the same bounded focus path; all other protocol URLs
-  are inert and a cold invalid launch exits without creating a window. After
-  focusing, Electron authenticates its loopback acknowledgement with a random
+  handoff. Node retains the initiating window identity on the opaque flow, and
+  the callback records return intent before opening the fixed deep link so
+  Electron can restore that live window rather than whichever window was
+  focused most recently. macOS `open-url`, Windows/Linux second instances, and
+  cold-start arguments converge on the same bounded focus path; all other
+  protocol URLs are inert and a cold invalid launch exits without creating a
+  window. Electron authenticates its loopback acknowledgement with a random
   per-launch child-process token so the browser page closes only on evidence
   from the exact native handler.
 - macOS may remain alive without a window and recreate one on activation.

--- a/code-review/window-lifecycle.md
+++ b/code-review/window-lifecycle.md
@@ -42,7 +42,9 @@ after readiness, a save failure or timeout keeps the window open.
   revives a window. The packaged `stashbase://` handler accepts only the exact
   data-free `oauth-complete` authority. macOS `open-url`, Windows/Linux second
   instances, and cold-start arguments converge on the same bounded focus path;
-  all other protocol URLs are inert.
+  all other protocol URLs are inert. After focusing, Electron acknowledges the
+  handoff to the loopback account Module so the browser page can close on
+  evidence rather than a generic focus change.
 - macOS may remain alive without a window and recreate one on activation.
   Windows and Linux quit after the final window closes. Platform window
   accelerators never masquerade as document-tab commands.

--- a/code-review/window-lifecycle.md
+++ b/code-review/window-lifecycle.md
@@ -36,15 +36,15 @@ after readiness, a save failure or timeout keeps the window open.
   membership still contains the folder.
 - A single-flight initial-window operation plus the single-instance lock
   prevents startup races from creating duplicate windows.
-- Browser-owned OAuth may return focus only to the live main window whose
-  renderer requests it. The focus channel restores, shows, and focuses that
-  same sender window; it never accepts an arbitrary identity or creates or
-  revives a window. The packaged `stashbase://` handler accepts only the exact
-  data-free `oauth-complete` authority. macOS `open-url`, Windows/Linux second
-  instances, and cold-start arguments converge on the same bounded focus path;
-  all other protocol URLs are inert. After focusing, Electron acknowledges the
-  handoff to the loopback account Module so the browser page can close on
-  evidence rather than a generic focus change.
+- Browser-owned OAuth returns focus only through the packaged `stashbase://`
+  handler, which accepts the exact data-free `oauth-complete` authority.
+  Renderer polling updates account state without racing that browser-owned
+  handoff. macOS `open-url`, Windows/Linux second instances, and cold-start
+  arguments converge on the same bounded focus path; all other protocol URLs
+  are inert and a cold invalid launch exits without creating a window. After
+  focusing, Electron authenticates its loopback acknowledgement with a random
+  per-launch child-process token so the browser page closes only on evidence
+  from the exact native handler.
 - macOS may remain alive without a window and recreate one on activation.
   Windows and Linux quit after the final window closes. Platform window
   accelerators never masquerade as document-tab commands.

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -90,7 +90,8 @@ user-visible source file.
   rebinds the single local daemon without rebuilding compatible vectors.
 - Hosted indexing and meaning-based queries share one token allowance. When it
   is exhausted, hosted semantic work stops while exact text retrieval and all
-  other local workflows remain available.
+  other local workflows remain available. Pending semantic work resumes after
+  the allowance resets or the user selects an available BYOK source.
 - Incomplete, stale, or partial derived output is never current truth.
 - Reconcile and reindex bring external file changes back into the library.
 - Reconcile estimates new or changed semantic work before embedding. Large

--- a/design-docs/architecture.md
+++ b/design-docs/architecture.md
@@ -32,6 +32,12 @@ library per installation.
 | Bug-report drafts | StashBase desktop application | They are ephemeral application state; renderers receive only opaque references and safe display metadata. |
 | Credentials and user settings | StashBase settings | They are managed through Settings, not environment variables. Appearance is user-wide, updates every open window immediately, and is limited to theme plus UI and reading-size presets. |
 
+The optional StashBase account session is owned by the local Node service and
+stored with the same owner-only configuration as bring-your-own-key
+credentials. The Python indexing daemon never receives the Supabase access or
+refresh token. It calls an ephemeral loopback broker credential; Node refreshes
+the account session and forwards only extracted text to the hosted API.
+
 Derived artifacts must not appear as ordinary files in the workspace. When
 search finds derived evidence, the result still identifies and opens the
 user-visible source file.
@@ -79,6 +85,12 @@ user-visible source file.
   available to keyword retrieval before semantic indexing is ready.
 - Semantic retrieval is optional. Without embedding configuration, browsing,
   editing, and keyword retrieval remain available.
+- AI Index can use either a signed-in StashBase account allowance or a user
+  supplied OpenAI/OpenRouter key. The active source is explicit; switching
+  rebinds the single local daemon without rebuilding compatible vectors.
+- Hosted indexing and meaning-based queries share one token allowance. When it
+  is exhausted, hosted semantic work stops while exact text retrieval and all
+  other local workflows remain available.
 - Incomplete, stale, or partial derived output is never current truth.
 - Reconcile and reindex bring external file changes back into the library.
 - Reconcile estimates new or changed semantic work before embedding. Large

--- a/design-docs/design/search.md
+++ b/design-docs/design/search.md
@@ -22,10 +22,13 @@ user-managed results.
 - AI Index provides meaning-based retrieval when an embedding source is
   configured. Product copy says **AI Index**; engineering terms such as
   semantic indexing and embeddings appear only where technically necessary.
-- Setup offers a verified-email StashBase account with an included monthly
-  allowance as the primary path and OpenAI/OpenRouter keys as the advanced
+- Setup offers a Supabase browser sign-in with Google and an included monthly
+  allowance as the primary path, with OpenAI/OpenRouter keys as the advanced
   path. The active source is explicit, while inactive account and key
-  credentials remain available for later switching.
+  credentials remain available for later switching. After browser sign-in,
+  the initiating desktop window returns to the foreground and the centered
+  callback card attempts to close. If the OS or browser blocks the automatic
+  handoff, the card offers an explicit **Open StashBase** action.
 - The search popup searches the whole library by default and can narrow to one
   member folder. It remembers query, mode, options, scope, and results across
   close, reopen, and folder switches, then refreshes against current content.
@@ -59,8 +62,10 @@ user-managed results.
   is presented. Current indexed files may still provide partial results.
 - Result scope never widens silently, and a derived path never crosses the
   product boundary.
-- Credentials are managed through Settings. Browsing local files and serving
-  an existing local index never depends on online authentication.
+- BYOK credentials are managed through Settings. Account login starts only
+  from an explicit Sign in action in setup, Settings, or the account menu.
+  Browsing local files and serving an existing local index never depends on
+  online authentication.
 - Account sessions remain Node-owned. Renderer responses contain only account
   display/quota state, and the Python daemon receives only an ephemeral
   loopback credential rather than Supabase access or refresh tokens.

--- a/design-docs/design/search.md
+++ b/design-docs/design/search.md
@@ -50,7 +50,9 @@ user-managed results.
 - Hosted indexing and meaning-based queries draw from one token allowance.
   The account menu shows identity, remaining percentage, and reset date. When
   the allowance is exhausted, hosted semantic work stops while Exact search
-  and every local-file workflow remain available.
+  and every local-file workflow remain available. Pending semantic work
+  resumes after the allowance refreshes or an available BYOK source is
+  selected.
 - In-app and MCP retrieval share source identity and access rules. MCP also
   supports validated source-type categories.
 

--- a/design-docs/design/search.md
+++ b/design-docs/design/search.md
@@ -22,6 +22,10 @@ user-managed results.
 - AI Index provides meaning-based retrieval when an embedding source is
   configured. Product copy says **AI Index**; engineering terms such as
   semantic indexing and embeddings appear only where technically necessary.
+- Setup offers a verified-email StashBase account with an included monthly
+  allowance as the primary path and OpenAI/OpenRouter keys as the advanced
+  path. The active source is explicit, while inactive account and key
+  credentials remain available for later switching.
 - The search popup searches the whole library by default and can narrow to one
   member folder. It remembers query, mode, options, scope, and results across
   close, reopen, and folder switches, then refreshes against current content.
@@ -40,6 +44,10 @@ user-managed results.
 - AI Index setup is strongly recommended but not a gate for local browsing,
   editing, preview, or exact search. Activation persists; “Skip for now” is a
   per-window choice and remains reversible from Files or Settings.
+- Hosted indexing and meaning-based queries draw from one token allowance.
+  The account menu shows identity, remaining percentage, and reset date. When
+  the allowance is exhausted, hosted semantic work stops while Exact search
+  and every local-file workflow remain available.
 - In-app and MCP retrieval share source identity and access rules. MCP also
   supports validated source-type categories.
 
@@ -53,6 +61,9 @@ user-managed results.
   product boundary.
 - Credentials are managed through Settings. Browsing local files and serving
   an existing local index never depends on online authentication.
+- Account sessions remain Node-owned. Renderer responses contain only account
+  display/quota state, and the Python daemon receives only an ephemeral
+  loopback credential rather than Supabase access or refresh tokens.
 - A credential save fails with an actionable error when the app-owned settings
   path is not writable. StashBase does not change filesystem ownership, flags,
   or access-control entries to make the save succeed.

--- a/design-docs/design/workspace.md
+++ b/design-docs/design/workspace.md
@@ -26,6 +26,10 @@ manager, or a primary graph-navigation tool.
   the account utilities at the bottom. A no-folder window shows the
   zero-folder card when the library is empty, or a quiet pointer at the
   titlebar switcher when members exist.
+- The account row reads **Anonymous** without restricting local work. Its menu
+  routes signed-out users to AI Index setup and shows signed-in identity,
+  hosted-usage percentage, reset date, Learn more, and Sign out. AI Index
+  source selection remains in Settings rather than persistent sidebar chrome.
 - Users can open or create a local folder, switch folders in place, favorite a
   member, open it in another window, sync it, or remove it from the library.
   A created folder is an ordinary directory. Removing membership clears only

--- a/design-docs/user-journeys.md
+++ b/design-docs/user-journeys.md
@@ -76,14 +76,19 @@ current truth.
 the visible source.
 
 1. Open library search and enter a query.
-2. Use exact text without AI Index, or meaning-based search when configured.
-3. Optionally narrow to one member folder.
-4. Review grouped evidence and readiness guidance.
-5. Open the result without exposing a hidden derived artifact or unexpectedly
+2. Use exact text without AI Index, or configure meaning-based search by
+   verifying an email for the included allowance or supplying an
+   OpenAI/OpenRouter key.
+3. When using the hosted allowance, inspect its remaining percentage and reset
+   date from the account menu; indexing and queries share that allowance.
+4. Optionally narrow to one member folder.
+5. Review grouped evidence and readiness guidance.
+6. Open the result without exposing a hidden derived artifact or unexpectedly
    replacing the window's active folder.
 
-Important recovery: partial preparation, stale index state, and provider
-failure are distinguishable from an empty result.
+Important recovery: partial preparation, stale index state, provider failure,
+and hosted quota exhaustion are distinguishable from an empty result. Exact
+search remains available when hosted semantic work cannot continue.
 
 ## J06: Start and continue an Agent chat
 

--- a/design-docs/user-journeys.md
+++ b/design-docs/user-journeys.md
@@ -77,8 +77,10 @@ the visible source.
 
 1. Open library search and enter a query.
 2. Use exact text without AI Index, or configure meaning-based search by
-   verifying an email for the included allowance or supplying an
-   OpenAI/OpenRouter key.
+   signing in through Supabase with Google for the included allowance, or
+   supplying an OpenAI/OpenRouter key. A completed browser sign-in returns to
+   the initiating StashBase window automatically when the OS permits it; the
+   callback card offers **Open StashBase** when automatic return is blocked.
 3. When using the hosted allowance, inspect its remaining percentage and reset
    date from the account menu; indexing and queries share that allowance.
 4. Optionally narrow to one member folder.

--- a/e2e/journeys/semantic-search-ui.spec.ts
+++ b/e2e/journeys/semantic-search-ui.spec.ts
@@ -15,7 +15,8 @@ test('semantic search UI renders deterministic loading, grouped, empty, and erro
     app = await launchApp(fixture, testInfo);
     await app.page.route('**/api/embedder', async (route) => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
-        provider: 'openai', hasKey: true, model: 'fixture-model',
+        provider: 'openai', hasKey: true, authorized: true, source: 'openai',
+        model: 'fixture-model', account: { signedIn: false, active: false },
       }) });
     });
     await app.page.route('**/api/library/search', async (route: Route) => {
@@ -92,13 +93,23 @@ test('removing the API key re-offers the AI Index dialog right away', async ({},
     let hasKey = true;
     await app.page.route('**/api/embedder', async (route) => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
-        provider: 'openai', hasKey, model: 'fixture-model',
+        provider: 'openai',
+        hasKey,
+        authorized: hasKey,
+        source: 'openai',
+        model: 'fixture-model',
+        account: { signedIn: false, active: false },
       }) });
     });
     await app.page.route('**/api/embedder/key', async (route) => {
       hasKey = false;
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
-        hasKey: false, provider: 'openai', model: 'fixture-model',
+        provider: 'openai',
+        hasKey: false,
+        authorized: false,
+        source: 'openai',
+        model: 'fixture-model',
+        account: { signedIn: false, active: false },
       }) });
     });
 

--- a/e2e/visual/document.spec.ts
+++ b/e2e/visual/document.spec.ts
@@ -61,6 +61,10 @@ test('compact document layout preserves the active reading surface', async ({}, 
     await expect(page.getByRole('tab', { name: 'Welcome.md' })).toHaveAttribute('aria-selected', 'true');
     await expect(document.getByRole('heading', { name: 'Welcome to Project Alpha' })).toBeVisible();
     await expect(page.locator('.chat-pane-shell')).toHaveAttribute('aria-hidden', 'true');
+    await expect(
+      page.getByRole('navigation', { name: 'Document outline' })
+        .getByRole('button', { name: 'Heading level 1: Welcome to Project Alpha' }),
+    ).toBeVisible();
 
     await expectLinuxScreenshot(page, 'compact-document.png');
   } finally {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -27,6 +27,7 @@ const { registerBugReportReviewIpc } = require('./bug-report-review-ipc.cjs');
 const { createBugReportReviewWindow } = require('./bug-report-review-window.cjs');
 const {
   WINDOW_ID_ARG_PREFIX,
+  classifyProtocolLaunch,
   createApplicationMenuTemplate,
   createRendererFlushCoordinator,
   createRendererFlushReadiness,
@@ -35,6 +36,7 @@ const {
   focusAllowedSenderWindow,
   focusWindow,
   isOAuthReturnUrl,
+  isStashBaseProtocolUrl,
   openOrFocusFolder,
   releaseWindowContextWithRetry,
   shouldQuitAfterLastWindow,
@@ -1123,9 +1125,15 @@ const initialWindowFlight = createSingleFlight(() => app.whenReady().then(() => 
 function focusOAuthReturn() {
   void app.whenReady().then(async () => {
     if (process.platform === 'darwin') app.focus({ steal: true });
-    if (focusLastMainWindow()) return;
-    await initialWindowFlight.run();
-    focusLastMainWindow();
+    if (!focusLastMainWindow()) {
+      await initialWindowFlight.run();
+      focusLastMainWindow();
+    }
+    const acknowledged = await requestJson(SERVER_PORT, '/api/account/oauth/app-return', 1000, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+    });
+    if (!acknowledged.ok) console.warn('[electron] could not acknowledge OAuth return to the callback page');
   });
 }
 
@@ -1137,8 +1145,8 @@ function registerOAuthReturnProtocol() {
 }
 
 app.on('open-url', (event, url) => {
+  if (isStashBaseProtocolUrl(url)) event.preventDefault();
   if (!isOAuthReturnUrl(url)) return;
-  event.preventDefault();
   focusOAuthReturn();
 });
 
@@ -1147,10 +1155,14 @@ if (!hasSingleInstanceLock) {
   app.quit();
 } else {
   app.on('second-instance', (_event, argv) => {
-    if (argv.some(isOAuthReturnUrl)) {
+    const protocolLaunch = classifyProtocolLaunch(argv);
+    if (protocolLaunch === 'oauth-return') {
       focusOAuthReturn();
       return;
     }
+    // A malformed or unsupported stashbase: URL must not fall through to the
+    // ordinary second-launch focus/create behavior.
+    if (protocolLaunch === 'inert') return;
     if (!focusLastMainWindow()) {
       void initialWindowFlight.run().then(() => { focusLastMainWindow(); });
     }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -33,7 +33,6 @@ const {
   createRendererFlushReadiness,
   createSingleFlight,
   createWindowRegistry,
-  focusAllowedSenderWindow,
   focusWindow,
   isOAuthReturnUrl,
   isStashBaseProtocolUrl,
@@ -1001,23 +1000,6 @@ ipcMain.handle('bug-report:open', async (event) => {
   return true;
 });
 
-// OAuth completion is observed by the initiating renderer through an opaque
-// local flow status. Let only that live main window bring itself back from the
-// system browser; this channel cannot focus arbitrary or auxiliary windows.
-ipcMain.handle('window:focus-self', (event) => {
-  const senderWindow = focusAllowedSenderWindow({
-    BrowserWindow,
-    sender: event.sender,
-    isAllowed: isLiveMainWindow,
-    beforeFocus: () => {
-      if (process.platform === 'darwin') app.focus({ steal: true });
-    },
-  });
-  if (!senderWindow) return false;
-  lastMainWindow = senderWindow;
-  return true;
-});
-
 ipcMain.handle('window:setFolder', (event, folder) => {
   if (folder !== null && (typeof folder !== 'string' || !folder.trim())) return false;
   const senderWindow = BrowserWindow.fromWebContents(event.sender);
@@ -1126,11 +1108,6 @@ const initialWindowFlight = createSingleFlight(() => app.whenReady().then(() => 
 
 function focusOAuthReturn() {
   void app.whenReady().then(async () => {
-    if (process.platform === 'darwin') app.focus({ steal: true });
-    if (!focusLastMainWindow()) {
-      await initialWindowFlight.run();
-      focusLastMainWindow();
-    }
     const acknowledged = await requestJson(SERVER_PORT, '/api/account/oauth/app-return', 1000, {
       method: 'POST',
       headers: {
@@ -1138,7 +1115,22 @@ function focusOAuthReturn() {
         'x-stashbase-oauth-return-token': OAUTH_RETURN_TOKEN,
       },
     });
-    if (!acknowledged.ok) console.warn('[electron] could not acknowledge OAuth return to the callback page');
+    if (!acknowledged.reachable || acknowledged.statusCode !== 200) {
+      console.warn('[electron] could not acknowledge OAuth return to the callback page');
+    }
+    if (process.platform === 'darwin') app.focus({ steal: true });
+    const targetId = typeof acknowledged.body?.windowId === 'string'
+      ? acknowledged.body.windowId
+      : null;
+    const target = targetId ? windowRegistry.windowForId(targetId) : null;
+    if (isLiveMainWindow(target) && focusWindow(target)) {
+      lastMainWindow = target;
+      return;
+    }
+    if (!focusLastMainWindow()) {
+      await initialWindowFlight.run();
+      focusLastMainWindow();
+    }
   });
 }
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -32,7 +32,9 @@ const {
   createRendererFlushReadiness,
   createSingleFlight,
   createWindowRegistry,
+  focusAllowedSenderWindow,
   focusWindow,
+  isOAuthReturnUrl,
   openOrFocusFolder,
   releaseWindowContextWithRetry,
   shouldQuitAfterLastWindow,
@@ -995,6 +997,22 @@ ipcMain.handle('bug-report:open', async (event) => {
   return true;
 });
 
+// OAuth completion is observed by the initiating renderer through an opaque
+// local flow status. Let only that live main window bring itself back from the
+// system browser; this channel cannot focus arbitrary or auxiliary windows.
+ipcMain.handle('window:focus-self', (event) => {
+  const senderWindow = focusAllowedSenderWindow({
+    BrowserWindow,
+    sender: event.sender,
+    isAllowed: isLiveMainWindow,
+    beforeFocus: () => {
+      if (process.platform === 'darwin') app.focus({ steal: true });
+    },
+  });
+  if (!senderWindow) return false;
+  lastMainWindow = senderWindow;
+  return true;
+});
 
 ipcMain.handle('window:setFolder', (event, folder) => {
   if (folder !== null && (typeof folder !== 'string' || !folder.trim())) return false;
@@ -1101,17 +1119,45 @@ ipcMain.on('clipboard:setAgentComposerFocused', (event, focused) => {
 });
 
 const initialWindowFlight = createSingleFlight(() => app.whenReady().then(() => createWindow()));
+
+function focusOAuthReturn() {
+  void app.whenReady().then(async () => {
+    if (process.platform === 'darwin') app.focus({ steal: true });
+    if (focusLastMainWindow()) return;
+    await initialWindowFlight.run();
+    focusLastMainWindow();
+  });
+}
+
+function registerOAuthReturnProtocol() {
+  const registered = process.defaultApp && process.argv[1]
+    ? app.setAsDefaultProtocolClient('stashbase', process.execPath, [path.resolve(process.argv[1])])
+    : app.setAsDefaultProtocolClient('stashbase');
+  if (!registered) console.warn('[electron] could not register the stashbase:// return protocol');
+}
+
+app.on('open-url', (event, url) => {
+  if (!isOAuthReturnUrl(url)) return;
+  event.preventDefault();
+  focusOAuthReturn();
+});
+
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
 if (!hasSingleInstanceLock) {
   app.quit();
 } else {
-  app.on('second-instance', () => {
+  app.on('second-instance', (_event, argv) => {
+    if (argv.some(isOAuthReturnUrl)) {
+      focusOAuthReturn();
+      return;
+    }
     if (!focusLastMainWindow()) {
       void initialWindowFlight.run().then(() => { focusLastMainWindow(); });
     }
   });
 
   app.whenReady().then(async () => {
+    registerOAuthReturnProtocol();
     try {
       await bugReportHandoff.initializeSession();
     } catch {
@@ -1132,6 +1178,7 @@ if (!hasSingleInstanceLock) {
     }
     installApplicationMenu();
     await initialWindowFlight.run();
+    if (process.argv.some(isOAuthReturnUrl)) focusOAuthReturn();
   });
 
   app.on('activate', () => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -118,6 +118,7 @@ const SERVER_HOST = '127.0.0.1';
 const SERVER_URL = `http://${SERVER_HOST}:${SERVER_PORT}`;
 const SERVER_PROTOCOL_VERSION = 1;
 const SERVER_SHUTDOWN_TOKEN = crypto.randomBytes(32).toString('hex');
+const OAUTH_RETURN_TOKEN = crypto.randomBytes(32).toString('hex');
 const PROJECT_ROOT = app.isPackaged ? app.getAppPath() : path.resolve(__dirname, '..');
 const SERVER_ENTRY = app.isPackaged
   ? path.join(PROJECT_ROOT, 'dist', 'server', 'index.mjs')
@@ -419,6 +420,7 @@ async function startOrReuseServer() {
       ...process.env,
       ...packagedEnv,
       STASHBASE_SHUTDOWN_TOKEN: SERVER_SHUTDOWN_TOKEN,
+      STASHBASE_OAUTH_RETURN_TOKEN: OAUTH_RETURN_TOKEN,
     },
     // stdin = 'ignore' is intentional: the server never reads from
     // stdin, and inheriting the parent's TTY made Node attach a real
@@ -1131,7 +1133,10 @@ function focusOAuthReturn() {
     }
     const acknowledged = await requestJson(SERVER_PORT, '/api/account/oauth/app-return', 1000, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: {
+        'content-type': 'application/json',
+        'x-stashbase-oauth-return-token': OAUTH_RETURN_TOKEN,
+      },
     });
     if (!acknowledged.ok) console.warn('[electron] could not acknowledge OAuth return to the callback page');
   });
@@ -1151,6 +1156,7 @@ app.on('open-url', (event, url) => {
 });
 
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
+const initialProtocolLaunch = classifyProtocolLaunch(process.argv);
 if (!hasSingleInstanceLock) {
   app.quit();
 } else {
@@ -1170,6 +1176,12 @@ if (!hasSingleInstanceLock) {
 
   app.whenReady().then(async () => {
     registerOAuthReturnProtocol();
+    // A cold unsupported stashbase: URL is just as inert as the same URL sent
+    // to an existing instance: do not start the server or create a window.
+    if (initialProtocolLaunch === 'inert') {
+      app.quit();
+      return;
+    }
     try {
       await bugReportHandoff.initializeSession();
     } catch {
@@ -1190,7 +1202,7 @@ if (!hasSingleInstanceLock) {
     }
     installApplicationMenu();
     await initialWindowFlight.run();
-    if (process.argv.some(isOAuthReturnUrl)) focusOAuthReturn();
+    if (initialProtocolLaunch === 'oauth-return') focusOAuthReturn();
   });
 
   app.on('activate', () => {

--- a/electron/multi-window.cjs
+++ b/electron/multi-window.cjs
@@ -155,6 +155,9 @@ function createWindowRegistry({ platform = process.platform } = {}) {
       }
       return null;
     },
+    windowForId(windowId) {
+      return records.get(windowId)?.win ?? null;
+    },
     setFolder(windowId, folder) {
       const record = records.get(windowId);
       if (!record) return false;
@@ -186,13 +189,6 @@ function focusWindow(win) {
   win.show();
   win.focus();
   return true;
-}
-
-function focusAllowedSenderWindow({ BrowserWindow, sender, isAllowed, beforeFocus }) {
-  const win = BrowserWindow.fromWebContents(sender);
-  if (!win || !isAllowed(win)) return null;
-  beforeFocus?.(win);
-  return focusWindow(win) ? win : null;
 }
 
 function isOAuthReturnUrl(value) {
@@ -371,7 +367,6 @@ module.exports = {
   createRendererFlushReadiness,
   createSingleFlight,
   createWindowRegistry,
-  focusAllowedSenderWindow,
   focusWindow,
   isOAuthReturnUrl,
   isStashBaseProtocolUrl,

--- a/electron/multi-window.cjs
+++ b/electron/multi-window.cjs
@@ -188,6 +188,30 @@ function focusWindow(win) {
   return true;
 }
 
+function focusAllowedSenderWindow({ BrowserWindow, sender, isAllowed, beforeFocus }) {
+  const win = BrowserWindow.fromWebContents(sender);
+  if (!win || !isAllowed(win)) return null;
+  beforeFocus?.(win);
+  return focusWindow(win) ? win : null;
+}
+
+function isOAuthReturnUrl(value) {
+  if (typeof value !== 'string' || value.length > 256) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'stashbase:'
+      && url.hostname === 'oauth-complete'
+      && (url.pathname === '' || url.pathname === '/')
+      && url.search === ''
+      && url.hash === ''
+      && url.username === ''
+      && url.password === ''
+      && url.port === '';
+  } catch {
+    return false;
+  }
+}
+
 async function openOrFocusFolder({
   registry,
   folder,
@@ -334,7 +358,9 @@ module.exports = {
   createRendererFlushReadiness,
   createSingleFlight,
   createWindowRegistry,
+  focusAllowedSenderWindow,
   focusWindow,
+  isOAuthReturnUrl,
   openOrFocusFolder,
   releaseWindowContextWithRetry,
   shouldQuitAfterLastWindow,

--- a/electron/multi-window.cjs
+++ b/electron/multi-window.cjs
@@ -212,6 +212,18 @@ function isOAuthReturnUrl(value) {
   }
 }
 
+function isStashBaseProtocolUrl(value) {
+  if (typeof value !== 'string' || value.length > 2048) return false;
+  try { return new URL(value).protocol === 'stashbase:'; }
+  catch { return false; }
+}
+
+function classifyProtocolLaunch(argv) {
+  if (argv.some(isOAuthReturnUrl)) return 'oauth-return';
+  if (argv.some(isStashBaseProtocolUrl)) return 'inert';
+  return 'ordinary';
+}
+
 async function openOrFocusFolder({
   registry,
   folder,
@@ -353,6 +365,7 @@ function createRendererFlushReadiness() {
 module.exports = {
   WINDOW_ID_ARG_PREFIX,
   buildElectronSmokeArgs,
+  classifyProtocolLaunch,
   createApplicationMenuTemplate,
   createRendererFlushCoordinator,
   createRendererFlushReadiness,
@@ -361,6 +374,7 @@ module.exports = {
   focusAllowedSenderWindow,
   focusWindow,
   isOAuthReturnUrl,
+  isStashBaseProtocolUrl,
   openOrFocusFolder,
   releaseWindowContextWithRetry,
   shouldQuitAfterLastWindow,

--- a/electron/multi-window.test.cjs
+++ b/electron/multi-window.test.cjs
@@ -10,6 +10,7 @@ const {
 const {
   WINDOW_ID_ARG_PREFIX,
   buildElectronSmokeArgs,
+  classifyProtocolLaunch,
   createApplicationMenuTemplate,
   createRendererFlushCoordinator,
   createRendererFlushReadiness,
@@ -18,6 +19,7 @@ const {
   focusAllowedSenderWindow,
   focusWindow,
   isOAuthReturnUrl,
+  isStashBaseProtocolUrl,
   openOrFocusFolder,
   releaseWindowContextWithRetry,
   shouldQuitAfterLastWindow,
@@ -323,6 +325,12 @@ test('OAuth return deep links have one exact, data-free authority', () => {
   assert.equal(isOAuthReturnUrl('stashbase://other-action'), false);
   assert.equal(isOAuthReturnUrl('https://oauth-complete'), false);
   assert.equal(isOAuthReturnUrl('not a URL'), false);
+  assert.equal(isStashBaseProtocolUrl('stashbase://other-action'), true);
+  assert.equal(isStashBaseProtocolUrl('stashbase:not-a-return'), true);
+  assert.equal(isStashBaseProtocolUrl('https://oauth-complete'), false);
+  assert.equal(classifyProtocolLaunch(['/Applications/StashBase', 'stashbase://oauth-complete']), 'oauth-return');
+  assert.equal(classifyProtocolLaunch(['/Applications/StashBase', 'stashbase://other-action']), 'inert');
+  assert.equal(classifyProtocolLaunch(['/Applications/StashBase']), 'ordinary');
 
   const packageJson = require('../package.json');
   assert.deepEqual(packageJson.build.protocols, [{

--- a/electron/multi-window.test.cjs
+++ b/electron/multi-window.test.cjs
@@ -16,7 +16,6 @@ const {
   createRendererFlushReadiness,
   createSingleFlight,
   createWindowRegistry,
-  focusAllowedSenderWindow,
   focusWindow,
   isOAuthReturnUrl,
   isStashBaseProtocolUrl,
@@ -262,6 +261,8 @@ test('folder registry finds an existing context, excludes the sender, and retire
   registry.add('window-2', second);
   registry.setFolder('window-1', 'C:\\Users\\Ada\\Notes');
 
+  assert.equal(registry.windowForId('window-1'), first);
+  assert.equal(registry.windowForId('missing'), null);
   assert.equal(registry.findByFolder('c:/users/ada/notes'), first);
   assert.equal(registry.findByFolder('C:\\Users\\Ada\\Notes', { excludeWindowId: 'window-1' }), null);
 
@@ -281,38 +282,6 @@ test('focusing an existing folder window restores it before bringing it forward'
 
   assert.equal(focusWindow(win), true);
   assert.deepEqual(calls, ['restore', 'show', 'focus']);
-});
-
-test('a live renderer may focus only its own allowed main window', () => {
-  const calls = [];
-  const sender = { id: 17 };
-  const win = {
-    isDestroyed: () => false,
-    isMinimized: () => true,
-    restore: () => calls.push('restore'),
-    show: () => calls.push('show'),
-    focus: () => calls.push('focus'),
-  };
-  const BrowserWindow = {
-    fromWebContents: (candidate) => candidate === sender ? win : null,
-  };
-
-  assert.equal(focusAllowedSenderWindow({
-    BrowserWindow,
-    sender,
-    isAllowed: (candidate) => candidate === win,
-    beforeFocus: () => calls.push('activate-app'),
-  }), win);
-  assert.deepEqual(calls, ['activate-app', 'restore', 'show', 'focus']);
-
-  calls.length = 0;
-  assert.equal(focusAllowedSenderWindow({
-    BrowserWindow,
-    sender,
-    isAllowed: () => false,
-    beforeFocus: () => calls.push('activate-app'),
-  }), null);
-  assert.deepEqual(calls, []);
 });
 
 test('OAuth return deep links have one exact, data-free authority', () => {

--- a/electron/multi-window.test.cjs
+++ b/electron/multi-window.test.cjs
@@ -15,7 +15,9 @@ const {
   createRendererFlushReadiness,
   createSingleFlight,
   createWindowRegistry,
+  focusAllowedSenderWindow,
   focusWindow,
+  isOAuthReturnUrl,
   openOrFocusFolder,
   releaseWindowContextWithRetry,
   shouldQuitAfterLastWindow,
@@ -277,6 +279,56 @@ test('focusing an existing folder window restores it before bringing it forward'
 
   assert.equal(focusWindow(win), true);
   assert.deepEqual(calls, ['restore', 'show', 'focus']);
+});
+
+test('a live renderer may focus only its own allowed main window', () => {
+  const calls = [];
+  const sender = { id: 17 };
+  const win = {
+    isDestroyed: () => false,
+    isMinimized: () => true,
+    restore: () => calls.push('restore'),
+    show: () => calls.push('show'),
+    focus: () => calls.push('focus'),
+  };
+  const BrowserWindow = {
+    fromWebContents: (candidate) => candidate === sender ? win : null,
+  };
+
+  assert.equal(focusAllowedSenderWindow({
+    BrowserWindow,
+    sender,
+    isAllowed: (candidate) => candidate === win,
+    beforeFocus: () => calls.push('activate-app'),
+  }), win);
+  assert.deepEqual(calls, ['activate-app', 'restore', 'show', 'focus']);
+
+  calls.length = 0;
+  assert.equal(focusAllowedSenderWindow({
+    BrowserWindow,
+    sender,
+    isAllowed: () => false,
+    beforeFocus: () => calls.push('activate-app'),
+  }), null);
+  assert.deepEqual(calls, []);
+});
+
+test('OAuth return deep links have one exact, data-free authority', () => {
+  assert.equal(isOAuthReturnUrl('stashbase://oauth-complete'), true);
+  assert.equal(isOAuthReturnUrl('stashbase://oauth-complete/'), true);
+  assert.equal(isOAuthReturnUrl('stashbase://oauth-complete?token=secret'), false);
+  assert.equal(isOAuthReturnUrl('stashbase://oauth-complete#flow'), false);
+  assert.equal(isOAuthReturnUrl('stashbase://oauth-complete:123'), false);
+  assert.equal(isOAuthReturnUrl('stashbase://user@oauth-complete'), false);
+  assert.equal(isOAuthReturnUrl('stashbase://other-action'), false);
+  assert.equal(isOAuthReturnUrl('https://oauth-complete'), false);
+  assert.equal(isOAuthReturnUrl('not a URL'), false);
+
+  const packageJson = require('../package.json');
+  assert.deepEqual(packageJson.build.protocols, [{
+    name: 'StashBase OAuth Return',
+    schemes: ['stashbase'],
+  }]);
 });
 
 test('folder action follows the user flow: focus another matching window or open a new one', async () => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -72,8 +72,6 @@ contextBridge.exposeInMainWorld('electron', {
    *  be reliable, and the system browser already has user cookies. */
   openExternal: (url) => ipcRenderer.invoke('shell:openExternal', url),
   reportBug: () => ipcRenderer.invoke('bug-report:open'),
-  /** Restore and focus this window after a browser-owned OAuth flow. */
-  focusWindow: () => ipcRenderer.invoke('window:focus-self'),
   openFolderWindow: (name) => ipcRenderer.invoke('window:openFolder', name),
   /** Keep the main-process folder → BrowserWindow registry current so
    *  "Open in New Window" can focus an existing matching context. */

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -72,6 +72,8 @@ contextBridge.exposeInMainWorld('electron', {
    *  be reliable, and the system browser already has user cookies. */
   openExternal: (url) => ipcRenderer.invoke('shell:openExternal', url),
   reportBug: () => ipcRenderer.invoke('bug-report:open'),
+  /** Restore and focus this window after a browser-owned OAuth flow. */
+  focusWindow: () => ipcRenderer.invoke('window:focus-self'),
   openFolderWindow: (name) => ipcRenderer.invoke('window:openFolder', name),
   /** Keep the main-process folder → BrowserWindow registry current so
    *  "Open in New Window" can focus an existing matching context. */

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build:desktop": "pnpm build && pnpm build:python-sidecar && pnpm build:transcription-sidecar",
     "setup:python": "node scripts/setup-python.mjs",
     "test:python": "node scripts/test-python.mjs",
-    "test:config": "node --import tsx --test server/app-config.test.ts server/hosted-account.test.ts",
+    "test:config": "node --import tsx --test server/app-config.test.ts server/embedding-availability.test.ts server/hosted-account.test.ts",
     "test:renderer": "node --import tsx --test web-src/src/__tests__/*.test.ts web-src/src/milkdown/__tests__/*.test.ts web-src/src/store/__tests__/*.test.ts",
     "test:electron": "node --test --test-reporter=spec electron/multi-window.test.cjs electron/bug-report-service.test.cjs electron/bug-report-redaction.test.cjs electron/bug-report-collection.test.cjs electron/bug-report-handoff.test.cjs electron/bug-report-review.test.cjs",
     "test:electron:smoke": "node electron/multi-window-smoke-runner.cjs",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build:desktop": "pnpm build && pnpm build:python-sidecar && pnpm build:transcription-sidecar",
     "setup:python": "node scripts/setup-python.mjs",
     "test:python": "node scripts/test-python.mjs",
-    "test:config": "node --import tsx --test server/app-config.test.ts",
+    "test:config": "node --import tsx --test server/app-config.test.ts server/hosted-account.test.ts",
     "test:renderer": "node --import tsx --test web-src/src/__tests__/*.test.ts web-src/src/milkdown/__tests__/*.test.ts web-src/src/store/__tests__/*.test.ts",
     "test:electron": "node --test --test-reporter=spec electron/multi-window.test.cjs electron/bug-report-service.test.cjs electron/bug-report-redaction.test.cjs electron/bug-report-collection.test.cjs electron/bug-report-handoff.test.cjs electron/bug-report-review.test.cjs",
     "test:electron:smoke": "node electron/multi-window-smoke-runner.cjs",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,14 @@
   "build": {
     "appId": "com.stashbase.app",
     "productName": "StashBase",
+    "protocols": [
+      {
+        "name": "StashBase OAuth Return",
+        "schemes": [
+          "stashbase"
+        ]
+      }
+    ],
     "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
     "icon": "build/icon",
     "electronDist": "node_modules/electron/dist",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "build:desktop": "pnpm build && pnpm build:python-sidecar && pnpm build:transcription-sidecar",
     "setup:python": "node scripts/setup-python.mjs",
     "test:python": "node scripts/test-python.mjs",
-    "test:config": "node --import tsx --test server/app-config.test.ts server/embedding-availability.test.ts server/hosted-account.test.ts",
+    "test:config": "node --import tsx --test server/app-config.test.ts server/embedding-availability.test.ts server/hosted-account.test.ts server/account-route.test.ts",
     "test:renderer": "node --import tsx --test web-src/src/__tests__/*.test.ts web-src/src/milkdown/__tests__/*.test.ts web-src/src/store/__tests__/*.test.ts",
     "test:electron": "node --test --test-reporter=spec electron/multi-window.test.cjs electron/bug-report-service.test.cjs electron/bug-report-redaction.test.cjs electron/bug-report-collection.test.cjs electron/bug-report-handoff.test.cjs electron/bug-report-review.test.cjs",
     "test:electron:smoke": "node electron/multi-window-smoke-runner.cjs",

--- a/python/stashbase_daemon.py
+++ b/python/stashbase_daemon.py
@@ -121,9 +121,10 @@ def make_embedder(provider: str = "openai", *, model=None, api_key=None, dimensi
     (`.embed(texts) -> list[list[float]]`, `.dimension`, `.model_name`).
 
     Rolled in-house — see `_OpenAIEmbedder`. ``provider`` is accepted for
-    protocol compatibility and is intentionally limited to OpenAI/OpenRouter.
+    protocol compatibility and is intentionally limited to OpenAI/OpenRouter
+    plus the loopback-only StashBase account broker.
     """
-    if provider not in ("openai", "openrouter"):
+    if provider not in ("openai", "openrouter", "stashbase"):
         raise ValueError(f"unsupported embedder provider {provider!r}")
     if not api_key:
         raise ValueError(f"{provider} embedder requires api_key")
@@ -163,7 +164,9 @@ class _OpenAIEmbedder:
     # (300k for text-embedding-3* at time of writing). Keep a margin and
     # batch locally so one big folder cannot take the daemon down.
     _MAX_REQUEST_TOKENS = 250_000
-    _MAX_BATCH_ITEMS = 128
+    # The hosted StashBase contract accepts at most 64 inputs. Keeping the
+    # same bound for direct providers makes batching source-independent.
+    _MAX_BATCH_ITEMS = 64
 
     def __init__(self, *, provider: str, model: str, api_key: str, dimension: int | None = None,
                  base_url: str | None = None,
@@ -180,7 +183,7 @@ class _OpenAIEmbedder:
         self._max_retries = max(1, max_retries)
         self._base_delay = base_delay
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
+    def embed(self, texts: list[str], *, purpose: str = "index") -> list[list[float]]:
         if not texts:
             return []
         out: list[list[float]] = []
@@ -197,13 +200,13 @@ class _OpenAIEmbedder:
                 batch_tokens + est > self._MAX_REQUEST_TOKENS
                 or len(batch) >= self._MAX_BATCH_ITEMS
             ):
-                out.extend(self._embed_batch(batch))
+                out.extend(self._embed_batch(batch, purpose=purpose))
                 batch = []
                 batch_tokens = 0
             batch.append(text)
             batch_tokens += est
         if batch:
-            out.extend(self._embed_batch(batch))
+            out.extend(self._embed_batch(batch, purpose=purpose))
         return out
 
     @staticmethod
@@ -212,7 +215,7 @@ class _OpenAIEmbedder:
         # ~4 chars/token; CJK is denser, so 3 chars/token leaves margin.
         return max(1, (len(text) + 2) // 3)
 
-    def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+    def _embed_batch(self, texts: list[str], *, purpose: str) -> list[list[float]]:
         transient = (
             self._openai.APITimeoutError,
             self._openai.APIConnectionError,
@@ -221,6 +224,8 @@ class _OpenAIEmbedder:
         )
         native = self._NATIVE_DIMS.get(self.model_name)
         kwargs: dict = {"model": self.model_name, "input": texts}
+        if self.provider == "stashbase":
+            kwargs["extra_headers"] = {"X-StashBase-Purpose": purpose}
         if native is not None and self.dimension != native:
             kwargs["dimensions"] = self.dimension
         last_err: Exception | None = None
@@ -849,6 +854,8 @@ def _flush_store(store) -> None:
 
 
 def _embed_with_cache(svc: "StashbaseStore", path: str, embedder, texts: list[str]) -> list:
+    if getattr(embedder, "provider", None) == "stashbase":
+        return embedder.embed(texts, purpose="index")
     return embedder.embed(texts)
 
 
@@ -1316,10 +1323,19 @@ def op_search(svc: StashbaseStore, args: dict) -> dict:
     try:
         if store.is_empty():
             return {"hits": []}
-        qvec = embedder.embed([query])[0]
+        qvec = (
+            embedder.embed([query], purpose="query")[0]
+            if getattr(embedder, "provider", None) == "stashbase"
+            else embedder.embed([query])[0]
+        )
         hits = store.hybrid_search(qvec, query, path_filter=path_filter, top_k=fetch_k)
     except Exception as exc:
         sys.stderr.write(f"[stashbase] search store failed: {exc}\n")
+        # Hosted quota exhaustion is a product state, not an empty result.
+        # Let Node surface it so the renderer can keep Exact search available
+        # while explaining why meaning-based search stopped.
+        if "quota_exhausted" in str(exc):
+            raise
         return {"hits": []}
 
     out = []

--- a/python/stashbase_daemon_test.py
+++ b/python/stashbase_daemon_test.py
@@ -252,6 +252,44 @@ class StashbaseDaemonTests(unittest.TestCase):
             },
         )
 
+    def test_stashbase_embedder_marks_query_purpose_for_loopback_broker(self) -> None:
+        captured = {}
+
+        class FakeEmbeddings:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return types.SimpleNamespace(data=[types.SimpleNamespace(embedding=[1.0, 0.0])])
+
+        class FakeOpenAIClient:
+            def __init__(self, **kwargs):
+                captured["client"] = kwargs
+                self.embeddings = FakeEmbeddings()
+
+        fake_openai = types.SimpleNamespace(
+            OpenAI=FakeOpenAIClient,
+            APITimeoutError=type("APITimeoutError", (Exception,), {}),
+            APIConnectionError=type("APIConnectionError", (Exception,), {}),
+            RateLimitError=type("RateLimitError", (Exception,), {}),
+            InternalServerError=type("InternalServerError", (Exception,), {}),
+        )
+        previous = sys.modules.get("openai")
+        sys.modules["openai"] = fake_openai
+        try:
+            embedder = stashbase_daemon.make_embedder(
+                "stashbase",
+                api_key="loopback-secret",
+                base_url="http://127.0.0.1:1234/v1",
+            )
+            self.assertEqual(embedder.embed(["query"], purpose="query"), [[1.0, 0.0]])
+        finally:
+            if previous is None:
+                sys.modules.pop("openai", None)
+            else:
+                sys.modules["openai"] = previous
+
+        self.assertEqual(captured["client"]["api_key"], "loopback-secret")
+        self.assertEqual(captured["extra_headers"], {"X-StashBase-Purpose": "query"})
+
     def test_index_listing_pages_past_1000_rows_without_primary_key_order(self) -> None:
         try:
             import milvus_lite  # noqa: F401

--- a/scripts/check-renderer-chunks.mjs
+++ b/scripts/check-renderer-chunks.mjs
@@ -30,6 +30,7 @@ const expectedEntries = [
   'src/components/SemanticIndexingNotice.tsx',
   'src/components/UnsupportedFilesCallout.tsx',
   'src/components/EmbeddingSetupCallout.tsx',
+  'src/components/SidebarAccountRow.tsx',
   'src/components/embedder/RequireApiKeyModal.tsx',
 ];
 

--- a/server/__tests__/shutdown-cleanup.test.ts
+++ b/server/__tests__/shutdown-cleanup.test.ts
@@ -7,11 +7,12 @@ test('MCP listener close failure cannot skip conversion and indexer cleanup', as
   await runShutdownCleanup({
     closeMcp: async () => { events.push('mcp'); throw new Error('close failed'); },
     cancelAgentInstalls: async () => { events.push('agent-installs'); return []; },
+    closeHostedBroker: async () => { events.push('hosted'); },
     cancelModelDownloads: async () => { events.push('model-downloads'); return []; },
     cancelConversions: async () => { events.push('conversions'); return []; },
     closeStateDb: () => { events.push('state-db'); },
     closeIndexer: async () => { events.push('indexer'); },
     onError: (step) => { events.push(`error:${step}`); },
   });
-  assert.deepEqual(events, ['mcp', 'error:mcp-http', 'agent-installs', 'model-downloads', 'conversions', 'state-db', 'indexer']);
+  assert.deepEqual(events, ['mcp', 'error:mcp-http', 'agent-installs', 'hosted', 'model-downloads', 'conversions', 'state-db', 'indexer']);
 });

--- a/server/account-route.test.ts
+++ b/server/account-route.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import type { Server as HttpServer } from 'node:http';
+import test from 'node:test';
+import express from 'express';
+import {
+  beginHostedOAuth,
+  failHostedOAuth,
+  hostedOAuthStatus,
+} from './hosted-account.ts';
+import { mount as mountAccountRoutes } from './routes/account.ts';
+
+test('OAuth app-return proof requires the Electron process-private token', async (t) => {
+  const app = express();
+  const flow = beginHostedOAuth('google', 'http://127.0.0.1:8090');
+  failHostedOAuth(flow.flowId, 'expected test failure');
+  mountAccountRoutes(app, { appReturnToken: 'private-return-token' });
+
+  const server: HttpServer = app.listen(0, '127.0.0.1');
+  t.after(() => new Promise<void>((resolve) => server.close(() => resolve())));
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const url = `http://127.0.0.1:${address.port}/api/account/oauth/app-return`;
+
+  assert.equal((await fetch(url, { method: 'POST' })).status, 403);
+  assert.equal(hostedOAuthStatus(flow.flowId).appReturned, undefined);
+
+  assert.equal((await fetch(url, {
+    method: 'POST',
+    headers: { 'x-stashbase-oauth-return-token': 'wrong-token' },
+  })).status, 403);
+  assert.equal(hostedOAuthStatus(flow.flowId).appReturned, undefined);
+
+  const accepted = await fetch(url, {
+    method: 'POST',
+    headers: { 'x-stashbase-oauth-return-token': 'private-return-token' },
+  });
+  assert.equal(accepted.status, 200);
+  assert.deepEqual(await accepted.json(), { acknowledged: true });
+  assert.equal(hostedOAuthStatus(flow.flowId).appReturned, true);
+});

--- a/server/account-route.test.ts
+++ b/server/account-route.test.ts
@@ -11,7 +11,7 @@ import { mount as mountAccountRoutes } from './routes/account.ts';
 
 test('OAuth app-return proof requires the Electron process-private token', async (t) => {
   const app = express();
-  const flow = beginHostedOAuth('google', 'http://127.0.0.1:8090');
+  const flow = beginHostedOAuth('google', 'http://127.0.0.1:8090', 'window-one');
   failHostedOAuth(flow.flowId, 'expected test failure');
   mountAccountRoutes(app, { appReturnToken: 'private-return-token' });
 
@@ -25,6 +25,12 @@ test('OAuth app-return proof requires the Electron process-private token', async
   assert.equal((await fetch(url, { method: 'POST' })).status, 403);
   assert.equal(hostedOAuthStatus(flow.flowId).appReturned, undefined);
 
+  const intent = await fetch(
+    `http://127.0.0.1:${address.port}/api/account/oauth/return-intent?flow=${flow.flowId}`,
+    { method: 'POST' },
+  );
+  assert.equal(intent.status, 200);
+
   assert.equal((await fetch(url, {
     method: 'POST',
     headers: { 'x-stashbase-oauth-return-token': 'wrong-token' },
@@ -36,6 +42,6 @@ test('OAuth app-return proof requires the Electron process-private token', async
     headers: { 'x-stashbase-oauth-return-token': 'private-return-token' },
   });
   assert.equal(accepted.status, 200);
-  assert.deepEqual(await accepted.json(), { acknowledged: true });
+  assert.deepEqual(await accepted.json(), { acknowledged: true, windowId: 'window-one' });
   assert.equal(hostedOAuthStatus(flow.flowId).appReturned, true);
 });

--- a/server/app-config.test.ts
+++ b/server/app-config.test.ts
@@ -39,6 +39,56 @@ function runConfigWrite(home: string) {
   );
 }
 
+function runConfigMutation(home: string, statement: string) {
+  return spawnSync(
+    process.execPath,
+    [
+      '--no-warnings',
+      '--import',
+      'tsx',
+      '--input-type=module',
+      '--eval',
+      `
+        try {
+          const config = await import('./server/app-config.ts');
+          ${statement}
+        } catch (error) {
+          process.stderr.write(error instanceof Error ? error.message : String(error));
+          process.exitCode = 17;
+        }
+      `,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: { ...process.env, HOME: home },
+    },
+  );
+}
+
+test('credential and source mutations never overwrite malformed config through a fallback read', () => {
+  const statements = [
+    `config.setHostedAccountSession({ accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800, userId: 'user', email: 'person@example.com' });`,
+    `config.setEmbedderConfig({ provider: 'openai', apiKey: 'sk-test' });`,
+    `config.setEmbeddingSource('openai');`,
+  ];
+  for (const statement of statements) {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-config-corrupt-test-'));
+    const configDir = path.join(home, '.stashbase');
+    const configPath = path.join(configDir, 'config.json');
+    fs.mkdirSync(configDir);
+    fs.writeFileSync(configPath, '{ malformed but user-owned config');
+    try {
+      const result = runConfigMutation(home, statement);
+      assert.equal(result.status, 17);
+      assert.match(result.stderr, /Could not read .*config\.json: invalid JSON/);
+      assert.equal(fs.readFileSync(configPath, 'utf8'), '{ malformed but user-owned config');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  }
+});
+
 test('macOS config writes do not alter an ACL that blocks atomic temp files', {
   skip: process.platform !== 'darwin',
 }, () => {

--- a/server/app-config.test.ts
+++ b/server/app-config.test.ts
@@ -34,7 +34,7 @@ function runConfigWrite(home: string) {
     {
       cwd: repoRoot,
       encoding: 'utf8',
-      env: { ...process.env, HOME: home },
+      env: { ...process.env, HOME: home, USERPROFILE: home },
     },
   );
 }
@@ -61,7 +61,7 @@ function runConfigMutation(home: string, statement: string) {
     {
       cwd: repoRoot,
       encoding: 'utf8',
-      env: { ...process.env, HOME: home },
+      env: { ...process.env, HOME: home, USERPROFILE: home },
     },
   );
 }

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -265,7 +265,7 @@ export function getHostedAccountSession(): HostedAccountSession | undefined {
 }
 
 export function setHostedAccountSession(session: HostedAccountSession | undefined): void {
-  const cfg = readAppConfig();
+  const cfg = readAppConfigStrict();
   if (session) cfg.account = { ...(cfg.account ?? {}), session: { ...session } };
   else {
     delete cfg.account?.session;
@@ -285,13 +285,13 @@ export function getEmbeddingSource(): EmbeddingSource {
 }
 
 export function setEmbeddingSource(source: EmbeddingSource): EmbeddingSource {
+  const cfg = readAppConfigStrict();
   if (source === 'stashbase-account') {
     if (!getHostedAccountSession()) throw new Error('Sign in before selecting the StashBase account allowance.');
   } else {
     const direct = getEmbedderConfig();
     if (!direct.apiKey || direct.provider !== source) throw new Error(`Add a ${source === 'openrouter' ? 'OpenRouter' : 'OpenAI'} key before selecting it.`);
   }
-  const cfg = readAppConfig();
   cfg.embeddingSource = source;
   writeAppConfigStrict(cfg);
   return source;
@@ -328,7 +328,7 @@ export function setApiKey(key: string | undefined, provider: EmbedderProvider = 
 }
 
 export function setEmbedderConfig(next: { provider: EmbedderProvider; apiKey?: string }): EmbedderConfig {
-  const cfg = readAppConfig();
+  const cfg = readAppConfigStrict();
   const defaults = EMBEDDER_DEFAULTS[next.provider];
   cfg.embedder = {
     ...(cfg.embedder ?? {}),
@@ -385,7 +385,7 @@ export function setTranscriptionPreferences(next: Partial<TranscriptionPreferenc
     ? current.language
     : normalizeTranscriptionLanguage(next.language);
   if (!language) throw new Error('transcription language must be `auto` or a language code');
-  const cfg = readAppConfig();
+  const cfg = readAppConfigStrict();
   cfg.transcription = { providerId, modelId, language };
   writeAppConfigStrict(cfg);
   return { providerId, modelId, language };
@@ -448,7 +448,12 @@ export function getAppearancePreferences(): AppearancePreferences {
 }
 
 export function setAppearancePreferences(next: Partial<AppearancePreferences>): AppearancePreferences {
-  return appearancePreferences.set(next);
+  const cfg = readAppConfigStrict();
+  const current = normalizeAppearancePreferences(cfg.appearance);
+  const resolved = normalizeAppearancePreferences({ ...current, ...next });
+  cfg.appearance = resolved;
+  writeAppConfigStrict(cfg);
+  return resolved;
 }
 
 /** One-time upgrade from the very first global-embedder schema, when
@@ -475,7 +480,7 @@ export function getOnboardingPreferences(): OnboardingPreferences {
 }
 
 export function setOnboardingPreferences(next: Partial<OnboardingPreferences>): OnboardingPreferences {
-  const cfg = readAppConfig();
+  const cfg = readAppConfigStrict();
   const current = cfg.onboarding ?? {};
   const updated = {
     ...current,

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -31,6 +31,7 @@ export interface RecentFolder {
 }
 
 export type EmbedderProvider = 'openai' | 'openrouter';
+export type EmbeddingSource = EmbedderProvider | 'stashbase-account';
 export type TranscriptionModelId = LocalTranscriptionModelId;
 export type AppearanceTheme = 'system' | 'light' | 'dark';
 export type AppearanceScale = 'small' | 'default' | 'large';
@@ -53,6 +54,14 @@ export interface EmbedderConfig {
   model: string;
   dimension: number;
   baseUrl?: string;
+}
+
+export interface HostedAccountSession {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  userId: string;
+  email: string;
 }
 
 const EMBEDDER_DEFAULTS: Record<EmbedderProvider, Omit<EmbedderConfig, 'provider' | 'apiKey'>> = {
@@ -92,6 +101,13 @@ export interface AppConfigFile {
     openaiKey?: string;
     model?: string;
     baseUrl?: string;
+  };
+  /** Active AI Index funding source. BYOK credentials and the account
+   * session are retained independently so switching never destroys the
+   * other option or silently falls back after a hosted failure. */
+  embeddingSource?: EmbeddingSource;
+  account?: {
+    session?: HostedAccountSession;
   };
   /** Legacy last-used agent field. No longer written or read by the
    *  chat panel; kept so old config files parse without churn. */
@@ -235,6 +251,59 @@ export function getApiKey(): string | undefined {
   return getEmbedderConfig().apiKey;
 }
 
+export function getHostedAccountSession(): HostedAccountSession | undefined {
+  const raw = readAppConfig().account?.session;
+  if (!raw || typeof raw !== 'object') return undefined;
+  if (
+    typeof raw.accessToken !== 'string' || !raw.accessToken ||
+    typeof raw.refreshToken !== 'string' || !raw.refreshToken ||
+    typeof raw.expiresAt !== 'number' || !Number.isFinite(raw.expiresAt) ||
+    typeof raw.userId !== 'string' || !raw.userId ||
+    typeof raw.email !== 'string' || !raw.email
+  ) return undefined;
+  return { ...raw };
+}
+
+export function setHostedAccountSession(session: HostedAccountSession | undefined): void {
+  const cfg = readAppConfig();
+  if (session) cfg.account = { ...(cfg.account ?? {}), session: { ...session } };
+  else {
+    delete cfg.account?.session;
+    if (cfg.account && Object.keys(cfg.account).length === 0) delete cfg.account;
+  }
+  writeAppConfigStrict(cfg);
+}
+
+export function getEmbeddingSource(): EmbeddingSource {
+  const cfg = readAppConfig();
+  const value = cfg.embeddingSource;
+  if (value === 'stashbase-account' || isEmbedderProvider(value)) return value;
+  const direct = getEmbedderConfig();
+  if (direct.apiKey) return direct.provider;
+  if (getHostedAccountSession()) return 'stashbase-account';
+  return direct.provider;
+}
+
+export function setEmbeddingSource(source: EmbeddingSource): EmbeddingSource {
+  if (source === 'stashbase-account') {
+    if (!getHostedAccountSession()) throw new Error('Sign in before selecting the StashBase account allowance.');
+  } else {
+    const direct = getEmbedderConfig();
+    if (!direct.apiKey || direct.provider !== source) throw new Error(`Add a ${source === 'openrouter' ? 'OpenRouter' : 'OpenAI'} key before selecting it.`);
+  }
+  const cfg = readAppConfig();
+  cfg.embeddingSource = source;
+  writeAppConfigStrict(cfg);
+  return source;
+}
+
+export function isEmbeddingConfigured(): boolean {
+  const source = getEmbeddingSource();
+  if (source === 'stashbase-account') return !!getHostedAccountSession();
+  const direct = getEmbedderConfig();
+  return direct.provider === source && !!direct.apiKey;
+}
+
 export function getEmbedderConfig(): EmbedderConfig {
   const cfg = readAppConfig();
   const provider = isEmbedderProvider(cfg.embedder?.provider) ? cfg.embedder.provider : 'openai';
@@ -272,6 +341,10 @@ export function setEmbedderConfig(next: { provider: EmbedderProvider; apiKey?: s
   delete cfg.embedder.openaiKey;
   if (next.provider === 'openai' && cfg.embedder.apiKey) cfg.apiKey = cfg.embedder.apiKey;
   else delete cfg.apiKey;
+  if (cfg.embedder.apiKey) cfg.embeddingSource = next.provider;
+  else if (cfg.embeddingSource === next.provider) {
+    cfg.embeddingSource = cfg.account?.session ? 'stashbase-account' : next.provider;
+  }
   writeAppConfigStrict(cfg);
   return getEmbedderConfig();
 }

--- a/server/embedding-availability.test.ts
+++ b/server/embedding-availability.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { shouldReconcileAfterEmbeddingSourceChange } from './embedding-availability.ts';
+
+test('switching from exhausted hosted allowance to BYOK always reconciles pending files', () => {
+  assert.equal(
+    shouldReconcileAfterEmbeddingSourceChange('stashbase-account', 'openai', false),
+    true,
+  );
+  assert.equal(
+    shouldReconcileAfterEmbeddingSourceChange('openai', 'openai', false),
+    true,
+  );
+  assert.equal(
+    shouldReconcileAfterEmbeddingSourceChange('openai', 'openai', true),
+    false,
+  );
+});

--- a/server/embedding-availability.ts
+++ b/server/embedding-availability.ts
@@ -1,0 +1,42 @@
+import {
+  getEmbeddingSource,
+  isEmbeddingConfigured,
+  type EmbeddingSource,
+} from './app-config.ts';
+import { isHostedQuotaExhausted } from './hosted-account.ts';
+
+export type EmbeddingUnavailableReason =
+  | 'embedding-source-required'
+  | 'hosted-quota-exhausted';
+
+export type EmbeddingAvailability =
+  | { configured: false; available: false; reason: 'embedding-source-required' }
+  | { configured: true; available: false; reason: 'hosted-quota-exhausted' }
+  | { configured: true; available: true };
+
+/**
+ * Process-wide semantic-work gate. Configuration answers whether the user has
+ * selected a usable source; availability additionally stops every hosted
+ * index/query entry point once the shared allowance reaches zero.
+ */
+export function embeddingAvailability(): EmbeddingAvailability {
+  if (!isEmbeddingConfigured()) {
+    return { configured: false, available: false, reason: 'embedding-source-required' };
+  }
+  if (getEmbeddingSource() === 'stashbase-account' && isHostedQuotaExhausted()) {
+    return { configured: true, available: false, reason: 'hosted-quota-exhausted' };
+  }
+  return { configured: true, available: true };
+}
+
+export function isEmbeddingAvailable(): boolean {
+  return embeddingAvailability().available;
+}
+
+export function shouldReconcileAfterEmbeddingSourceChange(
+  previous: EmbeddingSource,
+  next: EmbeddingSource,
+  previouslyAvailable: boolean,
+): boolean {
+  return previous !== next || !previouslyAvailable;
+}

--- a/server/file-save.ts
+++ b/server/file-save.ts
@@ -1,4 +1,4 @@
-import { isEmbeddingConfigured } from './app-config.ts';
+import { isEmbeddingAvailable } from './embedding-availability.ts';
 import { normalizeFolderRelativePath } from './folder-relative-path.ts';
 import { toSourcePath } from './folder.ts';
 import { detectFormat, isDerivedNoteName } from './format.ts';
@@ -34,8 +34,8 @@ export function validateEditableFileWrite(name: string): void {
 }
 
 export async function upsertSavedFile(name: string, content: string): Promise<string | undefined> {
-  if (!isEmbeddingConfigured()) {
-    log.info(`save: skipped index update for ${name} because no embedding key is configured`);
+  if (!isEmbeddingAvailable()) {
+    log.info(`save: skipped index update for ${name} because semantic embedding is unavailable`);
     return undefined;
   }
   if (!content.trim()) {

--- a/server/file-save.ts
+++ b/server/file-save.ts
@@ -1,4 +1,4 @@
-import { getApiKey } from './app-config.ts';
+import { isEmbeddingConfigured } from './app-config.ts';
 import { normalizeFolderRelativePath } from './folder-relative-path.ts';
 import { toSourcePath } from './folder.ts';
 import { detectFormat, isDerivedNoteName } from './format.ts';
@@ -34,7 +34,7 @@ export function validateEditableFileWrite(name: string): void {
 }
 
 export async function upsertSavedFile(name: string, content: string): Promise<string | undefined> {
-  if (!getApiKey()) {
+  if (!isEmbeddingConfigured()) {
     log.info(`save: skipped index update for ${name} because no embedding key is configured`);
     return undefined;
   }

--- a/server/hosted-account.test.ts
+++ b/server/hosted-account.test.ts
@@ -1,12 +1,44 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { oauthResultPage } from './oauth-result-page.ts';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('OAuth callback renders a safe centered card with delayed app return and fallback button', () => {
+  const html = oauthResultPage({
+    title: 'Signed in <now>',
+    message: 'Ready & returning',
+    autoReturn: true,
+  });
+
+  assert.match(html, /class="shell"/);
+  assert.match(html, /class="card" data-auto-return="true"/);
+  assert.match(html, /href="stashbase:\/\/oauth-complete" hidden/);
+  assert.match(html, /window\.location\.href = 'stashbase:\/\/oauth-complete'/);
+  assert.match(html, /window\.close\(\)/);
+  assert.match(html, /Didn’t return automatically\?/);
+  assert.match(html, /Signed in &lt;now&gt;/);
+  assert.match(html, /Ready &amp; returning/);
+  assert.doesNotMatch(html, /Signed in <now>/);
+});
+
+test('failed OAuth callback keeps the return button visible without automatic launch', () => {
+  const html = oauthResultPage({
+    title: 'Sign-in failed',
+    message: 'Try again.',
+    kind: 'error',
+  });
+
+  assert.match(html, /data-auto-return="false"/);
+  assert.match(html, /href="stashbase:\/\/oauth-complete">/);
+  assert.doesNotMatch(html, /href="stashbase:\/\/oauth-complete" hidden/);
+});
 
 function runIsolated(source: string) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-hosted-account-test-'));
@@ -29,13 +61,12 @@ function runIsolated(source: string) {
   }
 }
 
-test('email OTP session persists locally and authenticates quota requests', () => {
+test('OAuth PKCE session persists locally and authenticates quota requests', () => {
   const result = runIsolated(`
     const calls = [];
     globalThis.fetch = async (url, init = {}) => {
       calls.push({ url: String(url), body: init.body ? JSON.parse(String(init.body)) : null, authorization: new Headers(init.headers).get('authorization') });
-      if (String(url).endsWith('/auth/v1/otp')) return new Response('{}', { status: 200 });
-      if (String(url).endsWith('/auth/v1/verify')) return Response.json({
+      if (String(url).endsWith('/auth/v1/token?grant_type=pkce')) return Response.json({
         access_token: 'access-1', refresh_token: 'refresh-1', expires_at: 4102444800,
         user: { id: 'user-1', email: 'person@example.com' },
       });
@@ -47,17 +78,26 @@ test('email OTP session persists locally and authenticates quota requests', () =
     };
     const account = await import('./server/hosted-account.ts');
     const config = await import('./server/app-config.ts');
-    await account.requestEmailOtp('Person@Example.com');
-    await account.verifyEmailOtp('Person@Example.com', '123456');
+    const started = account.beginHostedOAuth('google', 'http://127.0.0.1:8090');
+    await account.exchangeHostedOAuthCode(started.flowId, 'auth-code-1');
+    account.finishHostedOAuth(started.flowId);
     config.setEmbeddingSource('stashbase-account');
     const quota = await account.fetchHostedQuota();
-    process.stdout.write(JSON.stringify({ calls, quota, session: config.getHostedAccountSession(), source: config.getEmbeddingSource() }));
+    process.stdout.write(JSON.stringify({ started, status: account.hostedOAuthStatus(started.flowId), calls, quota, session: config.getHostedAccountSession(), source: config.getEmbeddingSource() }));
   `);
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
-  assert.equal(output.calls[0].body.email, 'person@example.com');
-  assert.equal(output.calls[1].body.type, 'email');
-  assert.equal(output.calls[2].authorization, 'Bearer access-1');
+  const authorize = new URL(output.started.url);
+  assert.equal(authorize.pathname, '/auth/v1/authorize');
+  assert.equal(authorize.searchParams.get('provider'), 'google');
+  const redirectTo = authorize.searchParams.get('redirect_to');
+  assert.ok(redirectTo);
+  assert.equal(new URL(redirectTo).searchParams.get('flow'), output.started.flowId);
+  assert.equal(output.calls[0].body.auth_code, 'auth-code-1');
+  const expectedChallenge = crypto.createHash('sha256').update(output.calls[0].body.code_verifier).digest('base64url');
+  assert.equal(authorize.searchParams.get('code_challenge'), expectedChallenge);
+  assert.equal(output.status.state, 'complete');
+  assert.equal(output.calls[1].authorization, 'Bearer access-1');
   assert.equal(output.quota.remainingTokens, 999_988);
   assert.equal(output.session.refreshToken, 'refresh-1');
   assert.equal(output.source, 'stashbase-account');

--- a/server/hosted-account.test.ts
+++ b/server/hosted-account.test.ts
@@ -16,6 +16,7 @@ test('OAuth callback renders a safe centered card with delayed app return and fa
     message: 'Ready & returning',
     autoReturn: true,
     returnStatusUrl: '/api/account/oauth/status?flow=safe-flow',
+    returnIntentUrl: '/api/account/oauth/return-intent?flow=safe-flow',
   });
 
   assert.match(html, /class="shell"/);
@@ -24,6 +25,7 @@ test('OAuth callback renders a safe centered card with delayed app return and fa
   assert.match(html, /window\.location\.href = 'stashbase:\/\/oauth-complete'/);
   assert.match(html, /window\.close\(\)/);
   assert.match(html, /fetch\(returnStatusUrl/);
+  assert.match(html, /fetch\(returnIntentUrl, \{ method: 'POST'/);
   assert.match(html, /result\.appReturned === true/);
   assert.doesNotMatch(html, /addEventListener\('blur'/);
   assert.match(html, /Didn’t return automatically\?/);
@@ -49,6 +51,7 @@ test('a failed callback can receive app-return proof through an opaque local sta
     const account = await import('./server/hosted-account.ts');
     const flowId = account.createFailedHostedOAuthFlow('Missing sign-in flow.');
     const before = account.hostedOAuthStatus(flowId);
+    account.noteHostedOAuthReturnIntent(flowId);
     const acknowledged = account.noteHostedOAuthAppReturn();
     const after = account.hostedOAuthStatus(flowId);
     process.stdout.write(JSON.stringify({ flowId, before, acknowledged, after }));
@@ -58,8 +61,26 @@ test('a failed callback can receive app-return proof through an opaque local sta
   assert.match(output.flowId, /^[A-Za-z0-9_-]+$/);
   assert.equal(output.before.state, 'error');
   assert.equal(output.before.appReturned, undefined);
-  assert.equal(output.acknowledged, true);
+  assert.deepEqual(output.acknowledged, { acknowledged: true });
   assert.equal(output.after.appReturned, true);
+});
+
+test('a data-free native return focuses the window attached to the browser return intent', () => {
+  const result = runIsolated(`
+    const account = await import('./server/hosted-account.ts');
+    const first = account.beginHostedOAuth('google', 'http://127.0.0.1:8090', 'window-one');
+    const second = account.beginHostedOAuth('google', 'http://127.0.0.1:8090', 'window-two');
+    account.failHostedOAuth(first.flowId, 'first stopped');
+    account.failHostedOAuth(second.flowId, 'second stopped');
+    account.noteHostedOAuthReturnIntent(first.flowId);
+    const acknowledged = account.noteHostedOAuthAppReturn();
+    process.stdout.write(JSON.stringify({ acknowledged, first: account.hostedOAuthStatus(first.flowId), second: account.hostedOAuthStatus(second.flowId) }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.acknowledged, { acknowledged: true, windowId: 'window-one' });
+  assert.equal(output.first.appReturned, true);
+  assert.equal(output.second.appReturned, undefined);
 });
 
 function runIsolated(source: string) {

--- a/server/hosted-account.test.ts
+++ b/server/hosted-account.test.ts
@@ -44,6 +44,24 @@ test('failed OAuth callback keeps the return button visible without automatic la
   assert.doesNotMatch(html, /href="stashbase:\/\/oauth-complete" hidden/);
 });
 
+test('a failed callback can receive app-return proof through an opaque local status ticket', () => {
+  const result = runIsolated(`
+    const account = await import('./server/hosted-account.ts');
+    const flowId = account.createFailedHostedOAuthFlow('Missing sign-in flow.');
+    const before = account.hostedOAuthStatus(flowId);
+    const acknowledged = account.noteHostedOAuthAppReturn();
+    const after = account.hostedOAuthStatus(flowId);
+    process.stdout.write(JSON.stringify({ flowId, before, acknowledged, after }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.match(output.flowId, /^[A-Za-z0-9_-]+$/);
+  assert.equal(output.before.state, 'error');
+  assert.equal(output.before.appReturned, undefined);
+  assert.equal(output.acknowledged, true);
+  assert.equal(output.after.appReturned, true);
+});
+
 function runIsolated(source: string) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-hosted-account-test-'));
   try {

--- a/server/hosted-account.test.ts
+++ b/server/hosted-account.test.ts
@@ -96,7 +96,7 @@ function runIsolated(source: string) {
     ], {
       cwd: repoRoot,
       encoding: 'utf8',
-      env: { ...process.env, HOME: home },
+      env: { ...process.env, HOME: home, USERPROFILE: home },
       timeout: 15_000,
     });
   } finally {

--- a/server/hosted-account.test.ts
+++ b/server/hosted-account.test.ts
@@ -15,6 +15,7 @@ test('OAuth callback renders a safe centered card with delayed app return and fa
     title: 'Signed in <now>',
     message: 'Ready & returning',
     autoReturn: true,
+    returnStatusUrl: '/api/account/oauth/status?flow=safe-flow',
   });
 
   assert.match(html, /class="shell"/);
@@ -22,6 +23,9 @@ test('OAuth callback renders a safe centered card with delayed app return and fa
   assert.match(html, /href="stashbase:\/\/oauth-complete" hidden/);
   assert.match(html, /window\.location\.href = 'stashbase:\/\/oauth-complete'/);
   assert.match(html, /window\.close\(\)/);
+  assert.match(html, /fetch\(returnStatusUrl/);
+  assert.match(html, /result\.appReturned === true/);
+  assert.doesNotMatch(html, /addEventListener\('blur'/);
   assert.match(html, /Didn’t return automatically\?/);
   assert.match(html, /Signed in &lt;now&gt;/);
   assert.match(html, /Ready &amp; returning/);
@@ -81,9 +85,11 @@ test('OAuth PKCE session persists locally and authenticates quota requests', () 
     const started = account.beginHostedOAuth('google', 'http://127.0.0.1:8090');
     await account.exchangeHostedOAuthCode(started.flowId, 'auth-code-1');
     account.finishHostedOAuth(started.flowId);
+    account.noteHostedOAuthAppReturn();
     config.setEmbeddingSource('stashbase-account');
     const quota = await account.fetchHostedQuota();
-    process.stdout.write(JSON.stringify({ started, status: account.hostedOAuthStatus(started.flowId), calls, quota, session: config.getHostedAccountSession(), source: config.getEmbeddingSource() }));
+    const state = await account.hostedAccountState();
+    process.stdout.write(JSON.stringify({ started, status: account.hostedOAuthStatus(started.flowId), calls, quota, state, session: config.getHostedAccountSession(), source: config.getEmbeddingSource() }));
   `);
   assert.equal(result.status, 0, result.stderr);
   const output = JSON.parse(result.stdout);
@@ -97,10 +103,13 @@ test('OAuth PKCE session persists locally and authenticates quota requests', () 
   const expectedChallenge = crypto.createHash('sha256').update(output.calls[0].body.code_verifier).digest('base64url');
   assert.equal(authorize.searchParams.get('code_challenge'), expectedChallenge);
   assert.equal(output.status.state, 'complete');
+  assert.equal(output.status.appReturned, true);
   assert.equal(output.calls[1].authorization, 'Bearer access-1');
   assert.equal(output.quota.remainingTokens, 999_988);
   assert.equal(output.session.refreshToken, 'refresh-1');
   assert.equal(output.source, 'stashbase-account');
+  assert.equal(output.state.email, 'person@example.com');
+  assert.equal('userId' in output.state, false);
 });
 
 test('loopback broker translates OpenAI requests and preserves query purpose', () => {
@@ -140,4 +149,64 @@ test('loopback broker translates OpenAI requests and preserves query purpose', (
   assert.equal(output.upstream[0].body.purpose, 'query');
   assert.deepEqual(output.upstream[0].body.inputs, ['hello']);
   assert.match(output.upstream[0].headers['idempotency-key'], /^[0-9a-f-]{36}$/);
+});
+
+test('cached hosted exhaustion blocks semantic work and availability recovery notifies its owner', () => {
+  const result = runIsolated(`
+    const config = await import('./server/app-config.ts');
+    const account = await import('./server/hosted-account.ts');
+    const availability = await import('./server/embedding-availability.ts');
+    config.setHostedAccountSession({ accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800, userId: 'user', email: 'person@example.com' });
+    config.setEmbeddingSource('stashbase-account');
+    let recovered = 0;
+    account.setHostedQuotaAvailableHandler(() => { recovered += 1; });
+    account.rememberHostedQuota({ plan: 'free', grantedTokens: 1000000, usedTokens: 1000000, reservedTokens: 0, remainingTokens: 0, periodStartedAt: null, periodEndsAt: null });
+    const exhausted = availability.embeddingAvailability();
+    account.rememberHostedQuota({ plan: 'free', grantedTokens: 1000000, usedTokens: 0, reservedTokens: 0, remainingTokens: 1000000, periodStartedAt: null, periodEndsAt: null });
+    await new Promise((resolve) => setImmediate(resolve));
+    process.stdout.write(JSON.stringify({ exhausted, recovered }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.exhausted, {
+    configured: true,
+    available: false,
+    reason: 'hosted-quota-exhausted',
+  });
+  assert.equal(output.recovered, 1);
+});
+
+test('broker caches a quota response and does not retry later hosted requests', () => {
+  const result = runIsolated(`
+    const originalFetch = globalThis.fetch;
+    let upstreamCalls = 0;
+    globalThis.fetch = async (url, init = {}) => {
+      if (String(url).startsWith('http://127.0.0.1:')) return originalFetch(url, init);
+      upstreamCalls += 1;
+      return Response.json({ code: 'quota_exhausted', message: 'quota exhausted' }, { status: 402 });
+    };
+    const config = await import('./server/app-config.ts');
+    const account = await import('./server/hosted-account.ts');
+    const broker = await import('./server/hosted-embedding-broker.ts');
+    config.setHostedAccountSession({ accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800, userId: 'user', email: 'person@example.com' });
+    config.setEmbeddingSource('stashbase-account');
+    await broker.startHostedEmbeddingBroker();
+    const runtime = broker.hostedEmbeddingRuntime();
+    const request = () => originalFetch(runtime.baseUrl + '/embeddings', {
+      method: 'POST',
+      headers: { authorization: 'Bearer ' + runtime.apiKey, 'content-type': 'application/json' },
+      body: JSON.stringify({ model: runtime.model, input: ['hello'] }),
+    });
+    const first = await request();
+    const second = await request();
+    await broker.stopHostedEmbeddingBroker();
+    process.stdout.write(JSON.stringify({ first: first.status, second: second.status, upstreamCalls, exhausted: account.isHostedQuotaExhausted() }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    first: 402,
+    second: 402,
+    upstreamCalls: 1,
+    exhausted: true,
+  });
 });

--- a/server/hosted-account.test.ts
+++ b/server/hosted-account.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function runIsolated(source: string) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-hosted-account-test-'));
+  try {
+    return spawnSync(process.execPath, [
+      '--no-warnings',
+      '--import',
+      'tsx',
+      '--input-type=module',
+      '--eval',
+      source,
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: { ...process.env, HOME: home },
+      timeout: 15_000,
+    });
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+test('email OTP session persists locally and authenticates quota requests', () => {
+  const result = runIsolated(`
+    const calls = [];
+    globalThis.fetch = async (url, init = {}) => {
+      calls.push({ url: String(url), body: init.body ? JSON.parse(String(init.body)) : null, authorization: new Headers(init.headers).get('authorization') });
+      if (String(url).endsWith('/auth/v1/otp')) return new Response('{}', { status: 200 });
+      if (String(url).endsWith('/auth/v1/verify')) return Response.json({
+        access_token: 'access-1', refresh_token: 'refresh-1', expires_at: 4102444800,
+        user: { id: 'user-1', email: 'person@example.com' },
+      });
+      if (String(url).endsWith('/v1/account/usage')) return Response.json({
+        plan: 'free', grantedTokens: 1000000, usedTokens: 12, reservedTokens: 0,
+        remainingTokens: 999988, periodStartedAt: '2026-08-01T00:00:00.000Z', periodEndsAt: '2026-09-01T00:00:00.000Z',
+      });
+      throw new Error('unexpected URL ' + url);
+    };
+    const account = await import('./server/hosted-account.ts');
+    const config = await import('./server/app-config.ts');
+    await account.requestEmailOtp('Person@Example.com');
+    await account.verifyEmailOtp('Person@Example.com', '123456');
+    config.setEmbeddingSource('stashbase-account');
+    const quota = await account.fetchHostedQuota();
+    process.stdout.write(JSON.stringify({ calls, quota, session: config.getHostedAccountSession(), source: config.getEmbeddingSource() }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.calls[0].body.email, 'person@example.com');
+  assert.equal(output.calls[1].body.type, 'email');
+  assert.equal(output.calls[2].authorization, 'Bearer access-1');
+  assert.equal(output.quota.remainingTokens, 999_988);
+  assert.equal(output.session.refreshToken, 'refresh-1');
+  assert.equal(output.source, 'stashbase-account');
+});
+
+test('loopback broker translates OpenAI requests and preserves query purpose', () => {
+  const result = runIsolated(`
+    const originalFetch = globalThis.fetch;
+    const upstream = [];
+    globalThis.fetch = async (url, init = {}) => {
+      if (String(url).startsWith('http://127.0.0.1:')) return originalFetch(url, init);
+      upstream.push({ url: String(url), body: init.body ? JSON.parse(String(init.body)) : null, headers: Object.fromEntries(new Headers(init.headers)) });
+      return Response.json({
+        profile: 'stashbase-embedding-v1',
+        data: [{ index: 0, embedding: [0.25, 0.75] }],
+        usage: { inputTokens: 3 },
+        quota: { plan: 'free', grantedTokens: 1000000, usedTokens: 3, reservedTokens: 0, remainingTokens: 999997, periodStartedAt: null, periodEndsAt: null },
+      });
+    };
+    const config = await import('./server/app-config.ts');
+    config.setHostedAccountSession({ accessToken: 'access-2', refreshToken: 'refresh-2', expiresAt: 4102444800, userId: 'user-2', email: 'person@example.com' });
+    config.setEmbeddingSource('stashbase-account');
+    const broker = await import('./server/hosted-embedding-broker.ts');
+    await broker.startHostedEmbeddingBroker();
+    const runtime = broker.hostedEmbeddingRuntime();
+    const response = await originalFetch(runtime.baseUrl + '/embeddings', {
+      method: 'POST',
+      headers: { authorization: 'Bearer ' + runtime.apiKey, 'content-type': 'application/json', 'x-stashbase-purpose': 'query' },
+      body: JSON.stringify({ model: runtime.model, input: ['hello'] }),
+    });
+    const body = await response.json();
+    await broker.stopHostedEmbeddingBroker();
+    process.stdout.write(JSON.stringify({ status: response.status, body, upstream }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.status, 200);
+  assert.deepEqual(output.body.data[0].embedding, [0.25, 0.75]);
+  assert.equal(output.body.usage.prompt_tokens, 3);
+  assert.equal(output.upstream[0].body.purpose, 'query');
+  assert.deepEqual(output.upstream[0].body.inputs, ['hello']);
+  assert.match(output.upstream[0].headers['idempotency-key'], /^[0-9a-f-]{36}$/);
+});

--- a/server/hosted-account.ts
+++ b/server/hosted-account.ts
@@ -1,4 +1,5 @@
 import packageJson from '../package.json' with { type: 'json' };
+import crypto from 'node:crypto';
 import {
   getEmbeddingSource,
   getHostedAccountSession,
@@ -51,6 +52,30 @@ interface ErrorPayload {
   msg?: string;
 }
 
+export type HostedOAuthProvider = 'google' | 'github';
+
+export interface HostedOAuthStart {
+  flowId: string;
+  provider: HostedOAuthProvider;
+  url: string;
+}
+
+export interface HostedOAuthStatus {
+  state: 'pending' | 'complete' | 'error';
+  error?: string;
+}
+
+interface PendingOAuthFlow {
+  provider: HostedOAuthProvider;
+  verifier: string;
+  createdAt: number;
+  state: 'pending' | 'exchanged' | 'complete' | 'error';
+  error?: string;
+}
+
+const OAUTH_FLOW_TTL_MS = 10 * 60 * 1000;
+const pendingOAuthFlows = new Map<string, PendingOAuthFlow>();
+
 function messageOf(value: ErrorPayload | null, fallback: string): string {
   return value?.message ?? value?.error_description ?? value?.msg ?? value?.error ?? fallback;
 }
@@ -86,25 +111,88 @@ async function supabaseAuth(path: string, body: Record<string, unknown>, accessT
   return payload ?? {};
 }
 
-export async function requestEmailOtp(email: string): Promise<void> {
-  const normalized = email.trim().toLowerCase();
-  if (!/^\S+@\S+\.\S+$/.test(normalized)) throw new Error('Enter a valid email address.');
-  await supabaseAuth('/otp', { email: normalized, create_user: true });
+function base64Url(bytes: Buffer): string {
+  return bytes.toString('base64url');
 }
 
-export async function verifyEmailOtp(email: string, token: string): Promise<HostedAccountSession> {
-  const normalizedEmail = email.trim().toLowerCase();
-  const normalizedToken = token.replace(/\s+/g, '');
-  if (!normalizedToken) throw new Error('Enter the verification code from your email.');
-  const payload = await supabaseAuth('/verify', {
-    email: normalizedEmail,
-    token: normalizedToken,
-    type: 'email',
+function pruneOAuthFlows(now = Date.now()): void {
+  for (const [flowId, flow] of pendingOAuthFlows) {
+    if (now - flow.createdAt > OAUTH_FLOW_TTL_MS) pendingOAuthFlows.delete(flowId);
+  }
+}
+
+function assertLoopbackCallbackOrigin(callbackOrigin: string): URL {
+  const parsed = new URL(callbackOrigin);
+  if (parsed.protocol !== 'http:' || !['127.0.0.1', 'localhost', '[::1]'].includes(parsed.hostname)) {
+    throw new Error('OAuth callback must use the local StashBase server.');
+  }
+  return parsed;
+}
+
+export function beginHostedOAuth(provider: HostedOAuthProvider, callbackOrigin: string): HostedOAuthStart {
+  pruneOAuthFlows();
+  const origin = assertLoopbackCallbackOrigin(callbackOrigin);
+  const flowId = base64Url(crypto.randomBytes(24));
+  const verifier = base64Url(crypto.randomBytes(48));
+  const challenge = base64Url(crypto.createHash('sha256').update(verifier).digest());
+  const callback = new URL('/api/account/oauth/callback', origin);
+  callback.searchParams.set('flow', flowId);
+
+  pendingOAuthFlows.set(flowId, {
+    provider,
+    verifier,
+    createdAt: Date.now(),
+    state: 'pending',
   });
-  const session = sessionFrom(payload);
-  lastQuota = undefined;
-  setHostedAccountSession(session);
-  return session;
+
+  const authorize = new URL(`${SUPABASE_URL}/auth/v1/authorize`);
+  authorize.searchParams.set('provider', provider);
+  authorize.searchParams.set('redirect_to', callback.toString());
+  authorize.searchParams.set('code_challenge', challenge);
+  authorize.searchParams.set('code_challenge_method', 's256');
+  return { flowId, provider, url: authorize.toString() };
+}
+
+export async function exchangeHostedOAuthCode(flowId: string, authCode: string): Promise<HostedAccountSession> {
+  pruneOAuthFlows();
+  const flow = pendingOAuthFlows.get(flowId);
+  if (!flow || flow.state !== 'pending') throw new Error('This sign-in request expired. Start again from StashBase.');
+  if (!authCode.trim()) throw new Error('Supabase did not return an authorization code.');
+  try {
+    const payload = await supabaseAuth('/token?grant_type=pkce', {
+      auth_code: authCode,
+      code_verifier: flow.verifier,
+    });
+    const session = sessionFrom(payload);
+    lastQuota = undefined;
+    setHostedAccountSession(session);
+    flow.state = 'exchanged';
+    return session;
+  } catch (error: unknown) {
+    failHostedOAuth(flowId, error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+}
+
+export function finishHostedOAuth(flowId: string): void {
+  const flow = pendingOAuthFlows.get(flowId);
+  if (flow?.state === 'exchanged') flow.state = 'complete';
+}
+
+export function failHostedOAuth(flowId: string, message: string): void {
+  const flow = pendingOAuthFlows.get(flowId);
+  if (!flow) return;
+  flow.state = 'error';
+  flow.error = message;
+}
+
+export function hostedOAuthStatus(flowId: string): HostedOAuthStatus {
+  pruneOAuthFlows();
+  const flow = pendingOAuthFlows.get(flowId);
+  if (!flow) return { state: 'error', error: 'This sign-in request expired. Start again.' };
+  if (flow.state === 'complete') return { state: 'complete' };
+  if (flow.state === 'error') return { state: 'error', error: flow.error ?? 'Sign-in failed.' };
+  return { state: 'pending' };
 }
 
 export async function hostedAccessToken(options: { forceRefresh?: boolean } = {}): Promise<string> {

--- a/server/hosted-account.ts
+++ b/server/hosted-account.ts
@@ -185,6 +185,22 @@ export function finishHostedOAuth(flowId: string): void {
   if (flow?.state === 'exchanged') flow.state = 'complete';
 }
 
+/** Give a callback that arrived without a usable OAuth flow its own bounded
+ * status ticket. The fixed deep link still carries no data, while the browser
+ * can prove a successful app return before closing. */
+export function createFailedHostedOAuthFlow(message: string): string {
+  pruneOAuthFlows();
+  const flowId = base64Url(crypto.randomBytes(24));
+  pendingOAuthFlows.set(flowId, {
+    provider: 'google',
+    verifier: base64Url(crypto.randomBytes(48)),
+    createdAt: Date.now(),
+    state: 'error',
+    error: message,
+  });
+  return flowId;
+}
+
 /** Electron calls this only after accepting the exact data-free deep link.
  * Callback pages poll their own flow state and close only after this proof,
  * never merely because the browser lost focus. */

--- a/server/hosted-account.ts
+++ b/server/hosted-account.ts
@@ -68,9 +68,11 @@ export interface HostedOAuthStatus {
 interface PendingOAuthFlow {
   provider: HostedOAuthProvider;
   verifier: string;
+  windowId?: string;
   createdAt: number;
   state: 'pending' | 'exchanged' | 'complete' | 'error';
   error?: string;
+  returnRequestedAt?: number;
   appReturnedAt?: number;
 }
 
@@ -135,7 +137,11 @@ function assertLoopbackCallbackOrigin(callbackOrigin: string): URL {
   return parsed;
 }
 
-export function beginHostedOAuth(provider: HostedOAuthProvider, callbackOrigin: string): HostedOAuthStart {
+export function beginHostedOAuth(
+  provider: HostedOAuthProvider,
+  callbackOrigin: string,
+  windowId?: string,
+): HostedOAuthStart {
   pruneOAuthFlows();
   const origin = assertLoopbackCallbackOrigin(callbackOrigin);
   const flowId = base64Url(crypto.randomBytes(24));
@@ -147,6 +153,7 @@ export function beginHostedOAuth(provider: HostedOAuthProvider, callbackOrigin: 
   pendingOAuthFlows.set(flowId, {
     provider,
     verifier,
+    ...(windowId?.trim() ? { windowId: windowId.trim().slice(0, 128) } : {}),
     createdAt: Date.now(),
     state: 'pending',
   });
@@ -201,18 +208,37 @@ export function createFailedHostedOAuthFlow(message: string): string {
   return flowId;
 }
 
+export function noteHostedOAuthReturnIntent(flowId: string, now = Date.now()): boolean {
+  pruneOAuthFlows(now);
+  const flow = pendingOAuthFlows.get(flowId);
+  if (!flow || (flow.state !== 'complete' && flow.state !== 'error')) return false;
+  flow.returnRequestedAt = now;
+  return true;
+}
+
 /** Electron calls this only after accepting the exact data-free deep link.
  * Callback pages poll their own flow state and close only after this proof,
  * never merely because the browser lost focus. */
-export function noteHostedOAuthAppReturn(now = Date.now()): boolean {
+export function noteHostedOAuthAppReturn(now = Date.now()): {
+  acknowledged: boolean;
+  windowId?: string;
+} {
   pruneOAuthFlows(now);
-  let updated = false;
-  for (const flow of pendingOAuthFlows.values()) {
-    if (flow.state !== 'complete' && flow.state !== 'error') continue;
-    flow.appReturnedAt = now;
-    updated = true;
-  }
-  return updated;
+  const candidates = [...pendingOAuthFlows.values()]
+    .filter((flow) => (
+      (flow.state === 'complete' || flow.state === 'error')
+      && !flow.appReturnedAt
+    ))
+    .sort((left, right) => (
+      (right.returnRequestedAt ?? right.createdAt) - (left.returnRequestedAt ?? left.createdAt)
+    ));
+  const flow = candidates.find((candidate) => candidate.returnRequestedAt) ?? candidates[0];
+  if (!flow) return { acknowledged: false };
+  flow.appReturnedAt = now;
+  return {
+    acknowledged: true,
+    ...(flow.windowId ? { windowId: flow.windowId } : {}),
+  };
 }
 
 export function failHostedOAuth(flowId: string, message: string): void {

--- a/server/hosted-account.ts
+++ b/server/hosted-account.ts
@@ -27,7 +27,6 @@ export interface HostedQuota {
 export interface HostedAccountState {
   signedIn: boolean;
   active: boolean;
-  userId?: string;
   email?: string;
   quota?: HostedQuota;
   quotaUnavailable?: boolean;
@@ -52,7 +51,7 @@ interface ErrorPayload {
   msg?: string;
 }
 
-export type HostedOAuthProvider = 'google' | 'github';
+export type HostedOAuthProvider = 'google';
 
 export interface HostedOAuthStart {
   flowId: string;
@@ -63,6 +62,7 @@ export interface HostedOAuthStart {
 export interface HostedOAuthStatus {
   state: 'pending' | 'complete' | 'error';
   error?: string;
+  appReturned?: boolean;
 }
 
 interface PendingOAuthFlow {
@@ -71,10 +71,16 @@ interface PendingOAuthFlow {
   createdAt: number;
   state: 'pending' | 'exchanged' | 'complete' | 'error';
   error?: string;
+  appReturnedAt?: number;
 }
 
 const OAUTH_FLOW_TTL_MS = 10 * 60 * 1000;
 const pendingOAuthFlows = new Map<string, PendingOAuthFlow>();
+const QUOTA_REFRESH_RETRY_MS = 5 * 60 * 1000;
+let lastQuota: HostedQuota | undefined;
+let quotaRefreshTimer: NodeJS.Timeout | null = null;
+let onQuotaAvailable: (() => void | Promise<void>) | null = null;
+let quotaAvailabilityRecovery: Promise<void> = Promise.resolve();
 
 function messageOf(value: ErrorPayload | null, fallback: string): string {
   return value?.message ?? value?.error_description ?? value?.msg ?? value?.error ?? fallback;
@@ -164,7 +170,7 @@ export async function exchangeHostedOAuthCode(flowId: string, authCode: string):
       code_verifier: flow.verifier,
     });
     const session = sessionFrom(payload);
-    lastQuota = undefined;
+    clearHostedQuota();
     setHostedAccountSession(session);
     flow.state = 'exchanged';
     return session;
@@ -179,6 +185,20 @@ export function finishHostedOAuth(flowId: string): void {
   if (flow?.state === 'exchanged') flow.state = 'complete';
 }
 
+/** Electron calls this only after accepting the exact data-free deep link.
+ * Callback pages poll their own flow state and close only after this proof,
+ * never merely because the browser lost focus. */
+export function noteHostedOAuthAppReturn(now = Date.now()): boolean {
+  pruneOAuthFlows(now);
+  let updated = false;
+  for (const flow of pendingOAuthFlows.values()) {
+    if (flow.state !== 'complete' && flow.state !== 'error') continue;
+    flow.appReturnedAt = now;
+    updated = true;
+  }
+  return updated;
+}
+
 export function failHostedOAuth(flowId: string, message: string): void {
   const flow = pendingOAuthFlows.get(flowId);
   if (!flow) return;
@@ -190,8 +210,15 @@ export function hostedOAuthStatus(flowId: string): HostedOAuthStatus {
   pruneOAuthFlows();
   const flow = pendingOAuthFlows.get(flowId);
   if (!flow) return { state: 'error', error: 'This sign-in request expired. Start again.' };
-  if (flow.state === 'complete') return { state: 'complete' };
-  if (flow.state === 'error') return { state: 'error', error: flow.error ?? 'Sign-in failed.' };
+  if (flow.state === 'complete') return {
+    state: 'complete',
+    ...(flow.appReturnedAt ? { appReturned: true } : {}),
+  };
+  if (flow.state === 'error') return {
+    state: 'error',
+    error: flow.error ?? 'Sign-in failed.',
+    ...(flow.appReturnedAt ? { appReturned: true } : {}),
+  };
   return { state: 'pending' };
 }
 
@@ -206,13 +233,14 @@ export async function hostedAccessToken(options: { forceRefresh?: boolean } = {}
     return refreshed.accessToken;
   } catch (error) {
     setHostedAccountSession(undefined);
+    clearHostedQuota();
     throw error;
   }
 }
 
 export async function signOutHostedAccount(): Promise<void> {
   const session = getHostedAccountSession();
-  lastQuota = undefined;
+  clearHostedQuota();
   setHostedAccountSession(undefined);
   if (!session) return;
   try { await supabaseAuth('/logout?scope=local', {}, session.accessToken); } catch { /* local sign-out still succeeds */ }
@@ -229,17 +257,56 @@ export async function fetchHostedQuota(options: { forceRefreshToken?: boolean } 
   const payload = await jsonBody<HostedQuota & ErrorPayload>(response);
   if (response.status === 401 && !options.forceRefreshToken) return fetchHostedQuota({ forceRefreshToken: true });
   if (!response.ok) throw new Error(messageOf(payload, `StashBase account service failed (HTTP ${response.status}).`));
-  return payload as HostedQuota;
+  const quota = payload as HostedQuota;
+  rememberHostedQuota(quota);
+  await quotaAvailabilityRecovery;
+  return quota;
 }
 
-let lastQuota: HostedQuota | undefined;
+function scheduleQuotaRefresh(quota: HostedQuota): void {
+  if (quotaRefreshTimer) clearTimeout(quotaRefreshTimer);
+  quotaRefreshTimer = null;
+  if (quota.remainingTokens > 0) return;
+  const resetAt = quota.periodEndsAt ? Date.parse(quota.periodEndsAt) : Number.NaN;
+  const untilReset = Number.isFinite(resetAt) ? resetAt - Date.now() + 1_000 : Number.NaN;
+  const delay = Number.isFinite(untilReset)
+    ? Math.max(untilReset, untilReset <= 0 ? QUOTA_REFRESH_RETRY_MS : 1_000)
+    : QUOTA_REFRESH_RETRY_MS;
+  quotaRefreshTimer = setTimeout(() => {
+    quotaRefreshTimer = null;
+    void fetchHostedQuota().catch(() => {
+      if (lastQuota) scheduleQuotaRefresh(lastQuota);
+    });
+  }, Math.min(delay, 2_147_000_000));
+  quotaRefreshTimer.unref?.();
+}
+
+function clearHostedQuota(): void {
+  lastQuota = undefined;
+  if (quotaRefreshTimer) clearTimeout(quotaRefreshTimer);
+  quotaRefreshTimer = null;
+}
 
 export function rememberHostedQuota(quota: HostedQuota): void {
+  const wasExhausted = isHostedQuotaExhausted();
   lastQuota = quota;
+  scheduleQuotaRefresh(quota);
+  if (wasExhausted && !isHostedQuotaExhausted()) {
+    quotaAvailabilityRecovery = Promise.resolve(onQuotaAvailable?.())
+      .catch(() => { /* owner logs recovery failures */ });
+  }
 }
 
 export function cachedHostedQuota(): HostedQuota | undefined {
   return lastQuota;
+}
+
+export function isHostedQuotaExhausted(): boolean {
+  return (lastQuota?.remainingTokens ?? 1) <= 0;
+}
+
+export function setHostedQuotaAvailableHandler(handler: (() => void | Promise<void>) | null): void {
+  onQuotaAvailable = handler;
 }
 
 export async function hostedAccountState(refreshQuota = false): Promise<HostedAccountState> {
@@ -250,7 +317,6 @@ export async function hostedAccountState(refreshQuota = false): Promise<HostedAc
   if (refreshQuota || !quota) {
     try {
       quota = await fetchHostedQuota();
-      lastQuota = quota;
     } catch {
       if (!getHostedAccountSession()) return { signedIn: false, active: false };
       quotaUnavailable = true;
@@ -259,7 +325,6 @@ export async function hostedAccountState(refreshQuota = false): Promise<HostedAc
   return {
     signedIn: true,
     active: getEmbeddingSource() === 'stashbase-account',
-    userId: session.userId,
     email: session.email,
     ...(quota ? { quota } : {}),
     ...(quotaUnavailable ? { quotaUnavailable: true } : {}),

--- a/server/hosted-account.ts
+++ b/server/hosted-account.ts
@@ -1,0 +1,183 @@
+import packageJson from '../package.json' with { type: 'json' };
+import {
+  getEmbeddingSource,
+  getHostedAccountSession,
+  setHostedAccountSession,
+  type HostedAccountSession,
+} from './app-config.ts';
+
+export const STASHBASE_API_URL = 'https://api.stashbase.ai';
+const SUPABASE_URL = 'https://vqtfigkoihpuziaimluf.supabase.co';
+// Supabase publishable keys are intentionally safe to ship in clients. The
+// project secret key remains server-only and must never enter this repository.
+const SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_D-S7Ry-IWC9pTdDx6DHHHw_-mmaTp3b';
+const CLIENT_VERSION = packageJson.version;
+
+export interface HostedQuota {
+  plan: string;
+  grantedTokens: number;
+  usedTokens: number;
+  reservedTokens: number;
+  remainingTokens: number;
+  periodStartedAt: string | null;
+  periodEndsAt: string | null;
+}
+
+export interface HostedAccountState {
+  signedIn: boolean;
+  active: boolean;
+  userId?: string;
+  email?: string;
+  quota?: HostedQuota;
+  quotaUnavailable?: boolean;
+}
+
+interface SupabaseTokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_at?: number;
+  expires_in?: number;
+  user?: { id?: string; email?: string };
+  error?: string;
+  error_description?: string;
+  msg?: string;
+}
+
+interface ErrorPayload {
+  code?: string;
+  message?: string;
+  error?: string;
+  error_description?: string;
+  msg?: string;
+}
+
+function messageOf(value: ErrorPayload | null, fallback: string): string {
+  return value?.message ?? value?.error_description ?? value?.msg ?? value?.error ?? fallback;
+}
+
+async function jsonBody<T>(response: Response): Promise<T | null> {
+  try { return await response.json() as T; } catch { return null; }
+}
+
+function sessionFrom(value: SupabaseTokenResponse, fallback?: HostedAccountSession): HostedAccountSession {
+  const accessToken = value.access_token;
+  const refreshToken = value.refresh_token ?? fallback?.refreshToken;
+  const userId = value.user?.id ?? fallback?.userId;
+  const email = value.user?.email ?? fallback?.email;
+  const expiresAt = value.expires_at ?? (value.expires_in ? Math.floor(Date.now() / 1000) + value.expires_in : fallback?.expiresAt);
+  if (!accessToken || !refreshToken || !userId || !email || !expiresAt) {
+    throw new Error('Supabase returned an incomplete login session.');
+  }
+  return { accessToken, refreshToken, userId, email, expiresAt };
+}
+
+async function supabaseAuth(path: string, body: Record<string, unknown>, accessToken?: string): Promise<SupabaseTokenResponse> {
+  const response = await fetch(`${SUPABASE_URL}/auth/v1${path}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_PUBLISHABLE_KEY,
+      'content-type': 'application/json',
+      ...(accessToken ? { authorization: `Bearer ${accessToken}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  const payload = await jsonBody<SupabaseTokenResponse>(response);
+  if (!response.ok) throw new Error(messageOf(payload ?? null, `Supabase authentication failed (HTTP ${response.status}).`));
+  return payload ?? {};
+}
+
+export async function requestEmailOtp(email: string): Promise<void> {
+  const normalized = email.trim().toLowerCase();
+  if (!/^\S+@\S+\.\S+$/.test(normalized)) throw new Error('Enter a valid email address.');
+  await supabaseAuth('/otp', { email: normalized, create_user: true });
+}
+
+export async function verifyEmailOtp(email: string, token: string): Promise<HostedAccountSession> {
+  const normalizedEmail = email.trim().toLowerCase();
+  const normalizedToken = token.replace(/\s+/g, '');
+  if (!normalizedToken) throw new Error('Enter the verification code from your email.');
+  const payload = await supabaseAuth('/verify', {
+    email: normalizedEmail,
+    token: normalizedToken,
+    type: 'email',
+  });
+  const session = sessionFrom(payload);
+  lastQuota = undefined;
+  setHostedAccountSession(session);
+  return session;
+}
+
+export async function hostedAccessToken(options: { forceRefresh?: boolean } = {}): Promise<string> {
+  const session = getHostedAccountSession();
+  if (!session) throw new Error('Sign in to StashBase to use the hosted allowance.');
+  if (!options.forceRefresh && session.expiresAt > Math.floor(Date.now() / 1000) + 60) return session.accessToken;
+  try {
+    const payload = await supabaseAuth('/token?grant_type=refresh_token', { refresh_token: session.refreshToken });
+    const refreshed = sessionFrom(payload, session);
+    setHostedAccountSession(refreshed);
+    return refreshed.accessToken;
+  } catch (error) {
+    setHostedAccountSession(undefined);
+    throw error;
+  }
+}
+
+export async function signOutHostedAccount(): Promise<void> {
+  const session = getHostedAccountSession();
+  lastQuota = undefined;
+  setHostedAccountSession(undefined);
+  if (!session) return;
+  try { await supabaseAuth('/logout?scope=local', {}, session.accessToken); } catch { /* local sign-out still succeeds */ }
+}
+
+export async function fetchHostedQuota(options: { forceRefreshToken?: boolean } = {}): Promise<HostedQuota> {
+  const token = await hostedAccessToken({ forceRefresh: options.forceRefreshToken });
+  const response = await fetch(`${STASHBASE_API_URL}/v1/account/usage`, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      'x-stashbase-client-version': CLIENT_VERSION,
+    },
+  });
+  const payload = await jsonBody<HostedQuota & ErrorPayload>(response);
+  if (response.status === 401 && !options.forceRefreshToken) return fetchHostedQuota({ forceRefreshToken: true });
+  if (!response.ok) throw new Error(messageOf(payload, `StashBase account service failed (HTTP ${response.status}).`));
+  return payload as HostedQuota;
+}
+
+let lastQuota: HostedQuota | undefined;
+
+export function rememberHostedQuota(quota: HostedQuota): void {
+  lastQuota = quota;
+}
+
+export function cachedHostedQuota(): HostedQuota | undefined {
+  return lastQuota;
+}
+
+export async function hostedAccountState(refreshQuota = false): Promise<HostedAccountState> {
+  const session = getHostedAccountSession();
+  if (!session) return { signedIn: false, active: false };
+  let quota = lastQuota;
+  let quotaUnavailable = false;
+  if (refreshQuota || !quota) {
+    try {
+      quota = await fetchHostedQuota();
+      lastQuota = quota;
+    } catch {
+      if (!getHostedAccountSession()) return { signedIn: false, active: false };
+      quotaUnavailable = true;
+    }
+  }
+  return {
+    signedIn: true,
+    active: getEmbeddingSource() === 'stashbase-account',
+    userId: session.userId,
+    email: session.email,
+    ...(quota ? { quota } : {}),
+    ...(quotaUnavailable ? { quotaUnavailable: true } : {}),
+  };
+}
+
+export function stashbaseClientVersion(): string {
+  return CLIENT_VERSION;
+}

--- a/server/hosted-embedding-broker.ts
+++ b/server/hosted-embedding-broker.ts
@@ -1,0 +1,180 @@
+import crypto from 'node:crypto';
+import http from 'node:http';
+import { getHostedAccountSession } from './app-config.ts';
+import {
+  cachedHostedQuota,
+  hostedAccessToken,
+  rememberHostedQuota,
+  stashbaseClientVersion,
+  STASHBASE_API_URL,
+  type HostedQuota,
+} from './hosted-account.ts';
+import { logger } from './log.ts';
+
+const log = logger('hosted-embedding-broker');
+const MAX_BODY_BYTES = 2 * 1024 * 1024;
+
+interface HostedEmbeddingResponse {
+  data: Array<{ index: number; embedding: number[] }>;
+  usage: { inputTokens: number };
+  quota: HostedQuota;
+}
+
+interface ProviderError {
+  code?: string;
+  message?: string;
+}
+
+function writeJson(response: http.ServerResponse, status: number, value: unknown): void {
+  response.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
+  response.end(JSON.stringify(value));
+}
+
+async function readJson(request: http.IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > MAX_BODY_BYTES) throw Object.assign(new Error('embedding request is too large'), { status: 413 });
+    chunks.push(buffer);
+  }
+  const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('JSON object required');
+  return parsed as Record<string, unknown>;
+}
+
+class HostedEmbeddingBroker {
+  private server: http.Server | null = null;
+  private startPromise: Promise<void> | null = null;
+  private port = 0;
+  private readonly secret = crypto.randomBytes(32).toString('base64url');
+
+  async start(): Promise<void> {
+    if (this.server) return;
+    if (this.startPromise) return this.startPromise;
+    this.startPromise = new Promise<void>((resolve, reject) => {
+      const server = http.createServer((request, response) => {
+        void this.handle(request, response).catch((error: unknown) => {
+          const status = typeof (error as { status?: unknown })?.status === 'number'
+            ? (error as { status: number }).status
+            : 500;
+          writeJson(response, status, {
+            error: {
+              message: error instanceof Error ? error.message : String(error),
+              type: 'stashbase_broker_error',
+              code: 'broker_error',
+            },
+          });
+        });
+      });
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          server.close();
+          reject(new Error('Could not bind the hosted embedding broker.'));
+          return;
+        }
+        this.server = server;
+        this.port = address.port;
+        log.info(`listening on 127.0.0.1:${this.port}`);
+        resolve();
+      });
+    }).finally(() => { this.startPromise = null; });
+    return this.startPromise;
+  }
+
+  runtime(): { provider: 'stashbase'; apiKey: string; model: string; dimension: number; baseUrl: string } | null {
+    if (!this.server || !getHostedAccountSession()) return null;
+    return {
+      provider: 'stashbase',
+      apiKey: this.secret,
+      model: 'text-embedding-3-small',
+      dimension: 1536,
+      baseUrl: `http://127.0.0.1:${this.port}/v1`,
+    };
+  }
+
+  async close(): Promise<void> {
+    const server = this.server;
+    this.server = null;
+    this.port = 0;
+    if (!server) return;
+    server.closeIdleConnections();
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  private async handle(request: http.IncomingMessage, response: http.ServerResponse): Promise<void> {
+    if (request.socket.remoteAddress !== '127.0.0.1' && request.socket.remoteAddress !== '::1') {
+      writeJson(response, 403, { error: { message: 'loopback access only', code: 'forbidden' } });
+      return;
+    }
+    if (request.method !== 'POST' || request.url !== '/v1/embeddings') {
+      writeJson(response, 404, { error: { message: 'not found', code: 'not_found' } });
+      return;
+    }
+    if (request.headers.authorization !== `Bearer ${this.secret}`) {
+      writeJson(response, 401, { error: { message: 'invalid broker credential', code: 'invalid_api_key' } });
+      return;
+    }
+    const body = await readJson(request);
+    const rawInput = body.input;
+    const inputs = typeof rawInput === 'string' ? [rawInput] : rawInput;
+    if (!Array.isArray(inputs) || inputs.length === 0 || inputs.some((item) => typeof item !== 'string' || !item)) {
+      writeJson(response, 400, { error: { message: 'input must contain text', code: 'invalid_request' } });
+      return;
+    }
+    const purpose = request.headers['x-stashbase-purpose'] === 'query' ? 'query' : 'index';
+    const call = async (forceRefresh: boolean) => {
+      const token = await hostedAccessToken({ forceRefresh });
+      return fetch(`${STASHBASE_API_URL}/v1/embeddings`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+          'idempotency-key': crypto.randomUUID(),
+          'x-stashbase-client-version': stashbaseClientVersion(),
+        },
+        body: JSON.stringify({ profile: 'stashbase-embedding-v1', purpose, inputs }),
+      });
+    };
+    let upstream = await call(false);
+    if (upstream.status === 401) upstream = await call(true);
+    const payload = await upstream.json().catch(() => null) as HostedEmbeddingResponse | ProviderError | null;
+    if (!upstream.ok) {
+      const error = payload as ProviderError | null;
+      if (upstream.status === 402) {
+        const current = cachedHostedQuota();
+        if (current) rememberHostedQuota({
+          ...current,
+          usedTokens: Math.max(current.usedTokens, current.grantedTokens),
+          remainingTokens: 0,
+        });
+      }
+      writeJson(response, upstream.status, {
+        error: {
+          message: error?.message ?? `Hosted embedding request failed (HTTP ${upstream.status}).`,
+          type: 'stashbase_hosted_error',
+          code: error?.code ?? 'hosted_error',
+        },
+      });
+      return;
+    }
+    const result = payload as HostedEmbeddingResponse;
+    rememberHostedQuota(result.quota);
+    writeJson(response, 200, {
+      object: 'list',
+      data: result.data.map((item) => ({ object: 'embedding', index: item.index, embedding: item.embedding })),
+      model: 'text-embedding-3-small',
+      usage: { prompt_tokens: result.usage.inputTokens, total_tokens: result.usage.inputTokens },
+    });
+  }
+}
+
+const broker = new HostedEmbeddingBroker();
+
+export const startHostedEmbeddingBroker = (): Promise<void> => broker.start();
+export const stopHostedEmbeddingBroker = (): Promise<void> => broker.close();
+export const hostedEmbeddingRuntime = () => broker.runtime();

--- a/server/hosted-embedding-broker.ts
+++ b/server/hosted-embedding-broker.ts
@@ -4,6 +4,7 @@ import { getHostedAccountSession } from './app-config.ts';
 import {
   cachedHostedQuota,
   hostedAccessToken,
+  isHostedQuotaExhausted,
   rememberHostedQuota,
   stashbaseClientVersion,
   STASHBASE_API_URL,
@@ -119,6 +120,16 @@ class HostedEmbeddingBroker {
       writeJson(response, 401, { error: { message: 'invalid broker credential', code: 'invalid_api_key' } });
       return;
     }
+    if (isHostedQuotaExhausted()) {
+      writeJson(response, 402, {
+        error: {
+          message: 'Hosted AI Index allowance is exhausted. Exact search remains available.',
+          type: 'stashbase_hosted_error',
+          code: 'quota_exhausted',
+        },
+      });
+      return;
+    }
     const body = await readJson(request);
     const rawInput = body.input;
     const inputs = typeof rawInput === 'string' ? [rawInput] : rawInput;
@@ -147,10 +158,18 @@ class HostedEmbeddingBroker {
       const error = payload as ProviderError | null;
       if (upstream.status === 402) {
         const current = cachedHostedQuota();
-        if (current) rememberHostedQuota({
+        rememberHostedQuota(current ? {
           ...current,
           usedTokens: Math.max(current.usedTokens, current.grantedTokens),
           remainingTokens: 0,
+        } : {
+          plan: 'unknown',
+          grantedTokens: 0,
+          usedTokens: 0,
+          reservedTokens: 0,
+          remainingTokens: 0,
+          periodStartedAt: null,
+          periodEndsAt: null,
         });
       }
       writeJson(response, upstream.status, {

--- a/server/index-status.test.ts
+++ b/server/index-status.test.ts
@@ -35,6 +35,8 @@ test('index status conversion maps are scoped and folder-relative', () => {
 
 test('semantic status distinguishes disabled, partial, paused, ready, and failed', () => {
   assert.equal(semanticIndexingState({ enabled: false, decision: null, indexed: 0, pending: 3, failed: false }), 'disabled');
+  assert.equal(semanticIndexingState({ enabled: true, decision: null, indexed: 0, pending: 3, failed: false, quotaExhausted: true }), 'quota-exhausted');
+  assert.equal(semanticIndexingState({ enabled: true, decision: null, indexed: 2, pending: 3, failed: false, quotaExhausted: true }), 'partial-quota-exhausted');
   assert.equal(semanticIndexingState({ enabled: true, decision: 'awaiting-decision', indexed: 2, pending: 3, failed: false }), 'awaiting-decision');
   assert.equal(semanticIndexingState({ enabled: true, decision: 'paused', indexed: 2, pending: 3, failed: false }), 'partial-paused');
   assert.equal(semanticIndexingState({ enabled: true, decision: 'paused', indexed: 2, pending: 3, failed: true }), 'partial-paused');

--- a/server/index-status.ts
+++ b/server/index-status.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { getApiKey } from './app-config.ts';
+import { isEmbeddingConfigured } from './app-config.ts';
 import { getConversionSchedulerSnapshot, getInFlightConversions } from './conversion.ts';
 import { clearRecord, listPreparationProblems, readProgress, type ConversionProgress } from './conversion-status.ts';
 import { blockedAudioSourcesForFolder } from './audio-transcription.ts';
@@ -37,7 +37,7 @@ export async function buildIndexStatus(folderRoot: string): Promise<Record<strin
   const curRoot = filesystemPath.absolute(folderRoot);
   const status = await indexer.status(curRoot);
   const treeVersion = getFsChangeCounter();
-  const semanticEnabled = !!getApiKey();
+  const semanticEnabled = isEmbeddingConfigured();
   const pending = semanticEnabled ? pendingVisibleFiles(status.pending, curRoot, folderRoot) : [];
   const orphaned = status.orphaned
     .map((p) => filesystemPath.relative(curRoot, p))

--- a/server/index-status.ts
+++ b/server/index-status.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { isEmbeddingConfigured } from './app-config.ts';
+import { embeddingAvailability } from './embedding-availability.ts';
 import { getConversionSchedulerSnapshot, getInFlightConversions } from './conversion.ts';
 import { clearRecord, listPreparationProblems, readProgress, type ConversionProgress } from './conversion-status.ts';
 import { blockedAudioSourcesForFolder } from './audio-transcription.ts';
@@ -24,8 +24,10 @@ export function semanticIndexingState(input: {
   indexed: number;
   pending: number;
   failed: boolean;
+  quotaExhausted?: boolean;
 }): string {
   if (!input.enabled) return 'disabled';
+  if (input.quotaExhausted) return input.indexed > 0 ? 'partial-quota-exhausted' : 'quota-exhausted';
   if (input.decision === 'awaiting-decision') return 'awaiting-decision';
   if (input.decision === 'paused') return input.indexed > 0 ? 'partial-paused' : 'paused';
   if (input.failed) return 'failed';
@@ -37,13 +39,16 @@ export async function buildIndexStatus(folderRoot: string): Promise<Record<strin
   const curRoot = filesystemPath.absolute(folderRoot);
   const status = await indexer.status(curRoot);
   const treeVersion = getFsChangeCounter();
-  const semanticEnabled = isEmbeddingConfigured();
-  const pending = semanticEnabled ? pendingVisibleFiles(status.pending, curRoot, folderRoot) : [];
+  const availability = embeddingAvailability();
+  const semanticEnabled = availability.configured;
+  const semanticAvailable = availability.available;
+  const unavailableReason = availability.available ? null : availability.reason;
+  const pending = semanticAvailable ? pendingVisibleFiles(status.pending, curRoot, folderRoot) : [];
   const orphaned = status.orphaned
     .map((p) => filesystemPath.relative(curRoot, p))
     .filter((p): p is string => p != null);
   const schedulerSnapshot = getConversionSchedulerSnapshot();
-  const semanticDecision = semanticEnabled ? getSemanticIndexingState(curRoot) : null;
+  const semanticDecision = semanticAvailable ? getSemanticIndexingState(curRoot) : null;
   const indexWarning = getIndexWarning(curRoot);
   const semanticState = semanticIndexingState({
     enabled: semanticEnabled,
@@ -51,18 +56,24 @@ export async function buildIndexStatus(folderRoot: string): Promise<Record<strin
     indexed: status.indexed,
     pending: pending.length,
     failed: indexWarning != null,
+    quotaExhausted: unavailableReason === 'hosted-quota-exhausted',
   });
 
   return {
     folder: curRoot,
     ...status,
     semanticEnabled,
-    ...(semanticEnabled ? {} : { semanticDisabledReason: 'Embedding API key required' }),
+    semanticAvailable,
+    ...(!semanticAvailable ? {
+      semanticDisabledReason: unavailableReason === 'hosted-quota-exhausted'
+        ? 'Hosted allowance exhausted; Exact search remains available'
+        : 'Embedding source required',
+    } : {}),
     pending,
     pendingCount: pending.length,
     orphaned,
     orphanedCount: orphaned.length,
-    visibleIndexingSettled: !semanticEnabled || semanticDecision != null || pending.length === 0,
+    visibleIndexingSettled: !semanticAvailable || semanticDecision != null || pending.length === 0,
     semanticIndexing: {
       state: semanticState,
       ...(semanticDecision ? {

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,8 +33,9 @@ import {
 } from './agent-contract.ts';
 import { onClose, ensureFolderHome, memberFolderRoots } from './folder.ts';
 import { filesystemPath } from './filesystem-path.ts';
-import { getHostedAccountSession, isEmbeddingConfigured, migrateLegacyEmbedderConfig } from './app-config.ts';
-import { bootBindAllFolders, reconcileLibraryFolders } from './state.ts';
+import { getEmbeddingSource, getHostedAccountSession, migrateLegacyEmbedderConfig } from './app-config.ts';
+import { isEmbeddingAvailable } from './embedding-availability.ts';
+import { bootBindAllFolders, reconcileLibraryFolders, resetIndexerRuntime } from './state.ts';
 import { reapOrphanDaemons } from './stale-lock.ts';
 import { logger } from './log.ts';
 import { cancelAllConversions, setDerivedNoteIndexer } from './conversion.ts';
@@ -77,6 +78,7 @@ import {
 } from './agent-runtime-installer.ts';
 import { createClientErrorHandler } from './client-error.ts';
 import { startHostedEmbeddingBroker, stopHostedEmbeddingBroker } from './hosted-embedding-broker.ts';
+import { hostedAccountState, setHostedQuotaAvailableHandler } from './hosted-account.ts';
 
 const log = logger('server');
 
@@ -91,7 +93,7 @@ for (const adapter of BUILT_IN_AGENT_ADAPTERS) registerAgentAdapter(adapter);
 // completion — there is no fs-watcher intermediary anymore. Wired here
 // (not inside conversion.ts) to avoid a conversion ↔ state module cycle.
 setDerivedNoteIndexer(async (sourceAbs, derivedAbs, boundSourceHash) => {
-  if (!isEmbeddingConfigured()) return;
+  if (!isEmbeddingAvailable()) return;
   // Derived text lives in app data; index it UNDER the source
   // PDF/image/DOCX path so folder-scoped search finds it. Stamp the SOURCE's
   // byte hash so the daemon's scan_diff (which hashes the source file) sees
@@ -108,6 +110,20 @@ setDerivedNoteIndexer(async (sourceAbs, derivedAbs, boundSourceHash) => {
   }
   await indexer.upsertConvertedFile(filesystemPath.absolute(sourceAbs), derivedContent, sourceHash, path.extname(derivedAbs));
   noteTreeChanged();
+});
+
+setHostedQuotaAvailableHandler(async () => {
+  if (getEmbeddingSource() !== 'stashbase-account') return;
+  try {
+    await startHostedEmbeddingBroker();
+    await resetIndexerRuntime({ forgetBindings: true });
+    await bootBindAllFolders();
+    void reconcileLibraryFolders('hosted allowance reset').catch((err: unknown) => {
+      log.warn(`hosted allowance backfill failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  } catch (err: unknown) {
+    log.warn(`hosted allowance recovery failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
 });
 
 function parsePortArg(argv: string[], fallback: number): number {
@@ -387,7 +403,9 @@ const server = app.listen(PORT, '127.0.0.1', () => {
   // already on disk and gets picked up. Configure the daemon + bind every
   // known folder so MCP / cross-folder search works without waiting for the
   // user to open one. Background.
-  (getHostedAccountSession() ? startHostedEmbeddingBroker() : Promise.resolve())
+  (getHostedAccountSession()
+    ? hostedAccountState(true).then(() => startHostedEmbeddingBroker())
+    : Promise.resolve())
     .then(() => bootBindAllFolders())
     .then(() => reconcileLibraryFolders('app boot'))
     .catch((err) =>

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,7 +33,7 @@ import {
 } from './agent-contract.ts';
 import { onClose, ensureFolderHome, memberFolderRoots } from './folder.ts';
 import { filesystemPath } from './filesystem-path.ts';
-import { getApiKey, migrateLegacyEmbedderConfig } from './app-config.ts';
+import { getHostedAccountSession, isEmbeddingConfigured, migrateLegacyEmbedderConfig } from './app-config.ts';
 import { bootBindAllFolders, reconcileLibraryFolders } from './state.ts';
 import { reapOrphanDaemons } from './stale-lock.ts';
 import { logger } from './log.ts';
@@ -68,6 +68,7 @@ import { mount as mountSessionsRoutes } from './routes/sessions.ts';
 import { mount as mountCodexSessionsRoutes } from './routes/codex-sessions.ts';
 import { mount as mountAgentSessionsRoutes } from './routes/agent-sessions.ts';
 import { mount as mountOnboardingRoutes } from './routes/onboarding.ts';
+import { mount as mountAccountRoutes } from './routes/account.ts';
 import { BUILT_IN_AGENT_ADAPTERS } from './agent-adapters.ts';
 import {
   cancelAgentRuntimeInstalls,
@@ -75,6 +76,7 @@ import {
   connectInstalledAgentMcpOnStartup,
 } from './agent-runtime-installer.ts';
 import { createClientErrorHandler } from './client-error.ts';
+import { startHostedEmbeddingBroker, stopHostedEmbeddingBroker } from './hosted-embedding-broker.ts';
 
 const log = logger('server');
 
@@ -89,7 +91,7 @@ for (const adapter of BUILT_IN_AGENT_ADAPTERS) registerAgentAdapter(adapter);
 // completion — there is no fs-watcher intermediary anymore. Wired here
 // (not inside conversion.ts) to avoid a conversion ↔ state module cycle.
 setDerivedNoteIndexer(async (sourceAbs, derivedAbs, boundSourceHash) => {
-  if (!getApiKey()) return;
+  if (!isEmbeddingConfigured()) return;
   // Derived text lives in app data; index it UNDER the source
   // PDF/image/DOCX path so folder-scoped search finds it. Stamp the SOURCE's
   // byte hash so the daemon's scan_diff (which hashes the source file) sees
@@ -305,6 +307,7 @@ app.use([
 
 // ----- mount routes -------------------------------------------------------
 mountAppearanceRoutes(app);
+mountAccountRoutes(app);
 mountEmbedderRoutes(app);
 mountTranscriptionRoutes(app);
 // Register exact `/api/files/prepare` and `/api/files/reprocess` endpoints
@@ -384,7 +387,8 @@ const server = app.listen(PORT, '127.0.0.1', () => {
   // already on disk and gets picked up. Configure the daemon + bind every
   // known folder so MCP / cross-folder search works without waiting for the
   // user to open one. Background.
-  bootBindAllFolders()
+  (getHostedAccountSession() ? startHostedEmbeddingBroker() : Promise.resolve())
+    .then(() => bootBindAllFolders())
     .then(() => reconcileLibraryFolders('app boot'))
     .catch((err) =>
       log.warn(`boot library bind/reconcile failed: ${err?.message ?? err}`),
@@ -588,6 +592,7 @@ async function shutdown(reason: string): Promise<void> {
     await runShutdownCleanup({
       closeMcp: () => mcpHttpService.close(),
       cancelAgentInstalls: cancelAgentRuntimeInstalls,
+      closeHostedBroker: stopHostedEmbeddingBroker,
       cancelModelDownloads: cancelAllTranscriptionModelDownloads,
       cancelConversions: cancelAllConversions,
       closeStateDb,

--- a/server/index.ts
+++ b/server/index.ts
@@ -323,7 +323,9 @@ app.use([
 
 // ----- mount routes -------------------------------------------------------
 mountAppearanceRoutes(app);
-mountAccountRoutes(app);
+mountAccountRoutes(app, {
+  appReturnToken: process.env.STASHBASE_OAUTH_RETURN_TOKEN ?? '',
+});
 mountEmbedderRoutes(app);
 mountTranscriptionRoutes(app);
 // Register exact `/api/files/prepare` and `/api/files/reprocess` endpoints

--- a/server/indexer.ts
+++ b/server/indexer.ts
@@ -160,6 +160,8 @@ export interface IndexStatus {
   upToDate: boolean;
   /** False when semantic indexing/retrieval is unavailable, e.g. no API key. */
   semanticEnabled?: boolean;
+  /** False while a configured hosted source is blocked by its shared quota. */
+  semanticAvailable?: boolean;
   /** Human-readable reason when semantic indexing/retrieval is disabled. */
   semanticDisabledReason?: string;
   /** False until the folder has received at least one daemon status response. */

--- a/server/indexer.ts
+++ b/server/indexer.ts
@@ -32,7 +32,7 @@ export interface SearchHit {
 export interface EmbedderRuntimeConfig {
   /** Supported embedding endpoints. OpenRouter is used only as an
    *  OpenAI-compatible embeddings endpoint for the fixed 1536d model. */
-  provider: 'openai' | 'openrouter';
+  provider: 'openai' | 'openrouter' | 'stashbase';
   /** Provider API key. Absent ⇒ the folder is registered but indexing
    *  stays disabled until the user adds a key (graceful no-key degrade). */
   apiKey?: string;

--- a/server/library-file-mutations.ts
+++ b/server/library-file-mutations.ts
@@ -1,4 +1,5 @@
 import { isEmbeddingConfigured } from './app-config.ts';
+import { isEmbeddingAvailable } from './embedding-availability.ts';
 import { queueConvertibleSource } from './conversion-dispatch.ts';
 import { clearRecord } from './conversion-status.ts';
 import { deleteDerivedForSource } from './derived-store.ts';
@@ -163,7 +164,7 @@ export async function moveLibraryFile(
           log.warn(`library move: conversion kickoff failed for ${newTarget.abs}: ${errorMessage(err)}`);
         }
         indexWarning = 'Searchable text is being regenerated in the background.';
-      } else if (!isEmbeddingConfigured()) {
+      } else if (!isEmbeddingAvailable()) {
         indexWarning = 'AI Index was not updated because it is not set up.';
       } else {
         const movedContent = readText(newTarget.folderRel) ?? content ?? '';
@@ -178,7 +179,7 @@ export async function moveLibraryFile(
         }
       }
       for (const updated of applied?.updated ?? []) {
-        if (!isEmbeddingConfigured()) break;
+        if (!isEmbeddingAvailable()) break;
         if (updated.name === newTarget.folderRel) continue;
         const body = readText(updated.name);
         if (body != null) await indexer.upsertFile(filesystemPath.join(oldTarget.folderRoot, updated.name), body);

--- a/server/library-file-mutations.ts
+++ b/server/library-file-mutations.ts
@@ -1,4 +1,4 @@
-import { getApiKey } from './app-config.ts';
+import { isEmbeddingConfigured } from './app-config.ts';
 import { queueConvertibleSource } from './conversion-dispatch.ts';
 import { clearRecord } from './conversion-status.ts';
 import { deleteDerivedForSource } from './derived-store.ts';
@@ -163,7 +163,7 @@ export async function moveLibraryFile(
           log.warn(`library move: conversion kickoff failed for ${newTarget.abs}: ${errorMessage(err)}`);
         }
         indexWarning = 'Searchable text is being regenerated in the background.';
-      } else if (!getApiKey()) {
+      } else if (!isEmbeddingConfigured()) {
         indexWarning = 'AI Index was not updated because it is not set up.';
       } else {
         const movedContent = readText(newTarget.folderRel) ?? content ?? '';
@@ -178,7 +178,7 @@ export async function moveLibraryFile(
         }
       }
       for (const updated of applied?.updated ?? []) {
-        if (!getApiKey()) break;
+        if (!isEmbeddingConfigured()) break;
         if (updated.name === newTarget.folderRel) continue;
         const body = readText(updated.name);
         if (body != null) await indexer.upsertFile(filesystemPath.join(oldTarget.folderRoot, updated.name), body);
@@ -207,7 +207,7 @@ export async function deleteLibraryFile(rawPath: unknown): Promise<{ path: strin
     catch (err: unknown) { log.warn(`library delete: derived cleanup failed for ${target.abs}: ${errorMessage(err)}`); }
     try { clearRecord(target.abs); }
     catch (err: unknown) { log.warn(`library delete: preparation status cleanup failed for ${target.abs}: ${errorMessage(err)}`); }
-    if (removed && getApiKey()) {
+    if (removed && isEmbeddingConfigured()) {
       for (const rel of [target.folderRel, ...derivedArtifacts.notes]) {
         const sourcePath = filesystemPath.join(target.folderRoot, rel);
         indexer.deleteFile(sourcePath).catch((err) => {

--- a/server/library-operations/index.test.ts
+++ b/server/library-operations/index.test.ts
@@ -18,6 +18,22 @@ test('Library Operations rejects AI Index retrieval without embedding configurat
   );
 });
 
+test('Library Operations distinguishes exhausted hosted quota', async () => {
+  const operations = createLibraryOperations({
+    getLibraryInfo: () => ({ folder_home: '/library', folders: [] }),
+    retrieval: { search: async () => ({
+      evidence: [], availability: { state: 'unavailable' as const, reason: 'hosted-quota-exhausted' as const }, truncated: false,
+    }) },
+  });
+
+  await assert.rejects(
+    operations.search({ query: 'architecture' }),
+    (error: unknown) => error instanceof LibraryOperationError
+      && error.status === 402
+      && error.code === 'HOSTED_QUOTA_EXHAUSTED',
+  );
+});
+
 test('Library Operations keeps search result identity at the visible source path', async () => {
   const operations = createLibraryOperations({
     getLibraryInfo: () => ({ folder_home: '/library', folders: [] }),

--- a/server/library-operations/index.ts
+++ b/server/library-operations/index.ts
@@ -144,6 +144,13 @@ export function createLibraryOperations(
         wholeWord,
       });
       if (result.availability.state === 'unavailable') {
+        if (result.availability.reason === 'hosted-quota-exhausted') {
+          throw routeError(
+            'Your hosted AI Index allowance is exhausted. Exact search is still available.',
+            402,
+            'HOSTED_QUOTA_EXHAUSTED',
+          );
+        }
         throw routeError(
           'AI Index is disabled until you set it up in StashBase Settings',
           412,

--- a/server/mfs-daemon.ts
+++ b/server/mfs-daemon.ts
@@ -73,7 +73,7 @@ const CALL_TIMEOUT_MS = 10 * 60_000;
 const READY_TIMEOUT_MS = 90_000;
 
 export interface BindFolderArgs {
-  provider: 'openai' | 'openrouter';
+  provider: 'openai' | 'openrouter' | 'stashbase';
   apiKey?: string;
   model?: string;
   dimension?: number;

--- a/server/oauth-result-page.ts
+++ b/server/oauth-result-page.ts
@@ -1,0 +1,125 @@
+const APP_RETURN_URL = 'stashbase://oauth-complete';
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  })[char] ?? char);
+}
+
+export function oauthResultPage({
+  title,
+  message,
+  kind = 'success',
+  autoReturn = false,
+}: {
+  title: string;
+  message: string;
+  kind?: 'success' | 'error';
+  autoReturn?: boolean;
+}): string {
+  const safeTitle = escapeHtml(title);
+  const safeMessage = escapeHtml(message);
+  const isSuccess = kind === 'success';
+  const icon = isSuccess
+    ? '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m7.4 12.1 3 3L16.8 8.7"/></svg>'
+    : '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 7.5v5M12 16.5h.01"/></svg>';
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="referrer" content="no-referrer">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
+  <title>${safeTitle}</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-width: 280px; min-height: 100vh; color: #18181b; background: radial-gradient(circle at 50% 8%, rgba(99, 102, 241, .10), transparent 36%), #f7f7f8; }
+    .shell { min-height: 100vh; display: grid; place-items: center; padding: 32px 20px; }
+    .stack { width: min(100%, 420px); text-align: center; }
+    .brand { display: inline-flex; align-items: center; gap: 9px; margin-bottom: 18px; color: #3f3f46; font-size: 14px; font-weight: 650; letter-spacing: -.01em; }
+    .brand-mark { display: grid; place-items: center; width: 24px; height: 24px; border-radius: 7px; color: white; background: linear-gradient(145deg, #6366f1, #4f46e5); box-shadow: 0 5px 14px rgba(79, 70, 229, .22); }
+    .brand-mark svg { width: 14px; fill: none; stroke: currentColor; stroke-width: 2; stroke-linecap: round; }
+    .card { padding: 34px 32px 30px; border: 1px solid rgba(24, 24, 27, .08); border-radius: 20px; background: rgba(255, 255, 255, .92); box-shadow: 0 18px 50px rgba(24, 24, 27, .09), 0 2px 8px rgba(24, 24, 27, .04); backdrop-filter: blur(14px); }
+    .result-icon { display: grid; place-items: center; width: 52px; height: 52px; margin: 0 auto 20px; border-radius: 16px; color: ${isSuccess ? '#15803d' : '#b91c1c'}; background: ${isSuccess ? '#ecfdf3' : '#fef2f2'}; }
+    .result-icon svg { width: 27px; fill: none; stroke: currentColor; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+    h1 { margin: 0; font-size: 22px; line-height: 1.25; letter-spacing: -.025em; }
+    .message { margin: 10px auto 0; max-width: 320px; color: #71717a; font-size: 14px; line-height: 1.6; }
+    .return-area { margin-top: 25px; padding-top: 22px; border-top: 1px solid #eeeef0; }
+    .status { min-height: 20px; margin: 0 0 13px; color: #71717a; font-size: 12px; line-height: 1.5; }
+    .button { display: inline-flex; min-height: 42px; align-items: center; justify-content: center; gap: 8px; padding: 0 18px; border-radius: 11px; color: #fff; background: #18181b; box-shadow: 0 5px 14px rgba(24, 24, 27, .16); font-size: 14px; font-weight: 650; text-decoration: none; transition: transform .15s ease, background .15s ease, box-shadow .15s ease; }
+    .button:hover { background: #27272a; box-shadow: 0 7px 18px rgba(24, 24, 27, .20); transform: translateY(-1px); }
+    .button:focus-visible { outline: 3px solid rgba(99, 102, 241, .28); outline-offset: 3px; }
+    .button svg { width: 16px; fill: none; stroke: currentColor; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    [hidden] { display: none !important; }
+    @media (prefers-reduced-motion: reduce) { .button { transition: none; } }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <div class="stack">
+      <div class="brand"><span class="brand-mark"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 7.5h10M7 12h10M7 16.5h6"/></svg></span>StashBase</div>
+      <section class="card" data-auto-return="${autoReturn ? 'true' : 'false'}" aria-labelledby="result-title">
+        <div class="result-icon">${icon}</div>
+        <h1 id="result-title">${safeTitle}</h1>
+        <p class="message">${safeMessage}</p>
+        <div class="return-area">
+          <p class="status" id="return-status" aria-live="polite">${autoReturn ? 'Returning you to the app…' : 'Return to StashBase to try again.'}</p>
+          <a class="button" id="return-button" href="${APP_RETURN_URL}"${autoReturn ? ' hidden' : ''}>
+            Open StashBase
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h13M13 7l5 5-5 5"/></svg>
+          </a>
+        </div>
+      </section>
+    </div>
+  </main>
+  <script>
+    (() => {
+      const card = document.querySelector('.card');
+      const button = document.getElementById('return-button');
+      const status = document.getElementById('return-status');
+      const autoReturn = card.dataset.autoReturn === 'true';
+      let handedOff = false;
+
+      const closeAfterHandoff = () => {
+        if (handedOff) return;
+        handedOff = true;
+        button.hidden = true;
+        status.textContent = 'StashBase is open. You can close this page.';
+        window.setTimeout(() => window.close(), 250);
+      };
+
+      const observeHandoff = () => {
+        window.setTimeout(() => {
+          if (document.visibilityState === 'hidden' || !document.hasFocus()) closeAfterHandoff();
+        }, 120);
+      };
+
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') closeAfterHandoff();
+      });
+      window.addEventListener('blur', observeHandoff);
+      button.addEventListener('click', () => {
+        status.textContent = 'Opening StashBase…';
+        window.setTimeout(() => {
+          if (!handedOff) status.textContent = 'Could not open automatically. Try the button again.';
+        }, 1600);
+      });
+
+      if (!autoReturn) return;
+      window.setTimeout(() => {
+        if (!handedOff && document.visibilityState === 'visible' && document.hasFocus()) {
+          window.location.href = '${APP_RETURN_URL}';
+        }
+      }, 1200);
+      window.setTimeout(() => {
+        if (handedOff) return;
+        button.hidden = false;
+        status.textContent = 'Didn’t return automatically?';
+      }, 2800);
+    })();
+  </script>
+</body>
+</html>`;
+}

--- a/server/oauth-result-page.ts
+++ b/server/oauth-result-page.ts
@@ -12,16 +12,19 @@ export function oauthResultPage({
   kind = 'success',
   autoReturn = false,
   returnStatusUrl,
+  returnIntentUrl,
 }: {
   title: string;
   message: string;
   kind?: 'success' | 'error';
   autoReturn?: boolean;
   returnStatusUrl?: string;
+  returnIntentUrl?: string;
 }): string {
   const safeTitle = escapeHtml(title);
   const safeMessage = escapeHtml(message);
   const returnStatusJson = JSON.stringify(returnStatusUrl ?? '').replace(/</g, '\\u003c');
+  const returnIntentJson = JSON.stringify(returnIntentUrl ?? '').replace(/</g, '\\u003c');
   const isSuccess = kind === 'success';
   const icon = isSuccess
     ? '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m7.4 12.1 3 3L16.8 8.7"/></svg>'
@@ -84,6 +87,7 @@ export function oauthResultPage({
       const status = document.getElementById('return-status');
       const autoReturn = card.dataset.autoReturn === 'true';
       const returnStatusUrl = ${returnStatusJson};
+      const returnIntentUrl = ${returnIntentJson};
       let handedOff = false;
       let returnAttempted = false;
 
@@ -119,7 +123,19 @@ export function oauthResultPage({
         }, 1600);
       };
 
-      button.addEventListener('click', beginReturnAttempt);
+      const openStashBase = async () => {
+        beginReturnAttempt();
+        if (returnIntentUrl) {
+          try { await fetch(returnIntentUrl, { method: 'POST', cache: 'no-store' }); }
+          catch { /* the native fallback can still open the app */ }
+        }
+        window.location.href = '${APP_RETURN_URL}';
+      };
+
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        void openStashBase();
+      });
       document.addEventListener('visibilitychange', () => {
         if (document.visibilityState === 'visible') void pollAcknowledgement();
       });
@@ -127,8 +143,7 @@ export function oauthResultPage({
       if (!autoReturn) return;
       window.setTimeout(() => {
         if (!handedOff && document.visibilityState === 'visible' && document.hasFocus()) {
-          beginReturnAttempt();
-          window.location.href = '${APP_RETURN_URL}';
+          void openStashBase();
         }
       }, 1200);
       window.setTimeout(() => {

--- a/server/oauth-result-page.ts
+++ b/server/oauth-result-page.ts
@@ -11,14 +11,17 @@ export function oauthResultPage({
   message,
   kind = 'success',
   autoReturn = false,
+  returnStatusUrl,
 }: {
   title: string;
   message: string;
   kind?: 'success' | 'error';
   autoReturn?: boolean;
+  returnStatusUrl?: string;
 }): string {
   const safeTitle = escapeHtml(title);
   const safeMessage = escapeHtml(message);
+  const returnStatusJson = JSON.stringify(returnStatusUrl ?? '').replace(/</g, '\\u003c');
   const isSuccess = kind === 'success';
   const icon = isSuccess
     ? '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m7.4 12.1 3 3L16.8 8.7"/></svg>'
@@ -30,7 +33,7 @@ export function oauthResultPage({
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="referrer" content="no-referrer">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'">
   <title>${safeTitle}</title>
   <style>
     :root { color-scheme: light; font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
@@ -80,9 +83,11 @@ export function oauthResultPage({
       const button = document.getElementById('return-button');
       const status = document.getElementById('return-status');
       const autoReturn = card.dataset.autoReturn === 'true';
+      const returnStatusUrl = ${returnStatusJson};
       let handedOff = false;
+      let returnAttempted = false;
 
-      const closeAfterHandoff = () => {
+      const closeAfterAcknowledgement = () => {
         if (handedOff) return;
         handedOff = true;
         button.hidden = true;
@@ -90,26 +95,39 @@ export function oauthResultPage({
         window.setTimeout(() => window.close(), 250);
       };
 
-      const observeHandoff = () => {
-        window.setTimeout(() => {
-          if (document.visibilityState === 'hidden' || !document.hasFocus()) closeAfterHandoff();
-        }, 120);
+      const pollAcknowledgement = async () => {
+        if (handedOff || !returnAttempted || !returnStatusUrl) return;
+        try {
+          const response = await fetch(returnStatusUrl, { cache: 'no-store' });
+          const result = response.ok ? await response.json() : null;
+          if (result && result.appReturned === true) {
+            closeAfterAcknowledgement();
+            return;
+          }
+        } catch { /* keep the fallback visible and retry */ }
+        window.setTimeout(pollAcknowledgement, 300);
       };
 
-      document.addEventListener('visibilitychange', () => {
-        if (document.visibilityState === 'hidden') closeAfterHandoff();
-      });
-      window.addEventListener('blur', observeHandoff);
-      button.addEventListener('click', () => {
+      const beginReturnAttempt = () => {
+        if (!returnAttempted) {
+          returnAttempted = true;
+          void pollAcknowledgement();
+        }
         status.textContent = 'Opening StashBase…';
         window.setTimeout(() => {
           if (!handedOff) status.textContent = 'Could not open automatically. Try the button again.';
         }, 1600);
+      };
+
+      button.addEventListener('click', beginReturnAttempt);
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') void pollAcknowledgement();
       });
 
       if (!autoReturn) return;
       window.setTimeout(() => {
         if (!handedOff && document.visibilityState === 'visible' && document.hasFocus()) {
+          beginReturnAttempt();
           window.location.href = '${APP_RETURN_URL}';
         }
       }, 1200);

--- a/server/process-private-token.ts
+++ b/server/process-private-token.ts
@@ -1,0 +1,11 @@
+import crypto from 'node:crypto';
+
+export function processPrivateTokenMatches(
+  actual: string | undefined,
+  expected: string,
+): boolean {
+  if (!actual || !expected) return false;
+  const left = Buffer.from(actual);
+  const right = Buffer.from(expected);
+  return left.length === right.length && crypto.timingSafeEqual(left, right);
+}

--- a/server/retrieval/index.test.ts
+++ b/server/retrieval/index.test.ts
@@ -22,6 +22,22 @@ test('Retrieval reports unavailable semantic mode without invoking its adapter',
   assert.equal(called, false);
 });
 
+test('Retrieval distinguishes exhausted hosted quota without invoking vector search', async () => {
+  let called = false;
+  const retrieval = createRetrieval({
+    hasEmbeddingKey: () => false,
+    embeddingUnavailableReason: () => 'hosted-quota-exhausted',
+    vectorSearch: async () => {
+      called = true;
+      return [];
+    },
+  });
+
+  const result = await retrieval.search({ mode: 'semantic', query: 'architecture' });
+  assert.deepEqual(result.availability, { state: 'unavailable', reason: 'hosted-quota-exhausted' });
+  assert.equal(called, false);
+});
+
 test('Retrieval normalizes keyword matches into flat visible-source evidence', async () => {
   const retrieval = createRetrieval({
     keywordSearch: async () => ({

--- a/server/retrieval/index.test.ts
+++ b/server/retrieval/index.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { filesystemPath } from '../filesystem-path.ts';
 import { createRetrieval } from './index.ts';
 
 test('Retrieval reports unavailable semantic mode without invoking its adapter', async () => {
@@ -39,6 +40,7 @@ test('Retrieval distinguishes exhausted hosted quota without invoking vector sea
 });
 
 test('Retrieval normalizes keyword matches into flat visible-source evidence', async () => {
+  const folderRoot = filesystemPath.absolute('/library');
   const retrieval = createRetrieval({
     keywordSearch: async () => ({
       files: [{
@@ -52,12 +54,12 @@ test('Retrieval normalizes keyword matches into flat visible-source evidence', a
     }),
   });
 
-  const result = await retrieval.search({ mode: 'keyword', query: 'architecture', folderRoot: '/library' });
+  const result = await retrieval.search({ mode: 'keyword', query: 'architecture', folderRoot });
 
   assert.deepEqual(result, {
     evidence: [
-      { sourcePath: '/library/notes/brief.md', snippet: 'System architecture', ranges: [[7, 19]], sourceMatchCount: 2, locator: { line: 4 } },
-      { sourcePath: '/library/notes/brief.md', snippet: 'architecture diagram', ranges: [[0, 12]], sourceMatchCount: 2, locator: { line: 9 } },
+      { sourcePath: filesystemPath.join(folderRoot, 'notes/brief.md'), snippet: 'System architecture', ranges: [[7, 19]], sourceMatchCount: 2, locator: { line: 4 } },
+      { sourcePath: filesystemPath.join(folderRoot, 'notes/brief.md'), snippet: 'architecture diagram', ranges: [[0, 12]], sourceMatchCount: 2, locator: { line: 9 } },
     ],
     availability: { state: 'ready' },
     truncated: false,
@@ -92,18 +94,20 @@ test('Retrieval applies top_k to keyword evidence and reports truncation', async
 });
 
 test('Retrieval preserves semantic source identity and source-safe locators', async () => {
+  const folderRoot = filesystemPath.absolute('/library');
+  const sourcePath = filesystemPath.join(folderRoot, 'paper.pdf');
   const retrieval = createRetrieval({
     hasEmbeddingKey: () => true,
     vectorSearch: async () => [{
-      fileName: '/library/paper.pdf', chunkIndex: 3, content: 'derived evidence', heading: 'Results',
+      fileName: sourcePath, chunkIndex: 3, content: 'derived evidence', heading: 'Results',
       startLine: 42, endLine: 45, pdfPage: 7, score: 0.9,
     }],
   });
 
-  const result = await retrieval.search({ mode: 'semantic', query: 'evidence', folderRoot: '/library' });
+  const result = await retrieval.search({ mode: 'semantic', query: 'evidence', folderRoot });
 
   assert.deepEqual(result.evidence, [{
-    sourcePath: '/library/paper.pdf', snippet: 'derived evidence', heading: 'Results',
+    sourcePath, snippet: 'derived evidence', heading: 'Results',
     locator: { line: 42, endLine: 45, page: 7 }, score: 0.9, chunkIndex: 3,
   }]);
 });
@@ -143,7 +147,7 @@ test('Retrieval remaps scoped semantic legacy-derived hits to their visible sour
     const result = await retrieval.search({ mode: 'semantic', query: 'evidence', folderRoot });
 
     assert.deepEqual(result.evidence, [{
-      sourcePath, snippet: 'derived evidence', heading: '', locator: {}, score: 1, chunkIndex: 0,
+      sourcePath: filesystemPath.absolute(sourcePath), snippet: 'derived evidence', heading: '', locator: {}, score: 1, chunkIndex: 0,
     }]);
   } finally {
     fs.rmSync(folderRoot, { recursive: true, force: true });

--- a/server/retrieval/index.ts
+++ b/server/retrieval/index.ts
@@ -5,7 +5,7 @@
  * one flat evidence model keyed by the visible, absolute source path; prepared
  * representations never cross this seam.
  */
-import { getApiKey } from '../app-config.ts';
+import { isEmbeddingConfigured } from '../app-config.ts';
 import { searchExtensionsForTypes } from '../format.ts';
 import { filesystemPath } from '../filesystem-path.ts';
 import { runKeywordSearch, type KeywordSearchOpts } from '../keyword-search.ts';
@@ -47,7 +47,7 @@ export interface RetrievalDependencies {
 }
 
 const productionDependencies: RetrievalDependencies = {
-  hasEmbeddingKey: () => Boolean(getApiKey()),
+  hasEmbeddingKey: isEmbeddingConfigured,
   vectorSearch: (query, topK, folderRoot, pathPrefix, extensions) =>
     indexer.search(query, topK, folderRoot, pathPrefix, extensions),
   keywordSearch: runKeywordSearch,

--- a/server/retrieval/index.ts
+++ b/server/retrieval/index.ts
@@ -5,7 +5,7 @@
  * one flat evidence model keyed by the visible, absolute source path; prepared
  * representations never cross this seam.
  */
-import { isEmbeddingConfigured } from '../app-config.ts';
+import { embeddingAvailability, isEmbeddingAvailable } from '../embedding-availability.ts';
 import { searchExtensionsForTypes } from '../format.ts';
 import { filesystemPath } from '../filesystem-path.ts';
 import { runKeywordSearch, type KeywordSearchOpts } from '../keyword-search.ts';
@@ -21,7 +21,7 @@ export type RetrievalMode = SearchMode;
 export type RetrievalAvailability =
   | { state: 'ready' }
   | { state: 'partial'; reason: 'truncated' }
-  | { state: 'unavailable'; reason: 'embedding-key-required' };
+  | { state: 'unavailable'; reason: 'embedding-key-required' | 'hosted-quota-exhausted' };
 
 export interface RetrievalQuery {
   mode: RetrievalMode;
@@ -42,12 +42,19 @@ export interface RetrievalResult {
 
 export interface RetrievalDependencies {
   hasEmbeddingKey: () => boolean;
+  embeddingUnavailableReason: () => 'embedding-key-required' | 'hosted-quota-exhausted';
   vectorSearch: (query: string, topK: number, folderRoot?: string, pathPrefix?: string, extensions?: string[]) => Promise<SearchHit[]>;
   keywordSearch: (query: string, folderRoot: string, opts: KeywordSearchOpts) => Promise<{ files: import('../search-display.ts').KeywordHitFile[]; truncated: boolean }>;
 }
 
 const productionDependencies: RetrievalDependencies = {
-  hasEmbeddingKey: isEmbeddingConfigured,
+  hasEmbeddingKey: isEmbeddingAvailable,
+  embeddingUnavailableReason: () => {
+    const availability = embeddingAvailability();
+    return !availability.available && availability.reason === 'hosted-quota-exhausted'
+      ? 'hosted-quota-exhausted'
+      : 'embedding-key-required';
+  },
   vectorSearch: (query, topK, folderRoot, pathPrefix, extensions) =>
     indexer.search(query, topK, folderRoot, pathPrefix, extensions),
   keywordSearch: runKeywordSearch,
@@ -66,7 +73,11 @@ export function createRetrieval(overrides: Partial<RetrievalDependencies> = {}):
       if (!text) throw new Error('query required');
       if (query.mode === 'semantic') {
         if (!deps.hasEmbeddingKey()) {
-          return { evidence: [], availability: { state: 'unavailable', reason: 'embedding-key-required' }, truncated: false };
+          return {
+            evidence: [],
+            availability: { state: 'unavailable', reason: deps.embeddingUnavailableReason() },
+            truncated: false,
+          };
         }
         const hits = await deps.vectorSearch(
           text,

--- a/server/routes/account.ts
+++ b/server/routes/account.ts
@@ -5,16 +5,32 @@ import {
   setEmbeddingSource,
 } from '../app-config.ts';
 import {
+  beginHostedOAuth,
+  exchangeHostedOAuthCode,
+  failHostedOAuth,
+  finishHostedOAuth,
   hostedAccountState,
-  requestEmailOtp,
+  hostedOAuthStatus,
   signOutHostedAccount,
-  verifyEmailOtp,
+  type HostedOAuthProvider,
 } from '../hosted-account.ts';
 import { startHostedEmbeddingBroker } from '../hosted-embedding-broker.ts';
 import { errorMessage, logger } from '../log.ts';
+import { oauthResultPage } from '../oauth-result-page.ts';
 import { bootBindAllFolders, reconcileLibraryFolders, resetIndexerRuntime } from '../state.ts';
 
 const log = logger('routes/account');
+const OAUTH_PROVIDERS = new Set<HostedOAuthProvider>(['google', 'github']);
+
+function oauthProvider(value: unknown): HostedOAuthProvider | null {
+  return typeof value === 'string' && OAUTH_PROVIDERS.has(value as HostedOAuthProvider)
+    ? value as HostedOAuthProvider
+    : null;
+}
+
+function callbackOrigin(req: express.Request): string {
+  return new URL(`http://${req.get('host') ?? ''}`).origin;
+}
 
 async function activateHostedSource(reason: string): Promise<boolean> {
   await startHostedEmbeddingBroker();
@@ -38,25 +54,58 @@ export function mount(app: express.Express): void {
     res.json(await hostedAccountState(refresh));
   });
 
-  app.post('/api/account/otp', async (req, res) => {
+  app.post('/api/account/oauth/start', (req, res) => {
     try {
-      await requestEmailOtp(typeof req.body?.email === 'string' ? req.body.email : '');
-      res.json({ ok: true });
+      const provider = oauthProvider(req.body?.provider ?? 'google');
+      if (!provider) return res.status(400).json({ error: 'Unsupported sign-in provider.' });
+      res.json(beginHostedOAuth(provider, callbackOrigin(req)));
     } catch (error: unknown) {
       res.status(400).json({ error: errorMessage(error) });
     }
   });
 
-  app.post('/api/account/verify', async (req, res) => {
-    try {
-      const email = typeof req.body?.email === 'string' ? req.body.email : '';
-      const token = typeof req.body?.token === 'string' ? req.body.token : '';
-      await verifyEmailOtp(email, token);
-      const backfillStarted = await activateHostedSource('StashBase account activated');
-      res.json({ ...(await hostedAccountState(true)), backfillStarted });
-    } catch (error: unknown) {
-      res.status(400).json({ error: errorMessage(error) });
+  app.get('/api/account/oauth/callback', async (req, res) => {
+    const flowId = typeof req.query.flow === 'string' ? req.query.flow : '';
+    const authCode = typeof req.query.code === 'string' ? req.query.code : '';
+    const providerError = typeof req.query.error_description === 'string'
+      ? req.query.error_description
+      : typeof req.query.error === 'string' ? req.query.error : '';
+    if (!flowId) {
+      return res.status(400).type('html').send(oauthResultPage({
+        title: 'Sign-in failed',
+        message: 'The sign-in request is missing or expired. Return to StashBase and try again.',
+        kind: 'error',
+      }));
     }
+    if (providerError) {
+      failHostedOAuth(flowId, providerError);
+      return res.status(400).type('html').send(oauthResultPage({
+        title: 'Sign-in failed', message: providerError, kind: 'error',
+      }));
+    }
+    try {
+      await exchangeHostedOAuthCode(flowId, authCode);
+      const backfillStarted = await activateHostedSource('StashBase account activated');
+      finishHostedOAuth(flowId);
+      log.info(`OAuth sign-in completed${backfillStarted ? '; semantic backfill started' : ''}`);
+      res.type('html').send(oauthResultPage({
+        title: 'Signed in to StashBase',
+        message: 'Your account is ready. This page will return you to the app automatically.',
+        autoReturn: true,
+      }));
+    } catch (error: unknown) {
+      const message = errorMessage(error);
+      failHostedOAuth(flowId, message);
+      res.status(400).type('html').send(oauthResultPage({
+        title: 'Sign-in failed', message, kind: 'error',
+      }));
+    }
+  });
+
+  app.get('/api/account/oauth/status', (req, res) => {
+    const flowId = typeof req.query.flow === 'string' ? req.query.flow : '';
+    if (!flowId) return res.status(400).json({ error: 'Missing sign-in flow.' });
+    res.json(hostedOAuthStatus(flowId));
   });
 
   app.put('/api/account/source', async (_req, res) => {

--- a/server/routes/account.ts
+++ b/server/routes/account.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import {
-  getEmbedderConfig,
   getHostedAccountSession,
   setEmbeddingSource,
 } from '../app-config.ts';
@@ -11,6 +10,7 @@ import {
   finishHostedOAuth,
   hostedAccountState,
   hostedOAuthStatus,
+  noteHostedOAuthAppReturn,
   signOutHostedAccount,
   type HostedOAuthProvider,
 } from '../hosted-account.ts';
@@ -18,9 +18,10 @@ import { startHostedEmbeddingBroker } from '../hosted-embedding-broker.ts';
 import { errorMessage, logger } from '../log.ts';
 import { oauthResultPage } from '../oauth-result-page.ts';
 import { bootBindAllFolders, reconcileLibraryFolders, resetIndexerRuntime } from '../state.ts';
+import { isEmbeddingAvailable } from '../embedding-availability.ts';
 
 const log = logger('routes/account');
-const OAUTH_PROVIDERS = new Set<HostedOAuthProvider>(['google', 'github']);
+const OAUTH_PROVIDERS = new Set<HostedOAuthProvider>(['google']);
 
 function oauthProvider(value: unknown): HostedOAuthProvider | null {
   return typeof value === 'string' && OAUTH_PROVIDERS.has(value as HostedOAuthProvider)
@@ -33,8 +34,9 @@ function callbackOrigin(req: express.Request): string {
 }
 
 async function activateHostedSource(reason: string): Promise<boolean> {
+  // Learn a zero allowance before any daemon bind/reconcile can spend work.
+  await hostedAccountState(true);
   await startHostedEmbeddingBroker();
-  const hadDirectKey = !!getEmbedderConfig().apiKey;
   setEmbeddingSource('stashbase-account');
   try {
     await resetIndexerRuntime({ forgetBindings: true });
@@ -45,7 +47,7 @@ async function activateHostedSource(reason: string): Promise<boolean> {
   } catch (error: unknown) {
     log.warn(`${reason}: runtime reset/rebind failed: ${errorMessage(error)}`);
   }
-  return !hadDirectKey;
+  return isEmbeddingAvailable();
 }
 
 export function mount(app: express.Express): void {
@@ -81,6 +83,7 @@ export function mount(app: express.Express): void {
       failHostedOAuth(flowId, providerError);
       return res.status(400).type('html').send(oauthResultPage({
         title: 'Sign-in failed', message: providerError, kind: 'error',
+        returnStatusUrl: `/api/account/oauth/status?flow=${encodeURIComponent(flowId)}`,
       }));
     }
     try {
@@ -92,12 +95,14 @@ export function mount(app: express.Express): void {
         title: 'Signed in to StashBase',
         message: 'Your account is ready. This page will return you to the app automatically.',
         autoReturn: true,
+        returnStatusUrl: `/api/account/oauth/status?flow=${encodeURIComponent(flowId)}`,
       }));
     } catch (error: unknown) {
       const message = errorMessage(error);
       failHostedOAuth(flowId, message);
       res.status(400).type('html').send(oauthResultPage({
         title: 'Sign-in failed', message, kind: 'error',
+        returnStatusUrl: `/api/account/oauth/status?flow=${encodeURIComponent(flowId)}`,
       }));
     }
   });
@@ -106,6 +111,10 @@ export function mount(app: express.Express): void {
     const flowId = typeof req.query.flow === 'string' ? req.query.flow : '';
     if (!flowId) return res.status(400).json({ error: 'Missing sign-in flow.' });
     res.json(hostedOAuthStatus(flowId));
+  });
+
+  app.post('/api/account/oauth/app-return', (_req, res) => {
+    res.json({ acknowledged: noteHostedOAuthAppReturn() });
   });
 
   app.put('/api/account/source', async (_req, res) => {

--- a/server/routes/account.ts
+++ b/server/routes/account.ts
@@ -5,6 +5,7 @@ import {
 } from '../app-config.ts';
 import {
   beginHostedOAuth,
+  createFailedHostedOAuthFlow,
   exchangeHostedOAuthCode,
   failHostedOAuth,
   finishHostedOAuth,
@@ -19,9 +20,15 @@ import { errorMessage, logger } from '../log.ts';
 import { oauthResultPage } from '../oauth-result-page.ts';
 import { bootBindAllFolders, reconcileLibraryFolders, resetIndexerRuntime } from '../state.ts';
 import { isEmbeddingAvailable } from '../embedding-availability.ts';
+import { processPrivateTokenMatches } from '../process-private-token.ts';
 
 const log = logger('routes/account');
 const OAUTH_PROVIDERS = new Set<HostedOAuthProvider>(['google']);
+const OAUTH_RETURN_TOKEN_HEADER = 'x-stashbase-oauth-return-token';
+
+interface AccountRouteOptions {
+  appReturnToken: string;
+}
 
 function oauthProvider(value: unknown): HostedOAuthProvider | null {
   return typeof value === 'string' && OAUTH_PROVIDERS.has(value as HostedOAuthProvider)
@@ -50,7 +57,7 @@ async function activateHostedSource(reason: string): Promise<boolean> {
   return isEmbeddingAvailable();
 }
 
-export function mount(app: express.Express): void {
+export function mount(app: express.Express, { appReturnToken }: AccountRouteOptions): void {
   app.get('/api/account', async (req, res) => {
     const refresh = req.query.refresh === '1';
     res.json(await hostedAccountState(refresh));
@@ -73,10 +80,13 @@ export function mount(app: express.Express): void {
       ? req.query.error_description
       : typeof req.query.error === 'string' ? req.query.error : '';
     if (!flowId) {
+      const message = 'The sign-in request is missing or expired. Return to StashBase and try again.';
+      const failedFlowId = createFailedHostedOAuthFlow(message);
       return res.status(400).type('html').send(oauthResultPage({
         title: 'Sign-in failed',
-        message: 'The sign-in request is missing or expired. Return to StashBase and try again.',
+        message,
         kind: 'error',
+        returnStatusUrl: `/api/account/oauth/status?flow=${encodeURIComponent(failedFlowId)}`,
       }));
     }
     if (providerError) {
@@ -113,7 +123,10 @@ export function mount(app: express.Express): void {
     res.json(hostedOAuthStatus(flowId));
   });
 
-  app.post('/api/account/oauth/app-return', (_req, res) => {
+  app.post('/api/account/oauth/app-return', (req, res) => {
+    if (!processPrivateTokenMatches(req.header(OAUTH_RETURN_TOKEN_HEADER), appReturnToken)) {
+      return res.status(403).json({ error: 'forbidden' });
+    }
     res.json({ acknowledged: noteHostedOAuthAppReturn() });
   });
 

--- a/server/routes/account.ts
+++ b/server/routes/account.ts
@@ -12,6 +12,7 @@ import {
   hostedAccountState,
   hostedOAuthStatus,
   noteHostedOAuthAppReturn,
+  noteHostedOAuthReturnIntent,
   signOutHostedAccount,
   type HostedOAuthProvider,
 } from '../hosted-account.ts';
@@ -21,6 +22,7 @@ import { oauthResultPage } from '../oauth-result-page.ts';
 import { bootBindAllFolders, reconcileLibraryFolders, resetIndexerRuntime } from '../state.ts';
 import { isEmbeddingAvailable } from '../embedding-availability.ts';
 import { processPrivateTokenMatches } from '../process-private-token.ts';
+import { currentWindowId } from '../folder.ts';
 
 const log = logger('routes/account');
 const OAUTH_PROVIDERS = new Set<HostedOAuthProvider>(['google']);
@@ -67,7 +69,7 @@ export function mount(app: express.Express, { appReturnToken }: AccountRouteOpti
     try {
       const provider = oauthProvider(req.body?.provider ?? 'google');
       if (!provider) return res.status(400).json({ error: 'Unsupported sign-in provider.' });
-      res.json(beginHostedOAuth(provider, callbackOrigin(req)));
+      res.json(beginHostedOAuth(provider, callbackOrigin(req), currentWindowId()));
     } catch (error: unknown) {
       res.status(400).json({ error: errorMessage(error) });
     }
@@ -87,6 +89,7 @@ export function mount(app: express.Express, { appReturnToken }: AccountRouteOpti
         message,
         kind: 'error',
         returnStatusUrl: `/api/account/oauth/status?flow=${encodeURIComponent(failedFlowId)}`,
+        returnIntentUrl: `/api/account/oauth/return-intent?flow=${encodeURIComponent(failedFlowId)}`,
       }));
     }
     if (providerError) {
@@ -94,6 +97,7 @@ export function mount(app: express.Express, { appReturnToken }: AccountRouteOpti
       return res.status(400).type('html').send(oauthResultPage({
         title: 'Sign-in failed', message: providerError, kind: 'error',
         returnStatusUrl: `/api/account/oauth/status?flow=${encodeURIComponent(flowId)}`,
+        returnIntentUrl: `/api/account/oauth/return-intent?flow=${encodeURIComponent(flowId)}`,
       }));
     }
     try {
@@ -106,6 +110,7 @@ export function mount(app: express.Express, { appReturnToken }: AccountRouteOpti
         message: 'Your account is ready. This page will return you to the app automatically.',
         autoReturn: true,
         returnStatusUrl: `/api/account/oauth/status?flow=${encodeURIComponent(flowId)}`,
+        returnIntentUrl: `/api/account/oauth/return-intent?flow=${encodeURIComponent(flowId)}`,
       }));
     } catch (error: unknown) {
       const message = errorMessage(error);
@@ -113,6 +118,7 @@ export function mount(app: express.Express, { appReturnToken }: AccountRouteOpti
       res.status(400).type('html').send(oauthResultPage({
         title: 'Sign-in failed', message, kind: 'error',
         returnStatusUrl: `/api/account/oauth/status?flow=${encodeURIComponent(flowId)}`,
+        returnIntentUrl: `/api/account/oauth/return-intent?flow=${encodeURIComponent(flowId)}`,
       }));
     }
   });
@@ -123,11 +129,19 @@ export function mount(app: express.Express, { appReturnToken }: AccountRouteOpti
     res.json(hostedOAuthStatus(flowId));
   });
 
+  app.post('/api/account/oauth/return-intent', (req, res) => {
+    const flowId = typeof req.query.flow === 'string' ? req.query.flow : '';
+    if (!flowId || !noteHostedOAuthReturnIntent(flowId)) {
+      return res.status(404).json({ error: 'Sign-in flow is unavailable.' });
+    }
+    res.json({ accepted: true });
+  });
+
   app.post('/api/account/oauth/app-return', (req, res) => {
     if (!processPrivateTokenMatches(req.header(OAUTH_RETURN_TOKEN_HEADER), appReturnToken)) {
       return res.status(403).json({ error: 'forbidden' });
     }
-    res.json({ acknowledged: noteHostedOAuthAppReturn() });
+    res.json(noteHostedOAuthAppReturn());
   });
 
   app.put('/api/account/source', async (_req, res) => {

--- a/server/routes/account.ts
+++ b/server/routes/account.ts
@@ -1,0 +1,85 @@
+import express from 'express';
+import {
+  getEmbedderConfig,
+  getHostedAccountSession,
+  setEmbeddingSource,
+} from '../app-config.ts';
+import {
+  hostedAccountState,
+  requestEmailOtp,
+  signOutHostedAccount,
+  verifyEmailOtp,
+} from '../hosted-account.ts';
+import { startHostedEmbeddingBroker } from '../hosted-embedding-broker.ts';
+import { errorMessage, logger } from '../log.ts';
+import { bootBindAllFolders, reconcileLibraryFolders, resetIndexerRuntime } from '../state.ts';
+
+const log = logger('routes/account');
+
+async function activateHostedSource(reason: string): Promise<boolean> {
+  await startHostedEmbeddingBroker();
+  const hadDirectKey = !!getEmbedderConfig().apiKey;
+  setEmbeddingSource('stashbase-account');
+  try {
+    await resetIndexerRuntime({ forgetBindings: true });
+    await bootBindAllFolders();
+    void reconcileLibraryFolders(reason).catch((error: unknown) => {
+      log.warn(`${reason}: semantic backfill failed: ${errorMessage(error)}`);
+    });
+  } catch (error: unknown) {
+    log.warn(`${reason}: runtime reset/rebind failed: ${errorMessage(error)}`);
+  }
+  return !hadDirectKey;
+}
+
+export function mount(app: express.Express): void {
+  app.get('/api/account', async (req, res) => {
+    const refresh = req.query.refresh === '1';
+    res.json(await hostedAccountState(refresh));
+  });
+
+  app.post('/api/account/otp', async (req, res) => {
+    try {
+      await requestEmailOtp(typeof req.body?.email === 'string' ? req.body.email : '');
+      res.json({ ok: true });
+    } catch (error: unknown) {
+      res.status(400).json({ error: errorMessage(error) });
+    }
+  });
+
+  app.post('/api/account/verify', async (req, res) => {
+    try {
+      const email = typeof req.body?.email === 'string' ? req.body.email : '';
+      const token = typeof req.body?.token === 'string' ? req.body.token : '';
+      await verifyEmailOtp(email, token);
+      const backfillStarted = await activateHostedSource('StashBase account activated');
+      res.json({ ...(await hostedAccountState(true)), backfillStarted });
+    } catch (error: unknown) {
+      res.status(400).json({ error: errorMessage(error) });
+    }
+  });
+
+  app.put('/api/account/source', async (_req, res) => {
+    try {
+      if (!getHostedAccountSession()) return res.status(401).json({ error: 'Sign in first.' });
+      const backfillStarted = await activateHostedSource('StashBase account source selected');
+      res.json({ ...(await hostedAccountState(true)), backfillStarted });
+    } catch (error: unknown) {
+      res.status(400).json({ error: errorMessage(error) });
+    }
+  });
+
+  app.delete('/api/account', async (_req, res) => {
+    const wasActive = (await hostedAccountState(false)).active;
+    await signOutHostedAccount();
+    if (wasActive) {
+      try {
+        await resetIndexerRuntime({ forgetBindings: true });
+        await bootBindAllFolders();
+      } catch (error: unknown) {
+        log.warn(`sign out: runtime reset failed: ${errorMessage(error)}`);
+      }
+    }
+    res.json({ signedIn: false, active: false });
+  });
+}

--- a/server/routes/embedder.ts
+++ b/server/routes/embedder.ts
@@ -11,13 +11,17 @@ import express from 'express';
 import { logger, errorMessage } from '../log.ts';
 import { getCurrentFolder } from '../folder.ts';
 import {
+  getEmbeddingSource,
   getEmbedderConfig,
+  isEmbeddingConfigured,
   isEmbedderProvider,
   setApiKey,
+  setEmbeddingSource,
 } from '../app-config.ts';
 import type { EmbedderProvider } from '../app-config.ts';
 import { bootBindAllFolders, reconcileLibraryFolders, resetIndexerRuntime } from '../state.ts';
 import { sendError, validateEmbedderKey } from '../http.ts';
+import { hostedAccountState } from '../hosted-account.ts';
 
 const log = logger('routes/embedder');
 
@@ -32,12 +36,17 @@ function providerLabel(provider: EmbedderProvider): string {
 
 export function mount(app: express.Express): void {
   // Embedder status: active provider + whether a key is configured.
-  app.get('/api/embedder', (_req, res) => {
+  app.get('/api/embedder', async (_req, res) => {
     const cfg = getEmbedderConfig();
+    const source = getEmbeddingSource();
+    const account = await hostedAccountState(source === 'stashbase-account');
     res.json({
       provider: cfg.provider,
       hasKey: !!cfg.apiKey,
+      authorized: isEmbeddingConfigured(),
+      source,
       model: cfg.model,
+      account,
     });
   });
 
@@ -59,7 +68,7 @@ export function mount(app: express.Express): void {
     const check = await validateEmbedderKey(provider, key);
     const warning = check.ok ? undefined : check.error;
     if (!check.ok && check.status < 500) return res.status(check.status).json({ error: check.error });
-    const shouldBackfill = !current.apiKey;
+    const shouldBackfill = !isEmbeddingConfigured();
     try {
       setApiKey(key, provider);
     } catch (err: unknown) {
@@ -85,11 +94,37 @@ export function mount(app: express.Express): void {
     const saved = getEmbedderConfig();
     res.json({
       hasKey: true,
+      authorized: true,
+      source: saved.provider,
       provider: saved.provider,
       model: saved.model,
       backfillStarted: shouldBackfill,
       ...(warning ? { warning } : {}),
     });
+  });
+
+  app.put('/api/embedder/source', async (req, res) => {
+    const cfg = getEmbedderConfig();
+    const provider = parseProvider(req.body?.provider, cfg.provider);
+    if (!provider) return res.status(400).json({ error: 'unknown embedder provider' });
+    if (!cfg.apiKey || cfg.provider !== provider) {
+      return res.status(400).json({ error: `Add a ${providerLabel(provider)} key before selecting it.` });
+    }
+    try {
+      setEmbeddingSource(provider);
+      await resetIndexerRuntime({ forgetBindings: true });
+      await bootBindAllFolders();
+      res.json({
+        provider,
+        hasKey: true,
+        authorized: true,
+        source: provider,
+        model: getEmbedderConfig().model,
+        account: await hostedAccountState(false),
+      });
+    } catch (err: unknown) {
+      sendError(res, err);
+    }
   });
 
   // Wipe the active embedding key. New embed / search calls will no-op
@@ -108,6 +143,13 @@ export function mount(app: express.Express): void {
       log.warn(`key delete: runtime reset failed: ${errorMessage(err)}`);
     }
     const cfg = getEmbedderConfig();
-    res.json({ hasKey: false, provider: cfg.provider, model: cfg.model });
+    res.json({
+      hasKey: false,
+      authorized: isEmbeddingConfigured(),
+      source: getEmbeddingSource(),
+      provider: cfg.provider,
+      model: cfg.model,
+      account: await hostedAccountState(false),
+    });
   });
 }

--- a/server/routes/embedder.ts
+++ b/server/routes/embedder.ts
@@ -19,6 +19,10 @@ import {
   setEmbeddingSource,
 } from '../app-config.ts';
 import type { EmbedderProvider } from '../app-config.ts';
+import {
+  isEmbeddingAvailable,
+  shouldReconcileAfterEmbeddingSourceChange,
+} from '../embedding-availability.ts';
 import { bootBindAllFolders, reconcileLibraryFolders, resetIndexerRuntime } from '../state.ts';
 import { sendError, validateEmbedderKey } from '../http.ts';
 import { hostedAccountState } from '../hosted-account.ts';
@@ -68,7 +72,12 @@ export function mount(app: express.Express): void {
     const check = await validateEmbedderKey(provider, key);
     const warning = check.ok ? undefined : check.error;
     if (!check.ok && check.status < 500) return res.status(check.status).json({ error: check.error });
-    const shouldBackfill = !isEmbeddingConfigured();
+    const previousSource = getEmbeddingSource();
+    const shouldBackfill = shouldReconcileAfterEmbeddingSourceChange(
+      previousSource,
+      provider,
+      isEmbeddingAvailable(),
+    );
     try {
       setApiKey(key, provider);
     } catch (err: unknown) {
@@ -114,6 +123,10 @@ export function mount(app: express.Express): void {
       setEmbeddingSource(provider);
       await resetIndexerRuntime({ forgetBindings: true });
       await bootBindAllFolders();
+      void reconcileLibraryFolders(`${providerLabel(provider)} source selected`)
+        .catch((err: unknown) => {
+          log.warn(`source selected: semantic reconcile failed: ${errorMessage(err)}`);
+        });
       res.json({
         provider,
         hasKey: true,

--- a/server/routes/file-mutations.ts
+++ b/server/routes/file-mutations.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getApiKey } from '../app-config.ts';
+import { isEmbeddingConfigured } from '../app-config.ts';
 import { queueConvertibleSource } from '../conversion-dispatch.ts';
 import { clearRecord } from '../conversion-status.ts';
 import { deleteDerivedForSource } from '../derived-store.ts';
@@ -103,10 +103,10 @@ export function mountFileMutationRoutes(app: express.Express): void {
               log.warn(`rename: failed to remove legacy derived index row ${rel}: ${errorMessage(err)}`);
             });
           }
-          if (getApiKey()) await reindexUpdatedLinks();
+          if (isEmbeddingConfigured()) await reindexUpdatedLinks();
           return 'Searchable text is being regenerated in the background.';
         }
-        if (!getApiKey()) {
+        if (!isEmbeddingConfigured()) {
           log.info(`rename: skipped index update for ${oldName} -> ${newName} because no embedding key is configured`);
           return 'AI Index was not updated because it is not set up.';
         }
@@ -138,7 +138,7 @@ export function mountFileMutationRoutes(app: express.Express): void {
       try { remapFileOrderPath(oldName, newName, 'file'); }
       catch (err: unknown) { log.warn(`file-order remap failed for ${oldName} -> ${newName}: ${errorMessage(err)}`); }
       const warning = viewerOnly ? null : contentSizeError(content ?? '');
-      const noKey = !getApiKey();
+      const noKey = !isEmbeddingConfigured();
       res.json({
         name: newName,
         linksUpdated: linkPlan.length,

--- a/server/routes/file-mutations.ts
+++ b/server/routes/file-mutations.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { isEmbeddingConfigured } from '../app-config.ts';
+import { isEmbeddingAvailable } from '../embedding-availability.ts';
 import { queueConvertibleSource } from '../conversion-dispatch.ts';
 import { clearRecord } from '../conversion-status.ts';
 import { deleteDerivedForSource } from '../derived-store.ts';
@@ -103,10 +103,10 @@ export function mountFileMutationRoutes(app: express.Express): void {
               log.warn(`rename: failed to remove legacy derived index row ${rel}: ${errorMessage(err)}`);
             });
           }
-          if (isEmbeddingConfigured()) await reindexUpdatedLinks();
+          if (isEmbeddingAvailable()) await reindexUpdatedLinks();
           return 'Searchable text is being regenerated in the background.';
         }
-        if (!isEmbeddingConfigured()) {
+        if (!isEmbeddingAvailable()) {
           log.info(`rename: skipped index update for ${oldName} -> ${newName} because no embedding key is configured`);
           return 'AI Index was not updated because it is not set up.';
         }
@@ -138,7 +138,7 @@ export function mountFileMutationRoutes(app: express.Express): void {
       try { remapFileOrderPath(oldName, newName, 'file'); }
       catch (err: unknown) { log.warn(`file-order remap failed for ${oldName} -> ${newName}: ${errorMessage(err)}`); }
       const warning = viewerOnly ? null : contentSizeError(content ?? '');
-      const noKey = !isEmbeddingConfigured();
+      const noKey = !isEmbeddingAvailable();
       res.json({
         name: newName,
         linksUpdated: linkPlan.length,

--- a/server/routes/folders.ts
+++ b/server/routes/folders.ts
@@ -17,7 +17,7 @@ import {
 } from '../files.ts';
 import { applyRenamePlan, planRenameLinks } from '../links.ts';
 import { toSourcePath } from '../folder.ts';
-import { isEmbeddingConfigured } from '../app-config.ts';
+import { isEmbeddingAvailable } from '../embedding-availability.ts';
 import { errorMessage, logger } from '../log.ts';
 import { indexer } from '../state.ts';
 import { sendError } from '../http.ts';
@@ -129,7 +129,7 @@ export function mount(app: express.Express): void {
             throw new Error(`failed to update links in ${applied.failed.map((f) => f.name).join(', ')}`);
           }
 
-          if (!isEmbeddingConfigured()) {
+          if (!isEmbeddingAvailable()) {
             log.info(`rename_folder: skipped index update for ${oldPath} -> ${newPath} because no embedding key is configured`);
             return;
           }

--- a/server/routes/folders.ts
+++ b/server/routes/folders.ts
@@ -17,7 +17,7 @@ import {
 } from '../files.ts';
 import { applyRenamePlan, planRenameLinks } from '../links.ts';
 import { toSourcePath } from '../folder.ts';
-import { getApiKey } from '../app-config.ts';
+import { isEmbeddingConfigured } from '../app-config.ts';
 import { errorMessage, logger } from '../log.ts';
 import { indexer } from '../state.ts';
 import { sendError } from '../http.ts';
@@ -129,7 +129,7 @@ export function mount(app: express.Express): void {
             throw new Error(`failed to update links in ${applied.failed.map((f) => f.name).join(', ')}`);
           }
 
-          if (!getApiKey()) {
+          if (!isEmbeddingConfigured()) {
             log.info(`rename_folder: skipped index update for ${oldPath} -> ${newPath} because no embedding key is configured`);
             return;
           }

--- a/server/routes/indexing.ts
+++ b/server/routes/indexing.ts
@@ -289,6 +289,12 @@ export function mount(app: express.Express): void {
         mode: 'semantic', query, topK, folderRoot, pathPrefix: prefixAbs, types,
       });
       if (result.availability.state === 'unavailable') {
+        if (result.availability.reason === 'hosted-quota-exhausted') {
+          return res.status(402).json({
+            error: 'Your hosted AI Index allowance is exhausted. Exact search is still available.',
+            code: 'HOSTED_QUOTA_EXHAUSTED',
+          });
+        }
         return res.status(412).json({
           error: 'AI Index is disabled until you set it up in StashBase Settings',
           code: 'EMBEDDER_KEY_REQUIRED',

--- a/server/routes/internal-shutdown.ts
+++ b/server/routes/internal-shutdown.ts
@@ -1,16 +1,9 @@
-import crypto from 'node:crypto';
 import express from 'express';
+import { processPrivateTokenMatches } from '../process-private-token.ts';
 
 interface InternalShutdownOptions {
   token: string;
   shutdown: () => void;
-}
-
-function tokenMatches(actual: string | undefined, expected: string): boolean {
-  if (!actual || !expected) return false;
-  const left = Buffer.from(actual);
-  const right = Buffer.from(expected);
-  return left.length === right.length && crypto.timingSafeEqual(left, right);
 }
 
 /** Process-private graceful-shutdown handshake for the Electron owner.
@@ -21,7 +14,7 @@ export function mountInternalShutdownRoute(
   { token, shutdown }: InternalShutdownOptions,
 ): void {
   app.post('/api/internal/shutdown', (req, res) => {
-    if (!tokenMatches(req.header('x-stashbase-shutdown-token'), token)) {
+    if (!processPrivateTokenMatches(req.header('x-stashbase-shutdown-token'), token)) {
       return res.status(403).json({ error: 'forbidden' });
     }
     res.status(202).json({ ok: true });

--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -24,7 +24,7 @@ import {
   sanitizeFilename,
 } from '../files.ts';
 import { isConvertibleSource, isNoteName } from '../format.ts';
-import { isEmbeddingConfigured } from '../app-config.ts';
+import { isEmbeddingAvailable } from '../embedding-availability.ts';
 import { normalizeFolderRelativePath } from '../folder-relative-path.ts';
 import { errorMessage, logger } from '../log.ts';
 import {
@@ -301,7 +301,7 @@ async function processUploadedFiles(
   if (out.some((x) => !x.error)) noteTreeChanged();
   res.json({ files: out });
   // Background indexing — don't await; the response has already been sent.
-  if (isEmbeddingConfigured()) {
+  if (isEmbeddingAvailable()) {
     (async () => {
       for (const { name, sourcePath, text } of toIndex) {
         try {
@@ -312,7 +312,7 @@ async function processUploadedFiles(
       }
     })();
   } else if (toIndex.length) {
-    log.info(`upload: skipped indexing ${toIndex.length} file(s) because no embedding key is configured`);
+    log.info(`upload: skipped indexing ${toIndex.length} file(s) because semantic embedding is unavailable`);
   }
   // Kick off conversions fire-and-forget. They handle their own async
   // failures internally; guard only against a synchronous throw at

--- a/server/routes/upload.ts
+++ b/server/routes/upload.ts
@@ -24,7 +24,7 @@ import {
   sanitizeFilename,
 } from '../files.ts';
 import { isConvertibleSource, isNoteName } from '../format.ts';
-import { getApiKey } from '../app-config.ts';
+import { isEmbeddingConfigured } from '../app-config.ts';
 import { normalizeFolderRelativePath } from '../folder-relative-path.ts';
 import { errorMessage, logger } from '../log.ts';
 import {
@@ -301,7 +301,7 @@ async function processUploadedFiles(
   if (out.some((x) => !x.error)) noteTreeChanged();
   res.json({ files: out });
   // Background indexing — don't await; the response has already been sent.
-  if (getApiKey()) {
+  if (isEmbeddingConfigured()) {
     (async () => {
       for (const { name, sourcePath, text } of toIndex) {
         try {

--- a/server/semantic-workload.test.ts
+++ b/server/semantic-workload.test.ts
@@ -380,6 +380,36 @@ test('actual reconcile skips semantic preflight entirely without a key', async (
   }
 });
 
+test('hosted quota exhaustion pauses a batch before another embedding request', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-quota-pause-'));
+  const first = path.join(root, 'first.md');
+  const second = path.join(root, 'second.md');
+  fs.writeFileSync(first, 'first');
+  fs.writeFileSync(second, 'second');
+  let available = true;
+  const upserts: string[] = [];
+  try {
+    const result = await syncIndex({
+      syncDiff: async () => ({ added: [first, second], modified: [], deleted: [], renamed: [] }),
+      listFiles: async () => ({}),
+      upsertFile: async (source: string) => {
+        upserts.push(source);
+        available = false;
+        throw new Error('hosted allowance exhausted');
+      },
+      status: async () => ({ pending: [first, second], total: 2, indexed: 0, pendingCount: 2, orphanedCount: 0, orphaned: [], upToDate: false }),
+    } as unknown as Indexer, root, {
+      semanticEnabled: true,
+      embeddingAvailable: () => available,
+    });
+    assert.deepEqual(upserts, [first]);
+    assert.equal(result.semanticPaused, true);
+    assert.equal(result.cancelled, undefined);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('actual no-op reconcile neither warns nor publishes a decision', async () => {
   let published = false;
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-noop-'));

--- a/server/shutdown-cleanup.ts
+++ b/server/shutdown-cleanup.ts
@@ -2,6 +2,7 @@
 export interface ShutdownCleanupOptions {
   closeMcp(): Promise<void>;
   cancelAgentInstalls(): Promise<string[]>;
+  closeHostedBroker(): Promise<void>;
   cancelModelDownloads(): Promise<string[]>;
   cancelConversions(): Promise<string[]>;
   closeStateDb(): void;
@@ -9,7 +10,7 @@ export interface ShutdownCleanupOptions {
   onCancelled?(paths: string[]): void;
   onModelDownloadsCancelled?(ids: string[]): void;
   onAgentInstallsCancelled?(ids: string[]): void;
-  onError(step: 'mcp-http' | 'agent-installs' | 'model-downloads' | 'conversions' | 'state-db' | 'indexer', error: unknown): void;
+  onError(step: 'mcp-http' | 'agent-installs' | 'hosted-broker' | 'model-downloads' | 'conversions' | 'state-db' | 'indexer', error: unknown): void;
 }
 
 export async function runShutdownCleanup(options: ShutdownCleanupOptions): Promise<void> {
@@ -24,6 +25,12 @@ export async function runShutdownCleanup(options: ShutdownCleanupOptions): Promi
     options.onAgentInstallsCancelled?.(cancelled);
   } catch (err: unknown) {
     options.onError('agent-installs', err);
+  }
+
+  try {
+    await options.closeHostedBroker();
+  } catch (err: unknown) {
+    options.onError('hosted-broker', err);
   }
 
   try {

--- a/server/state.ts
+++ b/server/state.ts
@@ -16,7 +16,8 @@ import { MfsIndexer } from './indexer.mfs.ts';
 import type { Indexer, EmbedderRuntimeConfig } from './indexer.ts';
 import { getCurrentFolder, getRecentFolders, onClose, onSwitch, runWithWindowId } from './folder.ts';
 import { filesystemPath } from './filesystem-path.ts';
-import { getEmbedderConfig } from './app-config.ts';
+import { getEmbeddingSource, getEmbedderConfig } from './app-config.ts';
+import { hostedEmbeddingRuntime } from './hosted-embedding-broker.ts';
 import { syncIndex, type SyncResult } from './sync.ts';
 import { getDaemon } from './mfs-daemon.ts';
 import { clearStaleMilvusLock } from './stale-lock.ts';
@@ -120,11 +121,12 @@ export function semanticSyncPolicy(folderRoot: string, forceEmbedding = false): 
   };
 }
 
-/** Resolve the runtime embedder config. Returns null
- *  when no API key is set — the caller still binds the folder (so it's
+/** Resolve the active runtime embedder config. Returns null
+ *  when neither account allowance nor BYOK is active — the caller still binds the folder (so it's
  *  registered) but indexing stays disabled until the user adds a key
  *  (graceful no-key degrade). */
 function resolveEmbedder(): EmbedderRuntimeConfig | null {
+  if (getEmbeddingSource() === 'stashbase-account') return hostedEmbeddingRuntime();
   const cfg = getEmbedderConfig();
   if (!cfg.apiKey) return null;
   return {
@@ -138,8 +140,8 @@ function resolveEmbedder(): EmbedderRuntimeConfig | null {
 
 /** Configure + spawn the daemon, then bind every folder in Your Folders.
  *  Idempotent on the bind side; safe to call once at server
- *  startup. With no API key, folders are still bound (registered) but the
- *  collection isn't created until a key is supplied — search just
+ *  startup. With no embedding source, folders are still bound (registered) but the
+ *  collection isn't created until one is supplied — semantic search just
  *  returns nothing until then. */
 function libraryFolderRoots(): string[] {
   // Membership = "Your Folders" (the recents list), which can live anywhere
@@ -162,7 +164,9 @@ export async function bootBindAllFolders(): Promise<void> {
     return;
   }
   log.info(`boot bind: ${roots.length} folder(s)`);
-  const cfg = resolveEmbedder() ?? { provider: getEmbedderConfig().provider };
+  const cfg = resolveEmbedder() ?? {
+    provider: getEmbeddingSource() === 'stashbase-account' ? 'stashbase' : getEmbedderConfig().provider,
+  };
   for (const root of roots) {
     try {
       await indexer.bindFolder(root, cfg);
@@ -210,7 +214,7 @@ function claimStaleLockSweep(storeRoot: string): boolean {
 
 /** Bind the indexer to a folder using the configured embedder. Called on
  *  every folder switch (idempotent). Doesn't trigger sync — caller's
- *  responsibility via `scheduleIndexerSync`. With no key the folder is
+ *  responsibility via `scheduleIndexerSync`. With no active source the folder is
  *  still bound but indexing is disabled. */
 export async function bindIndexerForFolder(folderAbs: string): Promise<void> {
   // Before the first bind of this process, sweep any stashbase daemon
@@ -227,9 +231,11 @@ export async function bindIndexerForFolder(folderAbs: string): Promise<void> {
     }
   }
   const cfg = resolveEmbedder();
-  const runtime = cfg ?? { provider: getEmbedderConfig().provider };
+  const runtime = cfg ?? {
+    provider: getEmbeddingSource() === 'stashbase-account' ? 'stashbase' : getEmbedderConfig().provider,
+  };
   if (!cfg) {
-    log.warn(`embedder: no embedding key set — ${folderAbs} bound but indexing/search disabled until a key is added`);
+    log.warn(`embedder: no embedding source active — ${folderAbs} bound but AI Index is disabled until an account or key is selected`);
   }
   await indexer.bindFolder(filesystemPath.absolute(folderAbs), runtime);
 }

--- a/server/state.ts
+++ b/server/state.ts
@@ -17,6 +17,7 @@ import type { Indexer, EmbedderRuntimeConfig } from './indexer.ts';
 import { getCurrentFolder, getRecentFolders, onClose, onSwitch, runWithWindowId } from './folder.ts';
 import { filesystemPath } from './filesystem-path.ts';
 import { getEmbeddingSource, getEmbedderConfig } from './app-config.ts';
+import { isEmbeddingAvailable } from './embedding-availability.ts';
 import { hostedEmbeddingRuntime } from './hosted-embedding-broker.ts';
 import { syncIndex, type SyncResult } from './sync.ts';
 import { getDaemon } from './mfs-daemon.ts';
@@ -121,11 +122,11 @@ export function semanticSyncPolicy(folderRoot: string, forceEmbedding = false): 
   };
 }
 
-/** Resolve the active runtime embedder config. Returns null
- *  when neither account allowance nor BYOK is active — the caller still binds the folder (so it's
- *  registered) but indexing stays disabled until the user adds a key
- *  (graceful no-key degrade). */
+/** Resolve the active runtime embedder config. Returns null when no source is
+ * configured or the hosted allowance is exhausted — the caller still binds
+ * the folder, while semantic work stays paused until availability returns. */
 function resolveEmbedder(): EmbedderRuntimeConfig | null {
+  if (!isEmbeddingAvailable()) return null;
   if (getEmbeddingSource() === 'stashbase-account') return hostedEmbeddingRuntime();
   const cfg = getEmbedderConfig();
   if (!cfg.apiKey) return null;
@@ -349,7 +350,7 @@ export async function runFolderSyncOperation(
       return result;
     }
     if (syncTouchedVisibleTree(result)) noteTreeChanged();
-    if (result.failed.length) {
+    if (result.failed.length && !result.semanticPaused) {
       recordIndexWarning(folderRoot, syncFailureMessage(result));
     } else {
       clearIndexWarning(folderRoot);

--- a/server/sync.ts
+++ b/server/sync.ts
@@ -351,18 +351,23 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
   }
 
   const removedDone: string[] = [...excludedRemoved];
+  const currentResult = (
+    added: string[] = [],
+    modified: string[] = [],
+    outcome: { cancelled?: true; semanticPaused?: true } = {},
+  ): SyncResult => ({
+    added: toFolderRelList(root, added),
+    modified: toFolderRelList(root, modified),
+    removed: toFolderRelList(root, removedDone),
+    renamed: toFolderRelList(root, renamedDone),
+    failed: toFolderRelFailures(root, failed),
+    ...outcome,
+  });
   if (deletedCandidates.length) {
     log.info(`removing ${deletedCandidates.length} stale file(s) from index`);
     for (const sourcePath of deletedCandidates) {
       if (shouldStop(opts)) {
-        return {
-          added: [],
-          modified: [],
-          removed: toFolderRelList(root, removedDone),
-          renamed: toFolderRelList(root, renamedDone),
-          failed: toFolderRelFailures(root, failed),
-          cancelled: true,
-        };
+        return currentResult([], [], { cancelled: true });
       }
       try {
         cleanupRemovedSource(sourcePath);
@@ -386,43 +391,29 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
       indexer, root, diff.modified, workload, failed, opts.publishPaused,
     );
     if (published) {
-      return {
-        added: [], modified: [], removed: toFolderRelList(root, removedDone),
-        renamed: toFolderRelList(root, renamedDone),
-        failed: toFolderRelFailures(root, failed), semanticPaused: true,
-      };
+      return currentResult([], [], { semanticPaused: true });
     }
   }
   if (!pauseRequested && opts.commitEmbedding && !opts.commitEmbedding()) {
     log.warn(`semantic decision could not be cleared for "${root}"; leaving indexing paused`);
-    return {
-      added: [], modified: [], removed: toFolderRelList(root, removedDone),
-      renamed: toFolderRelList(root, renamedDone),
-      failed: toFolderRelFailures(root, failed), semanticPaused: true,
-    };
+    return currentResult([], [], { semanticPaused: true });
   }
 
   const convertedAddedDone = await indexFreshConvertedSources(indexer, root, diff.added, failed, opts);
   if (convertedAddedDone.cancelled || convertedAddedDone.semanticPaused) {
-    return {
-      added: toFolderRelList(root, convertedAddedDone.done),
-      modified: [],
-      removed: toFolderRelList(root, removedDone),
-      renamed: toFolderRelList(root, renamedDone),
-      failed: toFolderRelFailures(root, failed),
-      ...(convertedAddedDone.cancelled ? { cancelled: true } : { semanticPaused: true }),
-    };
+    return currentResult(
+      convertedAddedDone.done,
+      [],
+      convertedAddedDone.cancelled ? { cancelled: true } : { semanticPaused: true },
+    );
   }
   const convertedModifiedDone = await indexFreshConvertedSources(indexer, root, diff.modified, failed, opts);
   if (convertedModifiedDone.cancelled || convertedModifiedDone.semanticPaused) {
-    return {
-      added: toFolderRelList(root, convertedAddedDone.done),
-      modified: toFolderRelList(root, convertedModifiedDone.done),
-      removed: toFolderRelList(root, removedDone),
-      renamed: toFolderRelList(root, renamedDone),
-      failed: toFolderRelFailures(root, failed),
-      ...(convertedModifiedDone.cancelled ? { cancelled: true } : { semanticPaused: true }),
-    };
+    return currentResult(
+      convertedAddedDone.done,
+      convertedModifiedDone.done,
+      convertedModifiedDone.cancelled ? { cancelled: true } : { semanticPaused: true },
+    );
   }
 
   const addedCandidates = syncIndexCandidates(root, diff.added);
@@ -438,53 +429,27 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
   const modifiedDone: string[] = [...convertedModifiedDone.done];
   for (const sourcePath of addedCandidates) {
     if (shouldStop(opts)) {
-      return {
-        added: toFolderRelList(root, addedDone),
-        modified: [],
-        removed: toFolderRelList(root, removedDone),
-        renamed: toFolderRelList(root, renamedDone),
-        failed: toFolderRelFailures(root, failed),
-        cancelled: true,
-      };
+      return currentResult(addedDone, [], { cancelled: true });
     }
     if (!canEmbed(opts)) {
-      return {
-        added: toFolderRelList(root, addedDone), modified: [],
-        removed: toFolderRelList(root, removedDone), renamed: toFolderRelList(root, renamedDone),
-        failed: toFolderRelFailures(root, failed), semanticPaused: true,
-      };
+      return currentResult(addedDone, [], { semanticPaused: true });
     }
     const chunks = await indexOne(indexer, root, sourcePath, failed);
     if (chunks > 0) addedDone.push(sourcePath);
   }
   for (const sourcePath of modifiedCandidates) {
     if (shouldStop(opts)) {
-      return {
-        added: toFolderRelList(root, addedDone),
-        modified: toFolderRelList(root, modifiedDone),
-        removed: toFolderRelList(root, removedDone),
-        renamed: toFolderRelList(root, renamedDone),
-        failed: toFolderRelFailures(root, failed),
-        cancelled: true,
-      };
+      return currentResult(addedDone, modifiedDone, { cancelled: true });
     }
     if (!canEmbed(opts)) {
-      return {
-        added: toFolderRelList(root, addedDone), modified: toFolderRelList(root, modifiedDone),
-        removed: toFolderRelList(root, removedDone), renamed: toFolderRelList(root, renamedDone),
-        failed: toFolderRelFailures(root, failed), semanticPaused: true,
-      };
+      return currentResult(addedDone, modifiedDone, { semanticPaused: true });
     }
     const chunks = await indexOne(indexer, root, sourcePath, failed);
     if (chunks > 0) modifiedDone.push(sourcePath);
   }
 
   if (!canEmbed(opts)) {
-    return {
-      added: toFolderRelList(root, addedDone), modified: toFolderRelList(root, modifiedDone),
-      removed: toFolderRelList(root, removedDone), renamed: toFolderRelList(root, renamedDone),
-      failed: toFolderRelFailures(root, failed), semanticPaused: true,
-    };
+    return currentResult(addedDone, modifiedDone, { semanticPaused: true });
   }
 
   log.info(
@@ -494,13 +459,7 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
       `removed=${removedDone.length}/${deletedCandidates.length + excludedRemoved.length} failed=${failed.length}`,
   );
   await assertSyncConverged(indexer, root, [...addedDone, ...modifiedDone, ...renamedDone]);
-  return {
-    added: toFolderRelList(root, addedDone),
-    modified: toFolderRelList(root, modifiedDone),
-    removed: toFolderRelList(root, removedDone),
-    renamed: toFolderRelList(root, renamedDone),
-    failed: toFolderRelFailures(root, failed),
-  };
+  return currentResult(addedDone, modifiedDone);
 }
 
 async function indexFreshConvertedSources(

--- a/server/sync.ts
+++ b/server/sync.ts
@@ -20,6 +20,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { discoverConvertibleSources, indexFreshConvertibleSource } from './conversion-dispatch.ts';
 import { isEmbeddingConfigured } from './app-config.ts';
+import { isEmbeddingAvailable } from './embedding-availability.ts';
 import type { Indexer } from './indexer.ts';
 import { logger, errorMessage } from './log.ts';
 import { hasNoExtractableText, indexableFileSizeError, shouldIndexFilePath } from './indexable.ts';
@@ -117,6 +118,9 @@ export interface SyncOptions {
   commitEmbedding?: () => boolean;
   /** Test seam; production derives this exclusively from Settings. */
   semanticEnabled?: boolean;
+  /** Live gate checked before and between embedding calls. Production uses
+   * the hosted allowance cache so a 402 stops the remainder of the batch. */
+  embeddingAvailable?: () => boolean;
 }
 
 /** Transactional pause transition. Known-stale rows are invalidated before
@@ -152,6 +156,12 @@ function emptyResult(cancelled = false): SyncResult {
 
 function shouldStop(opts: SyncOptions | undefined): boolean {
   return opts?.shouldContinue ? !opts.shouldContinue() : false;
+}
+
+function canEmbed(opts: SyncOptions): boolean {
+  if (opts.embeddingAvailable) return opts.embeddingAvailable();
+  if (opts.semanticEnabled !== undefined) return opts.semanticEnabled;
+  return isEmbeddingAvailable();
 }
 
 function toFolderRelList(root: string, paths: string[]): string[] {
@@ -258,6 +268,13 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
     discoverConvertedSources(root);
     log.info(`no embedding source — skipping semantic index for "${root}" (conversion + keyword search unaffected)`);
     return emptyResult();
+  }
+
+  if (!canEmbed(opts)) {
+    cleanupMissingConvertedSources(root);
+    discoverConvertedSources(root);
+    log.info(`semantic embedding is paused for "${root}" (conversion + keyword search unaffected)`);
+    return { ...emptyResult(), semanticPaused: true };
   }
 
   if (shouldStop(opts)) return emptyResult(true);
@@ -386,25 +403,25 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
   }
 
   const convertedAddedDone = await indexFreshConvertedSources(indexer, root, diff.added, failed, opts);
-  if (convertedAddedDone.cancelled) {
+  if (convertedAddedDone.cancelled || convertedAddedDone.semanticPaused) {
     return {
       added: toFolderRelList(root, convertedAddedDone.done),
       modified: [],
       removed: toFolderRelList(root, removedDone),
       renamed: toFolderRelList(root, renamedDone),
       failed: toFolderRelFailures(root, failed),
-      cancelled: true,
+      ...(convertedAddedDone.cancelled ? { cancelled: true } : { semanticPaused: true }),
     };
   }
   const convertedModifiedDone = await indexFreshConvertedSources(indexer, root, diff.modified, failed, opts);
-  if (convertedModifiedDone.cancelled) {
+  if (convertedModifiedDone.cancelled || convertedModifiedDone.semanticPaused) {
     return {
       added: toFolderRelList(root, convertedAddedDone.done),
       modified: toFolderRelList(root, convertedModifiedDone.done),
       removed: toFolderRelList(root, removedDone),
       renamed: toFolderRelList(root, renamedDone),
       failed: toFolderRelFailures(root, failed),
-      cancelled: true,
+      ...(convertedModifiedDone.cancelled ? { cancelled: true } : { semanticPaused: true }),
     };
   }
 
@@ -430,6 +447,13 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
         cancelled: true,
       };
     }
+    if (!canEmbed(opts)) {
+      return {
+        added: toFolderRelList(root, addedDone), modified: [],
+        removed: toFolderRelList(root, removedDone), renamed: toFolderRelList(root, renamedDone),
+        failed: toFolderRelFailures(root, failed), semanticPaused: true,
+      };
+    }
     const chunks = await indexOne(indexer, root, sourcePath, failed);
     if (chunks > 0) addedDone.push(sourcePath);
   }
@@ -444,8 +468,23 @@ export async function syncIndex(indexer: Indexer, root: string, opts: SyncOption
         cancelled: true,
       };
     }
+    if (!canEmbed(opts)) {
+      return {
+        added: toFolderRelList(root, addedDone), modified: toFolderRelList(root, modifiedDone),
+        removed: toFolderRelList(root, removedDone), renamed: toFolderRelList(root, renamedDone),
+        failed: toFolderRelFailures(root, failed), semanticPaused: true,
+      };
+    }
     const chunks = await indexOne(indexer, root, sourcePath, failed);
     if (chunks > 0) modifiedDone.push(sourcePath);
+  }
+
+  if (!canEmbed(opts)) {
+    return {
+      added: toFolderRelList(root, addedDone), modified: toFolderRelList(root, modifiedDone),
+      removed: toFolderRelList(root, removedDone), renamed: toFolderRelList(root, renamedDone),
+      failed: toFolderRelFailures(root, failed), semanticPaused: true,
+    };
   }
 
   log.info(
@@ -470,10 +509,11 @@ async function indexFreshConvertedSources(
   paths: string[],
   failed: { name: string; error: string }[],
   opts: SyncOptions,
-): Promise<{ done: string[]; cancelled: boolean }> {
+): Promise<{ done: string[]; cancelled: boolean; semanticPaused?: boolean }> {
   const done: string[] = [];
   for (const sourcePath of paths) {
     if (shouldStop(opts)) return { done, cancelled: true };
+    if (!canEmbed(opts)) return { done, cancelled: false, semanticPaused: true };
     const folderRel = folderRelOf(root, sourcePath);
     if (folderRel == null || !isConvertibleSource(folderRel)) continue;
     try {
@@ -483,6 +523,7 @@ async function indexFreshConvertedSources(
       failed.push({ name: sourcePath, error: errorMessage(err) });
     }
   }
+  if (!canEmbed(opts)) return { done, cancelled: false, semanticPaused: true };
   return { done, cancelled: false };
 }
 

--- a/server/sync.ts
+++ b/server/sync.ts
@@ -19,7 +19,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { discoverConvertibleSources, indexFreshConvertibleSource } from './conversion-dispatch.ts';
-import { getApiKey } from './app-config.ts';
+import { isEmbeddingConfigured } from './app-config.ts';
 import type { Indexer } from './indexer.ts';
 import { logger, errorMessage } from './log.ts';
 import { hasNoExtractableText, indexableFileSizeError, shouldIndexFilePath } from './indexable.ts';
@@ -247,16 +247,16 @@ async function cleanupConvertedRename(
 export async function syncIndex(indexer: Indexer, root: string, opts: SyncOptions = {}): Promise<SyncResult> {
   if (shouldStop(opts)) return emptyResult(true);
 
-  // No embedding key → semantic indexing is disabled by design (§5.3): the
+  // No active embedding source → semantic indexing is disabled by design (§5.3): the
   // daemon has no embedder/store, so every upsert would throw "no bound
-  // root … set an embedding API key" and a whole-folder import would flood
+  // root … set an embedding source" and a whole-folder import would flood
   // the log with one failure per file. Conversion discovery still
   // runs so PDFs/images can produce AppData derived text for keyword search
     // and future reindex.
-  if (!(opts.semanticEnabled ?? !!getApiKey())) {
+  if (!(opts.semanticEnabled ?? isEmbeddingConfigured())) {
     cleanupMissingConvertedSources(root);
     discoverConvertedSources(root);
-    log.info(`no embedding key — skipping semantic index for "${root}" (conversion + keyword search unaffected)`);
+    log.info(`no embedding source — skipping semantic index for "${root}" (conversion + keyword search unaffected)`);
     return emptyResult();
   }
 

--- a/web-src/src/__tests__/account-sign-in.test.ts
+++ b/web-src/src/__tests__/account-sign-in.test.ts
@@ -64,7 +64,7 @@ test('account Sign in immediately opens one Supabase Google OAuth flow without a
   }
 });
 
-test('completed browser sign-in returns focus to the initiating StashBase window', async () => {
+test('completed browser sign-in leaves native return to the authenticated callback deep link', async () => {
   let focusRequests = 0;
   let signedInEmail: string | undefined;
   const originalWindow = globalThis.window;
@@ -122,7 +122,7 @@ test('completed browser sign-in returns focus to the initiating StashBase window
       await new Promise<void>((resolve) => setImmediate(resolve));
     });
 
-    assert.equal(focusRequests, 1);
+    assert.equal(focusRequests, 0);
     assert.equal(signedInEmail, 'person@example.com');
   } finally {
     if (renderer) await act(async () => renderer?.unmount());

--- a/web-src/src/__tests__/account-sign-in.test.ts
+++ b/web-src/src/__tests__/account-sign-in.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React, { createElement, StrictMode } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { AccountSignInForm } from '../components/account/AccountSignInForm';
+
+(globalThis as { React?: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+test('account Sign in immediately opens one Supabase Google OAuth flow without an email form', async () => {
+  const requests: Array<{ url: string; method: string }> = [];
+  const opened: string[] = [];
+  const storage = new Map<string, string>();
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+
+  Object.assign(globalThis, {
+    window: {
+      electron: undefined,
+      sessionStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      open: (url: string) => { opened.push(url); },
+      setTimeout: (callback: () => void) => setTimeout(callback, 0),
+      clearTimeout,
+    },
+    fetch: async (input: string | URL | Request, init: RequestInit = {}) => {
+      const url = String(input);
+      requests.push({ url, method: init.method ?? 'GET' });
+      if (url === '/api/account/oauth/start') {
+        return Response.json({
+          flowId: 'flow-1',
+          url: 'https://example.supabase.co/auth/v1/authorize?provider=google',
+        });
+      }
+      if (url === '/api/account/oauth/status?flow=flow-1') {
+        return Response.json({ state: 'error', error: 'Test flow finished.' });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    },
+  });
+
+  const mounted: { renderer?: ReactTestRenderer } = {};
+  try {
+    await act(async () => {
+      mounted.renderer = create(createElement(
+        StrictMode,
+        null,
+        createElement(AccountSignInForm, { onSignedIn: () => undefined }),
+      ));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    });
+
+    assert.equal(requests[0]?.url, '/api/account/oauth/start');
+    assert.equal(requests[0]?.method, 'POST');
+    assert.equal(requests.filter((request) => request.url === '/api/account/oauth/start').length, 1);
+    assert.deepEqual(opened, ['https://example.supabase.co/auth/v1/authorize?provider=google']);
+    assert.equal(mounted.renderer!.root.findAll((node) => node.type === 'input').length, 0);
+    assert.match(JSON.stringify(mounted.renderer!.toJSON()), /Finish signing in with Google/);
+  } finally {
+    if (mounted.renderer) await act(async () => mounted.renderer?.unmount());
+    Object.assign(globalThis, { window: originalWindow, fetch: originalFetch });
+  }
+});
+
+test('completed browser sign-in returns focus to the initiating StashBase window', async () => {
+  let focusRequests = 0;
+  let signedInEmail: string | undefined;
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+  const originalCustomEvent = globalThis.CustomEvent;
+
+  Object.assign(globalThis, {
+    CustomEvent: class TestCustomEvent {
+      constructor(public type: string) {}
+    },
+    window: {
+      electron: {
+        focusWindow: async () => {
+          focusRequests += 1;
+          return true;
+        },
+      },
+      sessionStorage: {
+        getItem: () => null,
+        setItem: () => undefined,
+      },
+      open: () => undefined,
+      setTimeout: (callback: () => void) => setTimeout(callback, 0),
+      clearTimeout,
+      dispatchEvent: () => true,
+    },
+    fetch: async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === '/api/account/oauth/start') {
+        return Response.json({
+          flowId: 'flow-complete',
+          url: 'https://example.supabase.co/auth/v1/authorize?provider=google',
+        });
+      }
+      if (url === '/api/account/oauth/status?flow=flow-complete') {
+        return Response.json({ state: 'complete' });
+      }
+      if (url === '/api/account?refresh=1') {
+        return Response.json({
+          signedIn: true,
+          active: true,
+          email: 'person@example.com',
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    },
+  });
+
+  let renderer: ReactTestRenderer | undefined;
+  try {
+    await act(async () => {
+      renderer = create(createElement(AccountSignInForm, {
+        onSignedIn: (account) => { signedInEmail = account.email; },
+      }));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    });
+
+    assert.equal(focusRequests, 1);
+    assert.equal(signedInEmail, 'person@example.com');
+  } finally {
+    if (renderer) await act(async () => renderer?.unmount());
+    Object.assign(globalThis, {
+      window: originalWindow,
+      fetch: originalFetch,
+      CustomEvent: originalCustomEvent,
+    });
+  }
+});

--- a/web-src/src/__tests__/account-sign-in.test.ts
+++ b/web-src/src/__tests__/account-sign-in.test.ts
@@ -49,7 +49,10 @@ test('account Sign in immediately opens one Supabase Google OAuth flow without a
         null,
         createElement(AccountSignInForm, { onSignedIn: () => undefined }),
       ));
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      for (let attempt = 0; attempt < 10; attempt += 1) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        if (JSON.stringify(mounted.renderer?.toJSON()).includes('Test flow finished.')) break;
+      }
     });
 
     assert.equal(requests[0]?.url, '/api/account/oauth/start');
@@ -65,7 +68,6 @@ test('account Sign in immediately opens one Supabase Google OAuth flow without a
 });
 
 test('completed browser sign-in leaves native return to the authenticated callback deep link', async () => {
-  let focusRequests = 0;
   let signedInEmail: string | undefined;
   const originalWindow = globalThis.window;
   const originalFetch = globalThis.fetch;
@@ -76,12 +78,7 @@ test('completed browser sign-in leaves native return to the authenticated callba
       constructor(public type: string) {}
     },
     window: {
-      electron: {
-        focusWindow: async () => {
-          focusRequests += 1;
-          return true;
-        },
-      },
+      electron: {},
       sessionStorage: {
         getItem: () => null,
         setItem: () => undefined,
@@ -119,10 +116,11 @@ test('completed browser sign-in leaves native return to the authenticated callba
       renderer = create(createElement(AccountSignInForm, {
         onSignedIn: (account) => { signedInEmail = account.email; },
       }));
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      for (let attempt = 0; attempt < 10 && !signedInEmail; attempt += 1) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
     });
 
-    assert.equal(focusRequests, 0);
     assert.equal(signedInEmail, 'person@example.com');
   } finally {
     if (renderer) await act(async () => renderer?.unmount());

--- a/web-src/src/__tests__/account-sign-in.test.ts
+++ b/web-src/src/__tests__/account-sign-in.test.ts
@@ -7,6 +7,16 @@ import { AccountSignInForm } from '../components/account/AccountSignInForm';
 (globalThis as { React?: typeof React }).React = React;
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
+async function waitUntil(predicate: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) assert.fail(message);
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 1));
+    });
+  }
+}
+
 test('account Sign in immediately opens one Supabase Google OAuth flow without an email form', async () => {
   const requests: Array<{ url: string; method: string }> = [];
   const opened: string[] = [];
@@ -49,11 +59,11 @@ test('account Sign in immediately opens one Supabase Google OAuth flow without a
         null,
         createElement(AccountSignInForm, { onSignedIn: () => undefined }),
       ));
-      for (let attempt = 0; attempt < 10; attempt += 1) {
-        await new Promise<void>((resolve) => setImmediate(resolve));
-        if (JSON.stringify(mounted.renderer?.toJSON()).includes('Test flow finished.')) break;
-      }
     });
+    await waitUntil(
+      () => JSON.stringify(mounted.renderer?.toJSON()).includes('Test flow finished.'),
+      'sign-in error did not settle',
+    );
 
     assert.equal(requests[0]?.url, '/api/account/oauth/start');
     assert.equal(requests[0]?.method, 'POST');
@@ -61,6 +71,7 @@ test('account Sign in immediately opens one Supabase Google OAuth flow without a
     assert.deepEqual(opened, ['https://example.supabase.co/auth/v1/authorize?provider=google']);
     assert.equal(mounted.renderer!.root.findAll((node) => node.type === 'input').length, 0);
     assert.match(JSON.stringify(mounted.renderer!.toJSON()), /Finish signing in with Google/);
+    assert.match(JSON.stringify(mounted.renderer!.toJSON()), /Test flow finished\./);
   } finally {
     if (mounted.renderer) await act(async () => mounted.renderer?.unmount());
     Object.assign(globalThis, { window: originalWindow, fetch: originalFetch });
@@ -116,10 +127,8 @@ test('completed browser sign-in leaves native return to the authenticated callba
       renderer = create(createElement(AccountSignInForm, {
         onSignedIn: (account) => { signedInEmail = account.email; },
       }));
-      for (let attempt = 0; attempt < 10 && !signedInEmail; attempt += 1) {
-        await new Promise<void>((resolve) => setImmediate(resolve));
-      }
     });
+    await waitUntil(() => signedInEmail !== undefined, 'completed sign-in did not settle');
 
     assert.equal(signedInEmail, 'person@example.com');
   } finally {

--- a/web-src/src/__tests__/embedding-auth.test.ts
+++ b/web-src/src/__tests__/embedding-auth.test.ts
@@ -1,10 +1,23 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import type { EmbedderState } from '../api';
 import {
   hasSkippedAiIndexing,
   isEmbeddingAuthorized,
   setAiIndexingSkipped,
 } from '../components/embedder/embeddingAuth';
+
+function state(patch: Partial<EmbedderState>): EmbedderState {
+  return {
+    provider: 'openai',
+    hasKey: false,
+    authorized: false,
+    source: 'openai',
+    model: 'text-embedding-3-small',
+    account: { signedIn: false, active: false },
+    ...patch,
+  };
+}
 
 test('the AI Index skip is per folder: another folder re-offers, activation clears all', () => {
   assert.equal(hasSkippedAiIndexing('/work/alpha'), false);
@@ -28,8 +41,9 @@ test('the AI Index skip is per folder: another folder re-offers, activation clea
   assert.equal(hasSkippedAiIndexing('/work/beta'), false);
 });
 
-test('authorization is the stored key, not login state', () => {
+test('AI Index authorization accepts either hosted account or BYOK source', () => {
   assert.equal(isEmbeddingAuthorized(null), false);
-  assert.equal(isEmbeddingAuthorized({ hasKey: false } as never), false);
-  assert.equal(isEmbeddingAuthorized({ hasKey: true } as never), true);
+  assert.equal(isEmbeddingAuthorized(state({ authorized: true, source: 'stashbase-account' })), true);
+  assert.equal(isEmbeddingAuthorized(state({ authorized: true, source: 'openrouter', hasKey: true })), true);
+  assert.equal(isEmbeddingAuthorized(state({ authorized: false, source: 'stashbase-account' })), false);
 });

--- a/web-src/src/__tests__/hosted-quota.test.ts
+++ b/web-src/src/__tests__/hosted-quota.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { hostedQuotaRemainingPercent, hostedQuotaResetLabel } from '../lib/hostedQuota.ts';
+
+const quota = {
+  plan: 'free',
+  grantedTokens: 1_000_000,
+  usedTokens: 80_000,
+  reservedTokens: 0,
+  remainingTokens: 920_000,
+  periodStartedAt: '2026-08-01T00:00:00.000Z',
+  periodEndsAt: '2026-09-01T00:00:00.000Z',
+};
+
+test('hosted quota presentation shares bounded percentage and reset formatting', () => {
+  assert.equal(hostedQuotaRemainingPercent(quota), 92);
+  assert.equal(hostedQuotaRemainingPercent({ ...quota, remainingTokens: 2_000_000 }), 100);
+  assert.equal(hostedQuotaRemainingPercent({ ...quota, remainingTokens: -1 }), 0);
+  assert.match(hostedQuotaResetLabel(quota), /^Resets /);
+  assert.equal(hostedQuotaResetLabel({ ...quota, periodEndsAt: null }), '');
+});

--- a/web-src/src/accountEvents.ts
+++ b/web-src/src/accountEvents.ts
@@ -1,0 +1,5 @@
+export const ACCOUNT_CHANGED_EVENT = 'stashbase-account-changed';
+
+export function notifyAccountChanged(): void {
+  window.dispatchEvent(new CustomEvent(ACCOUNT_CHANGED_EVENT));
+}

--- a/web-src/src/accountOAuth.ts
+++ b/web-src/src/accountOAuth.ts
@@ -1,0 +1,60 @@
+import { api, type HostedAccountState, type HostedOAuthProvider } from './api';
+import { notifyAccountChanged } from './accountEvents';
+import { electronBridge } from './electronBridge';
+import { openExternalUrl } from './lib/externalLink';
+
+const OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
+const OAUTH_POLL_MS = 750;
+
+function wait(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => {
+      window.clearTimeout(timer);
+      reject(signal.reason ?? new DOMException('Sign-in cancelled.', 'AbortError'));
+    }, { once: true });
+  });
+}
+
+/**
+ * Start a Node-owned Supabase PKCE flow, open the system browser, then poll
+ * only the safe local flow status. Supabase tokens never enter the renderer.
+ */
+async function runSignIn(
+  provider: HostedOAuthProvider = 'google',
+  options: { signal?: AbortSignal; onBrowserOpened?: () => void } = {},
+): Promise<HostedAccountState> {
+  const started = await api.startAccountOAuth(provider);
+  openExternalUrl(started.url);
+  options.onBrowserOpened?.();
+
+  const deadline = Date.now() + OAUTH_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await wait(OAUTH_POLL_MS, options.signal);
+    const status = await api.getAccountOAuthStatus(started.flowId);
+    if (status.state === 'error') throw new Error(status.error ?? 'Sign-in failed.');
+    if (status.state !== 'complete') continue;
+    const account = await api.getAccount(true);
+    if (!account.signedIn) throw new Error('Sign-in completed, but the local session is unavailable.');
+    try {
+      await electronBridge()?.focusWindow?.();
+    } catch {
+      // The browser callback page remains the fallback when native focus is
+      // unavailable (browser dev shell, a closing window, or OS refusal).
+    }
+    notifyAccountChanged();
+    return account;
+  }
+  throw new Error('Sign-in timed out. Start again from StashBase.');
+}
+
+let activeSignIn: Promise<HostedAccountState> | null = null;
+
+export function signInWithStashBase(
+  provider: HostedOAuthProvider = 'google',
+  options: { signal?: AbortSignal; onBrowserOpened?: () => void } = {},
+): Promise<HostedAccountState> {
+  if (activeSignIn) return activeSignIn;
+  activeSignIn = runSignIn(provider, options).finally(() => { activeSignIn = null; });
+  return activeSignIn;
+}

--- a/web-src/src/accountOAuth.ts
+++ b/web-src/src/accountOAuth.ts
@@ -1,6 +1,5 @@
 import { api, type HostedAccountState, type HostedOAuthProvider } from './api';
 import { notifyAccountChanged } from './accountEvents';
-import { electronBridge } from './electronBridge';
 import { openExternalUrl } from './lib/externalLink';
 
 const OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
@@ -36,12 +35,9 @@ async function runSignIn(
     if (status.state !== 'complete') continue;
     const account = await api.getAccount(true);
     if (!account.signedIn) throw new Error('Sign-in completed, but the local session is unavailable.');
-    try {
-      await electronBridge()?.focusWindow?.();
-    } catch {
-      // The browser callback page remains the fallback when native focus is
-      // unavailable (browser dev shell, a closing window, or OS refusal).
-    }
+    // The authenticated callback deep link owns native focus and sends the
+    // acknowledgement that lets its browser tab close. Renderer polling only
+    // updates account state; focusing here races that handoff.
     notifyAccountChanged();
     return account;
   }

--- a/web-src/src/api.ts
+++ b/web-src/src/api.ts
@@ -11,6 +11,9 @@ import type {
   EmbedderState,
   EmbedderProvider,
   HostedAccountState,
+  HostedOAuthProvider,
+  HostedOAuthStart,
+  HostedOAuthStatus,
   FileBody,
   FilesPayload,
   FolderState,
@@ -278,9 +281,10 @@ export const api = {
   useApiKeySource: (provider: EmbedderProvider) =>
     send<EmbedderState>('PUT', '/api/embedder/source', { provider }),
   getAccount: (refresh = false) => getJson<HostedAccountState>(`/api/account${refresh ? '?refresh=1' : ''}`),
-  requestAccountOtp: (email: string) => send<{ ok: true }>('POST', '/api/account/otp', { email }),
-  verifyAccountOtp: (email: string, token: string) =>
-    send<HostedAccountState>('POST', '/api/account/verify', { email, token }),
+  startAccountOAuth: (provider: HostedOAuthProvider = 'google') =>
+    send<HostedOAuthStart>('POST', '/api/account/oauth/start', { provider }),
+  getAccountOAuthStatus: (flowId: string) =>
+    getJson<HostedOAuthStatus>(`/api/account/oauth/status?flow=${encodeURIComponent(flowId)}`),
   useAccountAllowance: () => send<HostedAccountState>('PUT', '/api/account/source'),
   signOutAccount: () => send<HostedAccountState>('DELETE', '/api/account'),
 

--- a/web-src/src/api.ts
+++ b/web-src/src/api.ts
@@ -10,6 +10,7 @@ import type {
   ApiKeySaveResult,
   EmbedderState,
   EmbedderProvider,
+  HostedAccountState,
   FileBody,
   FilesPayload,
   FolderState,
@@ -274,6 +275,14 @@ export const api = {
     send<{ ok: true }>('DELETE', `/api/transcription/models/${encodeURIComponent(id)}`),
   // Embedder ----------------------------------------------------
   getEmbedder: () => getJson<EmbedderState>('/api/embedder'),
+  useApiKeySource: (provider: EmbedderProvider) =>
+    send<EmbedderState>('PUT', '/api/embedder/source', { provider }),
+  getAccount: (refresh = false) => getJson<HostedAccountState>(`/api/account${refresh ? '?refresh=1' : ''}`),
+  requestAccountOtp: (email: string) => send<{ ok: true }>('POST', '/api/account/otp', { email }),
+  verifyAccountOtp: (email: string, token: string) =>
+    send<HostedAccountState>('POST', '/api/account/verify', { email, token }),
+  useAccountAllowance: () => send<HostedAccountState>('PUT', '/api/account/source'),
+  signOutAccount: () => send<HostedAccountState>('DELETE', '/api/account'),
 
   // Agents (chat-panel CLIs) -----------------------------------
   // Server routes stay under `/api/terminal/*` for historical reasons;

--- a/web-src/src/apiTypes.ts
+++ b/web-src/src/apiTypes.ts
@@ -314,6 +314,19 @@ export interface HostedAccountState {
   backfillStarted?: boolean;
 }
 
+export type HostedOAuthProvider = 'google' | 'github';
+
+export interface HostedOAuthStart {
+  flowId: string;
+  provider: HostedOAuthProvider;
+  url: string;
+}
+
+export interface HostedOAuthStatus {
+  state: 'pending' | 'complete' | 'error';
+  error?: string;
+}
+
 export interface EmbedderState {
   provider: EmbedderProvider;
   hasKey: boolean;

--- a/web-src/src/apiTypes.ts
+++ b/web-src/src/apiTypes.ts
@@ -142,6 +142,8 @@ export interface IndexStatus {
   upToDate: boolean;
   /** False when semantic indexing/retrieval is unavailable, e.g. no embedding key. */
   semanticEnabled?: boolean;
+  /** False while a configured hosted source is blocked by its shared quota. */
+  semanticAvailable?: boolean;
   /** Human-readable reason when semantic indexing/retrieval is disabled. */
   semanticDisabledReason?: string;
   /** True when no UI-visible file is waiting for embedding. Unlike
@@ -149,7 +151,7 @@ export interface IndexStatus {
    *  relevant to search-readiness accounting. */
   visibleIndexingSettled?: boolean;
   semanticIndexing?: {
-    state: 'disabled' | 'awaiting-decision' | 'paused' | 'partial-paused' | 'indexing' | 'partial-indexing' | 'ready' | 'failed';
+    state: 'disabled' | 'quota-exhausted' | 'partial-quota-exhausted' | 'awaiting-decision' | 'paused' | 'partial-paused' | 'indexing' | 'partial-indexing' | 'ready' | 'failed';
     sourceCount?: number;
     estimatedBytes?: number;
   };
@@ -307,14 +309,13 @@ export interface HostedQuota {
 export interface HostedAccountState {
   signedIn: boolean;
   active: boolean;
-  userId?: string;
   email?: string;
   quota?: HostedQuota;
   quotaUnavailable?: boolean;
   backfillStarted?: boolean;
 }
 
-export type HostedOAuthProvider = 'google' | 'github';
+export type HostedOAuthProvider = 'google';
 
 export interface HostedOAuthStart {
   flowId: string;
@@ -325,6 +326,7 @@ export interface HostedOAuthStart {
 export interface HostedOAuthStatus {
   state: 'pending' | 'complete' | 'error';
   error?: string;
+  appReturned?: boolean;
 }
 
 export interface EmbedderState {

--- a/web-src/src/apiTypes.ts
+++ b/web-src/src/apiTypes.ts
@@ -292,11 +292,35 @@ export interface LibraryKeywordSearchResult {
 }
 
 export type EmbedderProvider = 'openai' | 'openrouter';
+export type EmbeddingSource = EmbedderProvider | 'stashbase-account';
+
+export interface HostedQuota {
+  plan: string;
+  grantedTokens: number;
+  usedTokens: number;
+  reservedTokens: number;
+  remainingTokens: number;
+  periodStartedAt: string | null;
+  periodEndsAt: string | null;
+}
+
+export interface HostedAccountState {
+  signedIn: boolean;
+  active: boolean;
+  userId?: string;
+  email?: string;
+  quota?: HostedQuota;
+  quotaUnavailable?: boolean;
+  backfillStarted?: boolean;
+}
 
 export interface EmbedderState {
   provider: EmbedderProvider;
   hasKey: boolean;
+  authorized: boolean;
+  source: EmbeddingSource;
   model: string;
+  account: HostedAccountState;
 }
 
 export interface McpHttpStatus {

--- a/web-src/src/components/EmbedderRequireKeyGate.tsx
+++ b/web-src/src/components/EmbedderRequireKeyGate.tsx
@@ -34,6 +34,7 @@ import { hasSkippedAiIndexing, isEmbeddingAuthorized, setAiIndexingSkipped } fro
 import { lazyWithRetry } from './ErrorBoundary';
 import { useOverlayLayer } from './OverlayStack';
 import { ModalLoadingStatus } from './ui/status';
+import { ACCOUNT_CHANGED_EVENT } from '../accountEvents';
 
 const RequireApiKeyModal = lazyWithRetry(() =>
   import('./embedder/RequireApiKeyModal').then((mod) => ({ default: mod.RequireApiKeyModal })),
@@ -53,6 +54,7 @@ export function EmbedderRequireKeyGate() {
   const folder = appState.folder;
   const [state, setState] = useState<EmbedderState | null>(null);
   const [open, setOpen] = useState(false);
+  const [authRevision, setAuthRevision] = useState(0);
   const layer = useOverlayLayer(open);
 
   useEffect(() => {
@@ -64,7 +66,7 @@ export function EmbedderRequireKeyGate() {
       .then((embedder) => {
         if (cancelled) return;
         setState(embedder);
-        dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: embedder.hasKey });
+        dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: embedder.authorized });
         // Recommend, don't force. Auto-open only with a folder open — the
         // dialog is a folder-context prompt; without one the standing callout
         // carries the offer. The skip is per folder within the window (see
@@ -77,7 +79,13 @@ export function EmbedderRequireKeyGate() {
     // embedderHasKey: removing the key in Settings must re-gate right away
     // ("removing a key later re-gates cleanly"), not wait for the next
     // folder switch to refire this effect.
-  }, [folder, appState.embedderHasKey]);
+  }, [folder, appState.embedderHasKey, authRevision]);
+
+  useEffect(() => {
+    const onChanged = () => setAuthRevision((value) => value + 1);
+    window.addEventListener(ACCOUNT_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(ACCOUNT_CHANGED_EVENT, onChanged);
+  }, []);
 
   useEffect(() => {
     function onOpen() { setOpen(true); }
@@ -93,13 +101,26 @@ export function EmbedderRequireKeyGate() {
         initialProvider={state?.provider}
         isTopmost={layer.isTopmost}
         onSaved={(provider, model, backfillStarted, warning) => {
-          setState((s) => (s ? { ...s, provider, model, hasKey: true } : s));
+          setState((s) => (s ? { ...s, provider, model, hasKey: true, authorized: true, source: provider } : s));
           dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: true });
           // Activated: clear any prior basic-mode choice so a future key
           // removal re-gates from a clean state instead of staying skipped.
           setAiIndexingSkipped(false, folder);
           setOpen(false);
           if (warning) actions.toast(`API key saved, but validation could not reach the provider: ${warning}`, { level: 'warning' });
+          if (backfillStarted) void actions.markVisibleFilesPendingForSearch();
+          void actions.refreshIndexState();
+        }}
+        onSignedIn={(backfillStarted) => {
+          setState((s) => (s ? {
+            ...s,
+            authorized: true,
+            source: 'stashbase-account',
+            account: { ...s.account, signedIn: true, active: true },
+          } : s));
+          dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: true });
+          setAiIndexingSkipped(false, folder);
+          setOpen(false);
           if (backfillStarted) void actions.markVisibleFilesPendingForSearch();
           void actions.refreshIndexState();
         }}

--- a/web-src/src/components/EmbeddingSetupCallout.tsx
+++ b/web-src/src/components/EmbeddingSetupCallout.tsx
@@ -25,9 +25,11 @@ import { useEffect, useState } from 'react';
 import { api, type EmbedderState } from '../api';
 import { openEmbeddingSetup } from './EmbedderRequireKeyGate';
 import { isEmbeddingAuthorized } from './embedder/embeddingAuth';
+import { ACCOUNT_CHANGED_EVENT } from '../accountEvents';
 
 export default function EmbeddingSetupCallout() {
   const [embedder, setEmbedder] = useState<EmbedderState | null>(null);
+  const [authRevision, setAuthRevision] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -35,6 +37,12 @@ export default function EmbeddingSetupCallout() {
       .then((state) => { if (!cancelled) setEmbedder(state); })
       .catch(() => { /* startup race with server boot — stay hidden */ });
     return () => { cancelled = true; };
+  }, [authRevision]);
+
+  useEffect(() => {
+    const onChanged = () => setAuthRevision((value) => value + 1);
+    window.addEventListener(ACCOUNT_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(ACCOUNT_CHANGED_EVENT, onChanged);
   }, []);
 
   if (isEmbeddingAuthorized(embedder)) return null;

--- a/web-src/src/components/ManagedLibrarySearch.tsx
+++ b/web-src/src/components/ManagedLibrarySearch.tsx
@@ -197,9 +197,15 @@ export default function ManagedLibrarySearch({ prefill, onClose }: {
       } else {
         const embedder = await api.getEmbedder();
         if (stale()) return;
-        dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: embedder.hasKey });
-        if (!embedder.hasKey) {
+        dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: embedder.authorized });
+        if (!embedder.authorized) {
           setError(EMBEDDER_KEY_ERROR);
+          setSemanticHits(null);
+          setSearching(false);
+          return;
+        }
+        if (embedder.source === 'stashbase-account' && embedder.account.quota?.remainingTokens === 0) {
+          setError('Your hosted AI Index allowance is exhausted. Exact search is still available.');
           setSemanticHits(null);
           setSearching(false);
           return;

--- a/web-src/src/components/Sidebar.tsx
+++ b/web-src/src/components/Sidebar.tsx
@@ -8,7 +8,6 @@ import {
   PlusIcon,
   StarIcon,
 } from '../icons';
-import { SidebarAccountRow } from './SidebarAccountRow';
 import { useApp } from '../store/AppContext';
 import { folderScope } from './agent/folderState';
 import { ALL_HISTORY_SCOPE } from './agent/sessionHistory';
@@ -40,6 +39,10 @@ import { Suspense, useCallback, useEffect, useRef, useState, type DragEvent } fr
  *  `ScopeHistoryButton.tsx`; re-exported here because the titlebar chat
  *  toggle imports it from this module. */
 export { activateChatTabForAgent } from './ScopeHistoryButton';
+
+const SidebarAccountRow = lazyWithRetry(() =>
+  import('./SidebarAccountRow').then((mod) => ({ default: mod.SidebarAccountRow })),
+);
 
 const DocumentOutline = lazyWithRetry(() =>
   import('./DocumentOutline').then((mod) => ({ default: mod.DocumentOutline })));
@@ -214,7 +217,9 @@ function FilesPanel() {
       )}
       {/* No mt-auto here: a dock block above always carries the bottom
         * anchor, and this row simply sits under it. */}
-      <SidebarAccountRow />
+      <Suspense fallback={<div className="h-[45px] flex-none border-t border-border" aria-hidden="true" />}>
+        <SidebarAccountRow />
+      </Suspense>
     </div>
   );
 }

--- a/web-src/src/components/SidebarAccountRow.tsx
+++ b/web-src/src/components/SidebarAccountRow.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { electronBridge } from '../electronBridge';
 import { BugIcon, DiscordIcon, ExternalLinkIcon, SettingsIcon, UserIcon } from '../icons';
-import { api, type HostedAccountState } from '../api';
+import { api, errorMessage, type HostedAccountState } from '../api';
 import { ACCOUNT_CHANGED_EVENT, notifyAccountChanged } from '../accountEvents';
+import { signInWithStashBase } from '../accountOAuth';
 import { DISCORD_INVITE_URL, openExternalUrl } from '../lib/externalLink';
 import { openSettings } from './SettingsModal';
 import { Button } from './ui/button';
@@ -23,6 +24,8 @@ import {
  */
 export function SidebarAccountRow() {
   const [account, setAccount] = useState<HostedAccountState | null>(null);
+  const [signingIn, setSigningIn] = useState(false);
+  const [signInError, setSignInError] = useState<string | null>(null);
 
   function refresh(refreshUsage = false) {
     api.getAccount(refreshUsage).then(setAccount).catch(() => { /* local server startup race */ });
@@ -50,6 +53,15 @@ export function SidebarAccountRow() {
         refresh(false);
       })
       .catch(() => { /* Settings remains the recovery surface */ });
+  }
+
+  function signIn() {
+    setSigningIn(true);
+    setSignInError(null);
+    void signInWithStashBase('google')
+      .then(setAccount)
+      .catch((error: unknown) => setSignInError(errorMessage(error)))
+      .finally(() => setSigningIn(false));
   }
 
   return (
@@ -117,11 +129,12 @@ export function SidebarAccountRow() {
                     <div className="mt-1 text-xs leading-relaxed text-muted-foreground">
                       Sign in for a free monthly embedding allowance. Local files and Exact search remain available without an account.
                     </div>
+                    {signInError && <div className="mt-2 text-xs text-destructive">{signInError}</div>}
                   </div>
                   <MenuSeparator className="m-0" />
                   <div className="p-1">
-                    <MenuItem label="Sign in to StashBase" onClick={() => openSettings('embedding')}>
-                      <span className="flex items-center gap-2"><ExternalLinkIcon className="size-4" />Sign in to StashBase</span>
+                    <MenuItem label="Sign in to StashBase" disabled={signingIn} onClick={signIn}>
+                      <span className="flex items-center gap-2"><ExternalLinkIcon className="size-4" />{signingIn ? 'Waiting for browser…' : 'Sign in to StashBase'}</span>
                     </MenuItem>
                   </div>
                 </>

--- a/web-src/src/components/SidebarAccountRow.tsx
+++ b/web-src/src/components/SidebarAccountRow.tsx
@@ -1,156 +1,136 @@
-import { useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { electronBridge } from '../electronBridge';
 import { BugIcon, DiscordIcon, ExternalLinkIcon, SettingsIcon, UserIcon } from '../icons';
+import { api, type HostedAccountState } from '../api';
+import { ACCOUNT_CHANGED_EVENT, notifyAccountChanged } from '../accountEvents';
 import { DISCORD_INVITE_URL, openExternalUrl } from '../lib/externalLink';
-import { Menu, type MenuItem } from './Menu';
 import { openSettings } from './SettingsModal';
 import { Button } from './ui/button';
+import {
+  Menu as AccountMenu,
+  MenuItem,
+  MenuPopup,
+  MenuPortal,
+  MenuPositioner,
+  MenuSeparator,
+  MenuTrigger,
+} from './ui/menu';
 
 /**
- * Bottom chrome row of the sidebar (Cursor's account/settings strip
- * position): WHO you are on the left, the app's small utility cluster on
- * the right.
- *
- * **Anonymous is a finished state, not a missing one.** Browsing, editing,
- * preview, and exact text search are local computations and must never be
- * gated behind a remote login, so the app has a working identity before
- * anyone signs in and says so plainly. The row never carries a standing
- * sign-in badge, dot, or index-readiness marker: recommending the hosted
- * path is the first-run setup dialog's job and it happens once, while
- * persistent chrome only ever states facts.
- *
- * Clicking the identity opens a MENU; it never jumps straight into sign-in.
- * Signing in leaves the app for a browser round trip, and an action that
- * takes the user somewhere else does not fire from an unguarded click on
- * what reads as a label — someone clicking a status row is usually asking
- * "what is this", not starting an auth flow. A direct jump also gets the
- * asymmetry backwards, guarding the cheap glance and letting the expensive
- * departure through. And the menu keeps the gesture identical once accounts
- * exist: signing in changes what the menu CONTAINS, never what the row does.
- *
- * Signed out the menu holds sign-in ALONE. A one-item menu is usually a
- * button in costume, but this one carries the thing a direct jump has
- * nowhere to put — what signing in actually buys — which is the whole
- * reason it exists, not a filler second row. AI Index state stays out:
- * `EmbeddingSetupCallout` sits directly above this row and owns that
- * prompt, so a source line here would be two prompts 8px apart, and once a
- * key is configured it would be pure status whose only action is the
- * Settings gear 60px to its right. Signed in, that line earns its place —
- * nothing else on screen reports hosted quota.
- *
- * Settings anchors the row's far-right edge. It loses its text label in the
- * trade, which is the real cost of putting identity on the sidebar's one
- * bottom line — the gear in the bottom-right corner is the near-universal
- * Settings position (Cursor, VS Code, Slack, Linear), it keeps its tooltip,
- * and the command palette still answers "Open Settings". Discord and Report
- * Bug remain adjacent immediately before it as the help/feedback group.
+ * Bottom sidebar chrome: identity on the left and persistent utilities on the
+ * right. Anonymous is a complete local-workspace state; the account menu adds
+ * sign-in and hosted-usage details without gating files or Exact search.
  */
 export function SidebarAccountRow() {
-  const identityRef = useRef<HTMLButtonElement | null>(null);
-  const [menuAnchor, setMenuAnchor] = useState<DOMRect | null>(null);
+  const [account, setAccount] = useState<HostedAccountState | null>(null);
 
-  const items: MenuItem[] = [
-    {
-      label: 'Sign in to StashBase',
-      /* Leading external-link mark, the same one `Open in New Window` uses:
-       * a click that hands the user to another surface says so first. Drawn
-       * now rather than added with the flow later, so the item never changes
-       * shape under someone who has learned it. */
-      icon: <ExternalLinkIcon />,
-      /* The reason the menu exists. A direct jump has nowhere to say this,
-       * and "what do I get" is the actual question of anyone still signed
-       * out — not "how do I sign in". Same promise the setup dialog's
-       * recommended card makes, in the same words. */
-      detail: 'Free monthly AI Index usage',
-      /* Dimmed AND marked until the account system ships: either alone
-       * reads as the other — a fade with no mark looks broken, a mark with
-       * no fade looks clickable. */
-      shortcut: 'Coming soon',
-      disabled: true,
-      onSelect: () => {},
-    },
-  ];
+  function refresh(refreshUsage = false) {
+    api.getAccount(refreshUsage).then(setAccount).catch(() => { /* local server startup race */ });
+  }
+
+  useEffect(() => {
+    refresh(false);
+    const onChanged = () => refresh(false);
+    window.addEventListener(ACCOUNT_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(ACCOUNT_CHANGED_EVENT, onChanged);
+  }, []);
+
+  const email = account?.signedIn ? account.email ?? '' : '';
+  const label = email || 'Anonymous';
+  const monogram = email ? email.slice(0, 2).toUpperCase() : '';
+  const quota = account?.quota;
+  const remainingPercent = quota
+    ? Math.max(0, Math.min(100, Math.round((quota.remainingTokens / Math.max(1, quota.grantedTokens)) * 100)))
+    : null;
+
+  function signOut() {
+    void api.signOutAccount()
+      .then(() => {
+        notifyAccountChanged();
+        refresh(false);
+      })
+      .catch(() => { /* Settings remains the recovery surface */ });
+  }
 
   return (
-    /* Taller than a list row on purpose. This is the sidebar's floor, and
-     * the New Chat block caps its top with 8px above / 12px below the same
-     * 28px control — a bottom strip clamped to 4px/6px made the panel look
-     * like it ran out of room rather than ended. The two caps now breathe
-     * within 2px of each other. */
     <div className="flex flex-none items-center gap-1 border-t border-border px-1.5 pt-2 pb-2.5">
-      <button
-        ref={identityRef}
-        type="button"
-        /* Hover brightens the TEXT only — no filled row surface. This strip
-         * is app chrome pinned under the dock's section bands, not a list
-         * row, and a hover pill here read as a fourth selectable item in
-         * the stack. */
-        className="group/account flex min-h-7 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-2 text-left text-base text-muted-foreground"
-        title="Account"
-        aria-haspopup="menu"
-        aria-expanded={!!menuAnchor}
-        onClick={() => {
-          if (menuAnchor) { setMenuAnchor(null); return; }
-          const rect = identityRef.current?.getBoundingClientRect();
-          if (rect) setMenuAnchor(rect);
-        }}
-      >
-        {/* A real avatar chip, not a resized glyph: the circle is the mark
-          * and the person is its CONTENT, which is why the inner glyph runs
-          * under the standalone utility cluster — it has to fit inside the
-          * identity container. It also has to survive contact with an
-          * account: signed in, the same circle carries a monogram, and only
-          * a container can do that.
-          *
-          * The circle OVERFLOWS its layout slot, 22px drawn from a 16px box.
-          * At 16px it was the faintest mark in a row of 16px glyphs — the
-          * row's own subject reading as its smallest element — but growing
-          * the slot would push the label off the dock's shared gutter. So
-          * the box stays 16px for layout and the circle bleeds 3px each
-          * side into padding that is already empty. 22px is the ceiling
-          * that gutter allows: past it the circle closes on the label and
-          * the row tightens again, so a larger avatar means giving up the
-          * alignment with Library above, not finding more room.
-          *
-          * Round, alone in a sidebar of rounded-md rows and rounded-xl
-          * boxes. The shape is the whole signal — it says "identity" before
-          * the label is read, so the row is never mistaken for one more
-          * navigable item in the stack above it. */}
-        <span className="relative inline-flex size-4 flex-none items-center justify-center">
-          <span className="absolute inset-[-3px] rounded-full bg-muted" aria-hidden="true" />
-          <UserIcon className="relative size-3.5" />
-        </span>
-        {/* Lands on the dock's shared 38px label gutter, same as Library,
-          * the section headers, and New Chat.
-          *
-          * `text-placeholder`, a step below the section labels above it, and
-          * the existing third text role rather than a new one: this slot
-          * holds no user-specific value yet, which is the same thing an
-          * empty field's hint says. At secondary weight "Anonymous" reads
-          * as a filled-in account name, the exact confusion that role
-          * exists to prevent. It also buys the signed-in state its
-          * indicator for free — a real name renders at
-          * `text-muted-foreground`, so the ink steps up on its own with no
-          * dot, badge, or colour spent.
-          *
-          * Hover (and an open menu) lifts it one step to the resting weight
-          * of a real name. That is the row's only affordance, so it has to
-          * move under the pointer; the momentary overlap with the signed-in
-          * colour costs nothing, since the string still reads "Anonymous"
-          * and hover only exists while a pointer sits on it. */}
-        <span className={
-          'min-w-0 truncate transition-colors '
-          + (menuAnchor ? 'text-muted-foreground' : 'text-placeholder group-hover/account:text-muted-foreground')
-        }>
-          Anonymous
-        </span>
-      </button>
-      {/* Community, Report Bug, Settings — one utility cluster on the row's
-        * right end. These sparse, persistent actions use the next optical
-        * step above dense section-header controls: 28px targets with 16px
-        * glyphs, large enough to read without making the row loose. */}
-      {/* Community — the app's only in-product route to a human, so it stays
-        * in persistent chrome rather than behind the account menu. */}
+      <AccountMenu onOpenChange={(open) => { if (open) refresh(true); }}>
+        <MenuTrigger
+          className="group/account flex min-h-7 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-2 text-left text-base text-muted-foreground hover:text-foreground"
+          title="Account"
+          aria-label={`Account: ${label}`}
+        >
+          <span className="relative inline-flex size-4 flex-none items-center justify-center">
+            <span className="absolute inset-[-3px] rounded-full bg-muted" aria-hidden="true" />
+            {monogram
+              ? <span className="relative text-2xs font-semibold text-foreground">{monogram}</span>
+              : <UserIcon className="relative size-3.5" />}
+          </span>
+          <span className={`min-w-0 truncate transition-colors ${email ? 'text-muted-foreground' : 'text-placeholder group-hover/account:text-muted-foreground'}`}>
+            {label}
+          </span>
+        </MenuTrigger>
+        <MenuPortal>
+          <MenuPositioner side="top" align="start" sideOffset={6} collisionPadding={8}>
+            <MenuPopup className="w-72 max-w-[calc(100vw-24px)] p-0" aria-label="StashBase account">
+              {account?.signedIn ? (
+                <>
+                  <div className="flex items-center gap-2.5 px-4 py-3">
+                    <span className="flex size-8 items-center justify-center rounded-full bg-accent/15 text-xs font-semibold text-accent">{monogram}</span>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold">{email.split('@')[0]}</div>
+                      <div className="truncate text-xs text-muted-foreground">{email}</div>
+                    </div>
+                  </div>
+                  <MenuSeparator className="m-0" />
+                  <div className="px-4 py-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-semibold">Remaining usage</span>
+                      {remainingPercent !== null && <span className="text-sm text-muted-foreground">{remainingPercent}%</span>}
+                    </div>
+                    {quota ? (
+                      <>
+                        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted">
+                          <div className="h-full rounded-full bg-accent" style={{ width: `${remainingPercent}%` }} />
+                        </div>
+                        <div className="mt-2 flex justify-between gap-3 text-xs text-muted-foreground">
+                          <span>{quota.remainingTokens.toLocaleString()} tokens</span>
+                          <span>{quota.periodEndsAt ? `Resets ${new Date(quota.periodEndsAt).toLocaleDateString()}` : ''}</span>
+                        </div>
+                      </>
+                    ) : (
+                      <div className="mt-2 text-xs text-muted-foreground">Usage is temporarily unavailable.</div>
+                    )}
+                  </div>
+                  <MenuSeparator className="m-0" />
+                  <div className="p-1">
+                    <MenuItem label="Learn more" onClick={() => openExternalUrl('https://stashbase.ai')}>
+                      <span className="flex items-center gap-2"><ExternalLinkIcon className="size-4" />Learn more</span>
+                    </MenuItem>
+                    <MenuItem label="Sign out" onClick={signOut}>Sign out</MenuItem>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="px-4 py-3">
+                    <div className="text-sm font-semibold">Use StashBase AI Index</div>
+                    <div className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                      Sign in for a free monthly embedding allowance. Local files and Exact search remain available without an account.
+                    </div>
+                  </div>
+                  <MenuSeparator className="m-0" />
+                  <div className="p-1">
+                    <MenuItem label="Sign in to StashBase" onClick={() => openSettings('embedding')}>
+                      <span className="flex items-center gap-2"><ExternalLinkIcon className="size-4" />Sign in to StashBase</span>
+                    </MenuItem>
+                  </div>
+                </>
+              )}
+            </MenuPopup>
+          </MenuPositioner>
+        </MenuPortal>
+      </AccountMenu>
+
       <Button
         variant="ghost"
         size="icon-sm"
@@ -186,20 +166,6 @@ export function SidebarAccountRow() {
       >
         <SettingsIcon className="size-4" />
       </Button>
-      {menuAnchor && (
-        /* Anchored to the identity's left edge, under the thing it belongs
-          * to — the utility cluster on the right is a different subject.
-          * base-ui flips the popup above the row on its own, which is what
-          * always happens here: this strip is the last thing in the window.
-          * No minWidth: the promise line is longer than the label it
-          * explains, so the content already clears the popup's own floor and
-          * a number here would only be a second one to keep in sync. */
-        <Menu
-          anchor={{ rect: menuAnchor, align: 'left' }}
-          items={items}
-          onClose={() => setMenuAnchor(null)}
-        />
-      )}
     </div>
   );
 }

--- a/web-src/src/components/SidebarAccountRow.tsx
+++ b/web-src/src/components/SidebarAccountRow.tsx
@@ -6,6 +6,7 @@ import { ACCOUNT_CHANGED_EVENT, notifyAccountChanged } from '../accountEvents';
 import { signInWithStashBase } from '../accountOAuth';
 import { DISCORD_INVITE_URL, openExternalUrl } from '../lib/externalLink';
 import { openSettings } from './SettingsModal';
+import { hostedQuotaRemainingPercent, hostedQuotaResetLabel } from '../lib/hostedQuota';
 import { Button } from './ui/button';
 import {
   Menu as AccountMenu,
@@ -42,9 +43,7 @@ export function SidebarAccountRow() {
   const label = email || 'Anonymous';
   const monogram = email ? email.slice(0, 2).toUpperCase() : '';
   const quota = account?.quota;
-  const remainingPercent = quota
-    ? Math.max(0, Math.min(100, Math.round((quota.remainingTokens / Math.max(1, quota.grantedTokens)) * 100)))
-    : null;
+  const remainingPercent = quota ? hostedQuotaRemainingPercent(quota) : null;
 
   function signOut() {
     void api.signOutAccount()
@@ -107,7 +106,7 @@ export function SidebarAccountRow() {
                         </div>
                         <div className="mt-2 flex justify-between gap-3 text-xs text-muted-foreground">
                           <span>{quota.remainingTokens.toLocaleString()} tokens</span>
-                          <span>{quota.periodEndsAt ? `Resets ${new Date(quota.periodEndsAt).toLocaleDateString()}` : ''}</span>
+                          <span>{hostedQuotaResetLabel(quota)}</span>
                         </div>
                       </>
                     ) : (

--- a/web-src/src/components/account/AccountSignInForm.tsx
+++ b/web-src/src/components/account/AccountSignInForm.tsx
@@ -1,0 +1,104 @@
+import { useRef, useState } from 'react';
+import { api, errorMessage, type HostedAccountState } from '../../api';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { StatusMessage } from '../ui/status';
+import { notifyAccountChanged } from '../../accountEvents';
+
+export function AccountSignInForm({
+  onSignedIn,
+  onBack,
+}: {
+  onSignedIn: (account: HostedAccountState) => void;
+  onBack?: () => void;
+}) {
+  const [email, setEmail] = useState('');
+  const [token, setToken] = useState('');
+  const [sent, setSent] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  async function sendCode() {
+    setBusy(true);
+    setError(null);
+    try {
+      await api.requestAccountOtp(email);
+      setSent(true);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    } catch (err: unknown) {
+      setError(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function verify() {
+    setBusy(true);
+    setError(null);
+    try {
+      const account = await api.verifyAccountOtp(email, token);
+      notifyAccountChanged();
+      onSignedIn(account);
+    } catch (err: unknown) {
+      setError(errorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div>
+      {!sent ? (
+        <>
+          <label className="mb-1.5 block text-sm font-medium" htmlFor="stashbase-account-email">Email</label>
+          <Input
+            id="stashbase-account-email"
+            ref={inputRef}
+            type="email"
+            autoComplete="email"
+            placeholder="you@example.com"
+            value={email}
+            disabled={busy}
+            onChange={(event) => { setEmail(event.target.value); setError(null); }}
+            onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); void sendCode(); } }}
+          />
+          <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+            We’ll email a one-time code. New addresses create an account after verification.
+          </p>
+        </>
+      ) : (
+        <>
+          <div className="mb-2 text-sm text-muted-foreground">Code sent to <span className="font-medium text-foreground">{email}</span></div>
+          <label className="mb-1.5 block text-sm font-medium" htmlFor="stashbase-account-code">Verification code</label>
+          <Input
+            id="stashbase-account-code"
+            ref={inputRef}
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            placeholder="Enter code"
+            value={token}
+            disabled={busy}
+            onChange={(event) => { setToken(event.target.value); setError(null); }}
+            onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); void verify(); } }}
+          />
+        </>
+      )}
+      {error && <StatusMessage tone="error" className="mt-2.5">{error}</StatusMessage>}
+      <div className="mt-3.5 flex items-center justify-between gap-2">
+        <button
+          type="button"
+          className="cursor-pointer border-0 bg-transparent p-0 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
+          disabled={busy}
+          onClick={() => {
+            if (sent) { setSent(false); setToken(''); setError(null); }
+            else onBack?.();
+          }}
+        >{sent ? 'Use another email' : onBack ? 'Back' : ''}</button>
+        <Button disabled={busy || (sent ? !token.trim() : !email.trim())} onClick={() => { void (sent ? verify() : sendCode()); }}>
+          {busy ? 'Please wait…' : sent ? 'Verify and sign in' : 'Email me a code'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web-src/src/components/account/AccountSignInForm.tsx
+++ b/web-src/src/components/account/AccountSignInForm.tsx
@@ -1,9 +1,8 @@
-import { useRef, useState } from 'react';
-import { api, errorMessage, type HostedAccountState } from '../../api';
+import { useEffect, useRef, useState } from 'react';
+import { errorMessage, type HostedAccountState } from '../../api';
+import { signInWithStashBase } from '../../accountOAuth';
 import { Button } from '../ui/button';
-import { Input } from '../ui/input';
 import { StatusMessage } from '../ui/status';
-import { notifyAccountChanged } from '../../accountEvents';
 
 export function AccountSignInForm({
   onSignedIn,
@@ -12,91 +11,51 @@ export function AccountSignInForm({
   onSignedIn: (account: HostedAccountState) => void;
   onBack?: () => void;
 }) {
-  const [email, setEmail] = useState('');
-  const [token, setToken] = useState('');
-  const [sent, setSent] = useState(false);
-  const [busy, setBusy] = useState(false);
+  const [busy, setBusy] = useState(true);
+  const [browserOpened, setBrowserOpened] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const startedRef = useRef(false);
+  const mountedRef = useRef(true);
 
-  async function sendCode() {
+  function start() {
     setBusy(true);
+    setBrowserOpened(false);
     setError(null);
-    try {
-      await api.requestAccountOtp(email);
-      setSent(true);
-      requestAnimationFrame(() => inputRef.current?.focus());
-    } catch (err: unknown) {
+    void signInWithStashBase('google', {
+      onBrowserOpened: () => { if (mountedRef.current) setBrowserOpened(true); },
+    }).then((account) => {
+      if (mountedRef.current) onSignedIn(account);
+    }).catch((err: unknown) => {
+      if (!mountedRef.current) return;
       setError(errorMessage(err));
-    } finally {
       setBusy(false);
-    }
+    });
   }
 
-  async function verify() {
-    setBusy(true);
-    setError(null);
-    try {
-      const account = await api.verifyAccountOtp(email, token);
-      notifyAccountChanged();
-      onSignedIn(account);
-    } catch (err: unknown) {
-      setError(errorMessage(err));
-    } finally {
-      setBusy(false);
+  useEffect(() => {
+    mountedRef.current = true;
+    if (!startedRef.current) {
+      startedRef.current = true;
+      start();
     }
-  }
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   return (
     <div>
-      {!sent ? (
-        <>
-          <label className="mb-1.5 block text-sm font-medium" htmlFor="stashbase-account-email">Email</label>
-          <Input
-            id="stashbase-account-email"
-            ref={inputRef}
-            type="email"
-            autoComplete="email"
-            placeholder="you@example.com"
-            value={email}
-            disabled={busy}
-            onChange={(event) => { setEmail(event.target.value); setError(null); }}
-            onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); void sendCode(); } }}
-          />
-          <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-            We’ll email a one-time code. New addresses create an account after verification.
-          </p>
-        </>
-      ) : (
-        <>
-          <div className="mb-2 text-sm text-muted-foreground">Code sent to <span className="font-medium text-foreground">{email}</span></div>
-          <label className="mb-1.5 block text-sm font-medium" htmlFor="stashbase-account-code">Verification code</label>
-          <Input
-            id="stashbase-account-code"
-            ref={inputRef}
-            inputMode="numeric"
-            autoComplete="one-time-code"
-            placeholder="Enter code"
-            value={token}
-            disabled={busy}
-            onChange={(event) => { setToken(event.target.value); setError(null); }}
-            onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); void verify(); } }}
-          />
-        </>
-      )}
+      <div className="text-sm font-medium">
+        {browserOpened ? 'Finish signing in with Google in your browser' : 'Opening Google sign-in…'}
+      </div>
+      <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+        Supabase handles the provider login in your browser. Return here when it completes; StashBase will continue automatically.
+      </p>
       {error && <StatusMessage tone="error" className="mt-2.5">{error}</StatusMessage>}
-      <div className="mt-3.5 flex items-center justify-between gap-2">
-        <button
-          type="button"
-          className="cursor-pointer border-0 bg-transparent p-0 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
-          disabled={busy}
-          onClick={() => {
-            if (sent) { setSent(false); setToken(''); setError(null); }
-            else onBack?.();
-          }}
-        >{sent ? 'Use another email' : onBack ? 'Back' : ''}</button>
-        <Button disabled={busy || (sent ? !token.trim() : !email.trim())} onClick={() => { void (sent ? verify() : sendCode()); }}>
-          {busy ? 'Please wait…' : sent ? 'Verify and sign in' : 'Email me a code'}
+      <div className="mt-3.5 flex flex-wrap items-center gap-2">
+        {onBack && <Button variant="ghost" disabled={busy} onClick={onBack}>Back</Button>}
+        <Button disabled={busy} onClick={start}>
+          {busy ? 'Waiting for Google…' : 'Continue with Google'}
         </Button>
       </div>
     </div>

--- a/web-src/src/components/embedder/EmbeddingAuthChoice.tsx
+++ b/web-src/src/components/embedder/EmbeddingAuthChoice.tsx
@@ -15,7 +15,8 @@
  *     neutral border as its sibling: tint plus a brand-toned border read as
  *     "already selected" rather than "recommended", which is the one thing
  *     this screen must not say — nothing is chosen until the user clicks.
- *     The account system uses verified email OTP and the shared hosted quota.
+ *     Supabase OAuth opens Google in the system browser; the local Node
+ *     service owns PKCE and the shared hosted quota session.
  *     Deployments may still disable the card explicitly; the quiet corner
  *     mark keeps that state distinguishable from a broken control.
  *   • Use your own API key — OpenAI or OpenRouter, for advanced users;

--- a/web-src/src/components/embedder/EmbeddingAuthChoice.tsx
+++ b/web-src/src/components/embedder/EmbeddingAuthChoice.tsx
@@ -15,10 +15,9 @@
  *     neutral border as its sibling: tint plus a brand-toned border read as
  *     "already selected" rather than "recommended", which is the one thing
  *     this screen must not say — nothing is chosen until the user clicks.
- *     Inert until the account system ships: drawn as the finished card, not
- *     faded out, with one quiet "Coming soon" mark in its top-right corner.
- *     A disabled card that says nothing reads as a broken button; the mark
- *     is the smallest thing that turns "it did not work" into "not yet".
+ *     The account system uses verified email OTP and the shared hosted quota.
+ *     Deployments may still disable the card explicitly; the quiet corner
+ *     mark keeps that state distinguishable from a broken control.
  *   • Use your own API key — OpenAI or OpenRouter, for advanced users;
  *     choosing it reveals the key field in place (the parent owns that swap).
  *
@@ -47,12 +46,11 @@
  * a box. Two boxes seen together are expected to wear the same corner.
  */
 
-export function EmbeddingAuthChoice({ onUseOwnKey, onSignIn, signInDisabled = true, onSkip }: {
+export function EmbeddingAuthChoice({ onUseOwnKey, onSignIn, signInDisabled = false, onSkip }: {
   onUseOwnKey: () => void;
   onSignIn?: () => void;
-  /** Sign-in ships behind the account system; until then the hero is
-   *  present but inert, so the primary path is visible from the first
-   *  release and does not appear out of nowhere later. */
+  /** Allows deployments without hosted accounts to hide the action while
+   * retaining the finished layout. */
   signInDisabled?: boolean;
   /** When provided (first-run gate only), renders the quiet exit to basic
    *  mode. Omitted in Settings, where continuing without indexing is moot. */
@@ -74,7 +72,7 @@ export function EmbeddingAuthChoice({ onUseOwnKey, onSignIn, signInDisabled = tr
             /* Corner mark, not a chip: a filled badge would compete with
              * the card's own title for the eye that is choosing. Sits on
              * the title's line so the card keeps its two-line shape. */
-            <span className="absolute top-2 right-4 text-2xs leading-none text-muted-foreground">Coming soon</span>
+            <span className="absolute top-2 right-4 text-2xs leading-none text-muted-foreground">Unavailable</span>
           )}
         </button>
 

--- a/web-src/src/components/embedder/RequireApiKeyModal.tsx
+++ b/web-src/src/components/embedder/RequireApiKeyModal.tsx
@@ -35,6 +35,7 @@ import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { SegmentedControl, SegmentedControlItem } from '../ui/segmented-control';
 import { StatusMessage } from '../ui/status';
+import { AccountSignInForm } from '../account/AccountSignInForm';
 
 const PROVIDERS: Record<EmbedderProvider, { label: string; model: string; placeholder: string }> = {
   openai: {
@@ -51,10 +52,11 @@ const PROVIDERS: Record<EmbedderProvider, { label: string; model: string; placeh
 
 const PROVIDER_ORDER: EmbedderProvider[] = ['openai', 'openrouter'];
 
-type View = 'choice' | 'key';
+type View = 'choice' | 'signin' | 'key';
 
 const TITLES: Record<View, string> = {
   choice: 'Set up AI Index',
+  signin: 'Sign in to StashBase',
   key: 'Add your API key',
 };
 
@@ -64,6 +66,7 @@ const TITLES: Record<View, string> = {
  * of this screen running two lines deep. */
 const DESCRIPTIONS: Record<View, string> = {
   choice: 'Help Agents find context across your files.',
+  signin: 'Use your free monthly AI Index allowance.',
   key: 'Paste an OpenAI or OpenRouter key.',
 };
 
@@ -71,11 +74,13 @@ export function RequireApiKeyModal({
   initialProvider = 'openai',
   isTopmost,
   onSaved,
+  onSignedIn,
   onSkip,
 }: {
   initialProvider?: EmbedderProvider;
   isTopmost: boolean;
   onSaved: (provider: EmbedderProvider, model: string, backfillStarted?: boolean, warning?: string) => void;
+  onSignedIn: (backfillStarted?: boolean) => void;
   onSkip: () => void;
 }) {
   const [provider, setProvider] = useState<EmbedderProvider>(initialProvider);
@@ -133,8 +138,18 @@ export function RequireApiKeyModal({
       {view === 'choice' && (
         <div ref={choiceRef} tabIndex={-1} className="outline-none">
           <EmbeddingAuthChoice
+            onSignIn={() => setView('signin')}
             onUseOwnKey={() => setView('key')}
             onSkip={onSkip}
+          />
+        </div>
+      )}
+
+      {view === 'signin' && (
+        <div ref={choiceRef} tabIndex={-1} className="outline-none">
+          <AccountSignInForm
+            onBack={() => setView('choice')}
+            onSignedIn={(account) => onSignedIn(account.backfillStarted)}
           />
         </div>
       )}

--- a/web-src/src/components/embedder/embeddingAuth.ts
+++ b/web-src/src/components/embedder/embeddingAuth.ts
@@ -2,18 +2,16 @@
  * Whether AI Index is authorized, whether the user has deliberately opted
  * out of it, and the one place that decides both.
  *
- * Today the only way to authorize is a provider API key the user pasted in.
- * A signed-in account is meant to become a second way, and the point of
- * this module is that adding it is ONE edit here rather than an audit of
- * every `!hasKey` in the renderer — the dialog, the Files-panel line, the
- * settings panel, and the sidebar all ask this question, and they must
- * never disagree about the answer.
+ * A signed-in account allowance and a provider API key are equal activation
+ * sources. The server resolves the explicit active source and exposes the
+ * resulting `authorized` fact so the dialog, Files-panel line, Settings, and
+ * search never disagree.
  */
 import type { EmbedderState } from '../../api';
 
 export function isEmbeddingAuthorized(state: EmbedderState | null | undefined): boolean {
   if (!state) return false;
-  return state.hasKey;
+  return state.authorized;
 }
 
 /**

--- a/web-src/src/components/settings/EmbeddingPanel.tsx
+++ b/web-src/src/components/settings/EmbeddingPanel.tsx
@@ -16,6 +16,7 @@ import { Input } from '../ui/input';
 import { SegmentedControl, SegmentedControlItem } from '../ui/segmented-control';
 import { AccountSignInForm } from '../account/AccountSignInForm';
 import { notifyAccountChanged } from '../../accountEvents';
+import { hostedQuotaRemainingPercent, hostedQuotaResetLabel } from '../../lib/hostedQuota';
 
 const PROVIDERS: Record<EmbedderProvider, { label: string; model: string; placeholder: string; costHint: string }> = {
   openai: {
@@ -196,7 +197,7 @@ export function EmbeddingPanel() {
                 </div>
                 {state.account.quota && (
                   <div className="text-right">
-                    <div className="text-base font-semibold">{Math.round((state.account.quota.remainingTokens / Math.max(1, state.account.quota.grantedTokens)) * 100)}%</div>
+                    <div className="text-base font-semibold">{hostedQuotaRemainingPercent(state.account.quota)}%</div>
                     <div className="text-2xs text-muted-foreground">remaining</div>
                   </div>
                 )}
@@ -204,11 +205,11 @@ export function EmbeddingPanel() {
               {state.account.quota && (
                 <div className="mt-3">
                   <div className="h-1.5 overflow-hidden rounded-full bg-muted">
-                    <div className="h-full rounded-full bg-accent" style={{ width: `${Math.max(0, Math.min(100, (state.account.quota.remainingTokens / Math.max(1, state.account.quota.grantedTokens)) * 100))}%` }} />
+                    <div className="h-full rounded-full bg-accent" style={{ width: `${hostedQuotaRemainingPercent(state.account.quota)}%` }} />
                   </div>
                   <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
                     <span>{state.account.quota.remainingTokens.toLocaleString()} tokens left</span>
-                    <span>{state.account.quota.periodEndsAt ? `Resets ${new Date(state.account.quota.periodEndsAt).toLocaleDateString()}` : ''}</span>
+                    <span>{hostedQuotaResetLabel(state.account.quota)}</span>
                   </div>
                 </div>
               )}

--- a/web-src/src/components/settings/EmbeddingPanel.tsx
+++ b/web-src/src/components/settings/EmbeddingPanel.tsx
@@ -1,8 +1,8 @@
 /**
- * Settings → AI Index panel. The user can choose the direct OpenAI
- * embedding endpoint or OpenRouter's OpenAI-compatible endpoint. With no
- * key set, indexing and search are disabled (files still save and
- * preview); the `RequireApiKeyModal` auto-pop on folder load lives in
+ * Settings → AI Index panel. The user can choose the signed-in StashBase
+ * allowance, direct OpenAI, or OpenRouter's OpenAI-compatible endpoint. With
+ * no active source, indexing and meaning-based search are disabled (files
+ * still save, preview, and Exact search); the setup modal on folder load lives in
  * `EmbedderRequireKeyGate` so it fires whether or not Settings is open.
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -14,6 +14,8 @@ import { RemoveKeyModal } from '../embedder/RemoveKeyModal';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { SegmentedControl, SegmentedControlItem } from '../ui/segmented-control';
+import { AccountSignInForm } from '../account/AccountSignInForm';
+import { notifyAccountChanged } from '../../accountEvents';
 
 const PROVIDERS: Record<EmbedderProvider, { label: string; model: string; placeholder: string; costHint: string }> = {
   openai: {
@@ -51,6 +53,8 @@ export function EmbeddingPanel() {
   // from either direction sees the two options with equal weight instead of
   // a key field plus a footnote about accounts.
   const [keyFormOpen, setKeyFormOpen] = useState(false);
+  const [signInFormOpen, setSignInFormOpen] = useState(false);
+  const [accountBusy, setAccountBusy] = useState(false);
   const mountedRef = useRef(false);
 
   useEffect(() => {
@@ -81,7 +85,7 @@ export function EmbeddingPanel() {
     const result = await api.changeApiKey(key, selectedProvider);
     if (!mountedRef.current) return;
     setKeyEditOpen(false);
-    setState((s) => (s ? { ...s, provider: result.provider, model: result.model, hasKey: true } : s));
+    setState((s) => (s ? { ...s, provider: result.provider, model: result.model, hasKey: true, authorized: true, source: result.provider } : s));
     setSelectedProvider(result.provider);
     dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: true });
     if (result.warning) actions.toast(`API key saved, but validation could not reach the provider: ${result.warning}`, { level: 'warning' });
@@ -100,7 +104,7 @@ export function EmbeddingPanel() {
       const result = await api.changeApiKey(trimmed, selectedProvider);
       if (!mountedRef.current) return;
       setAddKey('');
-      setState((s) => (s ? { ...s, provider: result.provider, model: result.model, hasKey: true } : s));
+      setState((s) => (s ? { ...s, provider: result.provider, model: result.model, hasKey: true, authorized: true, source: result.provider } : s));
       setSelectedProvider(result.provider);
       dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: true });
       if (result.warning) actions.toast(`API key saved, but validation could not reach the provider: ${result.warning}`, { level: 'warning' });
@@ -118,7 +122,7 @@ export function EmbeddingPanel() {
     await api.removeApiKey();
     if (!mountedRef.current) return;
     setKeyRemoveOpen(false);
-    setState((s) => (s ? { ...s, hasKey: false } : s));
+    setLoadNonce((n) => n + 1);
     // The search popup re-checks the embedder before every semantic run, so
     // flipping the shared key state here is all it needs.
     dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: false });
@@ -139,10 +143,41 @@ export function EmbeddingPanel() {
   const selected = PROVIDERS[selectedProvider];
   const activeProviderSelected = state.provider === selectedProvider;
   const hasSelectedProviderKey = state.hasKey && activeProviderSelected;
+  const directSourceActive = state.source === selectedProvider;
   // Provider and model are bring-your-own-key concerns. While the fork is
   // up they would be answering a question the user has not reached yet, so
   // the panel shows the choice alone until a path is picked.
-  const showingAuthChoice = !state.hasKey && !keyFormOpen;
+  const hostedActive = state.source === 'stashbase-account' && state.account.signedIn;
+  const showingHostedSummary = hostedActive && !keyFormOpen && !signInFormOpen;
+  const showingAuthChoice = !state.authorized && !keyFormOpen && !signInFormOpen;
+
+  async function refreshAccount() {
+    setAccountBusy(true);
+    try {
+      const account = await api.getAccount(true);
+      if (mountedRef.current) setState((current) => current ? { ...current, account } : current);
+    } catch (err: unknown) {
+      actions.toast(errorMessage(err), { level: 'error' });
+    } finally {
+      if (mountedRef.current) setAccountBusy(false);
+    }
+  }
+
+  async function signOut() {
+    setAccountBusy(true);
+    try {
+      await api.signOutAccount();
+      notifyAccountChanged();
+      if (!mountedRef.current) return;
+      setLoadNonce((n) => n + 1);
+      dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: false });
+      void actions.refreshIndexState();
+    } catch (err: unknown) {
+      actions.toast(errorMessage(err), { level: 'error' });
+    } finally {
+      if (mountedRef.current) setAccountBusy(false);
+    }
+  }
 
   return (
     <>
@@ -152,38 +187,129 @@ export function EmbeddingPanel() {
           <div className="mb-2.5 text-sm leading-normal text-muted-foreground">
             Powers meaning-based search and Agent retrieval. The model stays fixed so the local index remains compatible.
           </div>
-          {!showingAuthChoice && (
-          <SegmentedControl
-            aria-label="Embedding provider"
-            className="mt-0.5 mb-2 w-fit"
-            disabled={addBusy}
-            value={[selectedProvider]}
-            onValueChange={(next) => {
-              const picked = next[0] as EmbedderProvider | undefined;
-              if (!picked || picked === selectedProvider) return;
-              setSelectedProvider(picked);
-              setAddKey('');
-              setAddError(null);
-            }}
-          >
-            {PROVIDER_ORDER.map((provider) => (
-              <SegmentedControlItem key={provider} value={provider} className="min-w-24 text-sm">
-                {PROVIDERS[provider].label}
-              </SegmentedControlItem>
-            ))}
-          </SegmentedControl>
+          {showingHostedSummary && (
+            <div className="rounded-xl border border-border bg-card p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate text-base font-semibold">{state.account.email}</div>
+                  <div className="mt-0.5 text-xs text-muted-foreground">Using the StashBase account allowance</div>
+                </div>
+                {state.account.quota && (
+                  <div className="text-right">
+                    <div className="text-base font-semibold">{Math.round((state.account.quota.remainingTokens / Math.max(1, state.account.quota.grantedTokens)) * 100)}%</div>
+                    <div className="text-2xs text-muted-foreground">remaining</div>
+                  </div>
+                )}
+              </div>
+              {state.account.quota && (
+                <div className="mt-3">
+                  <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                    <div className="h-full rounded-full bg-accent" style={{ width: `${Math.max(0, Math.min(100, (state.account.quota.remainingTokens / Math.max(1, state.account.quota.grantedTokens)) * 100))}%` }} />
+                  </div>
+                  <div className="mt-1.5 flex justify-between text-xs text-muted-foreground">
+                    <span>{state.account.quota.remainingTokens.toLocaleString()} tokens left</span>
+                    <span>{state.account.quota.periodEndsAt ? `Resets ${new Date(state.account.quota.periodEndsAt).toLocaleDateString()}` : ''}</span>
+                  </div>
+                </div>
+              )}
+              {state.account.quotaUnavailable && <div className="mt-2 text-xs text-muted-foreground">Usage is temporarily unavailable.</div>}
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button variant="outline" size="sm" disabled={accountBusy} onClick={() => { void refreshAccount(); }}>Refresh usage</Button>
+                <Button variant="outline" size="sm" disabled={accountBusy} onClick={() => setKeyFormOpen(true)}>Use your own key</Button>
+                <Button variant="ghost" size="sm" disabled={accountBusy} onClick={() => { void signOut(); }}>Sign out</Button>
+              </div>
+            </div>
           )}
-          {!showingAuthChoice && (
+          {signInFormOpen && (
+            <AccountSignInForm
+              onBack={() => setSignInFormOpen(false)}
+              onSignedIn={(account) => {
+                setState((current) => current ? { ...current, authorized: true, source: 'stashbase-account', account } : current);
+                setSignInFormOpen(false);
+                dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: true });
+                if (account.backfillStarted) void actions.markVisibleFilesPendingForSearch();
+                void actions.refreshIndexState();
+              }}
+            />
+          )}
+          {state.account.signedIn && !hostedActive && !signInFormOpen && (
+            <div className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-3 py-2.5">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">Signed in as {state.account.email}</div>
+                <div className="text-xs text-muted-foreground">Your own API key is currently active.</div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={accountBusy}
+                onClick={() => {
+                  setAccountBusy(true);
+                  api.useAccountAllowance()
+                    .then((account) => {
+                      if (!mountedRef.current) return;
+                      setState((current) => current ? { ...current, source: 'stashbase-account', authorized: true, account } : current);
+                      setKeyFormOpen(false);
+                      dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: true });
+                      if (account.backfillStarted) void actions.markVisibleFilesPendingForSearch();
+                      void actions.refreshIndexState();
+                    })
+                    .catch((err: unknown) => actions.toast(errorMessage(err), { level: 'error' }))
+                    .finally(() => { if (mountedRef.current) setAccountBusy(false); });
+                }}
+              >Use account allowance</Button>
+            </div>
+          )}
+          {!showingHostedSummary && !signInFormOpen && !showingAuthChoice && (
+            <SegmentedControl
+              aria-label="Embedding provider"
+              className="mt-0.5 mb-2 w-fit"
+              disabled={addBusy}
+              value={[selectedProvider]}
+              onValueChange={(next) => {
+                const picked = next[0] as EmbedderProvider | undefined;
+                if (!picked || picked === selectedProvider) return;
+                setSelectedProvider(picked);
+                setAddKey('');
+                setAddError(null);
+              }}
+            >
+              {PROVIDER_ORDER.map((provider) => (
+                <SegmentedControlItem key={provider} value={provider} className="min-w-24 text-sm">
+                  {PROVIDERS[provider].label}
+                </SegmentedControlItem>
+              ))}
+            </SegmentedControl>
+          )}
+          {!showingHostedSummary && !signInFormOpen && !showingAuthChoice && (
           <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sm leading-normal text-muted-foreground [&_code]:font-mono [&_code]:text-xs [&_code]:whitespace-nowrap [&_code]:text-accent">
             {state.hasKey && <span>Current: {PROVIDERS[state.provider].label}</span>}
             <span>Model: <code>{selected.model}</code></span>
             <span>{selected.costHint}</span>
           </div>
           )}
-          {hasSelectedProviderKey ? (
+          {!showingHostedSummary && !signInFormOpen && (hasSelectedProviderKey ? (
             <div className="flex flex-wrap items-center gap-2">
-              <div className="min-w-0 text-sm leading-8 text-muted-foreground">Key configured</div>
+              <div className="min-w-0 text-sm leading-8 text-muted-foreground">{directSourceActive ? 'Key active' : 'Key configured'}</div>
               <div className="flex flex-wrap gap-2">
+                {!directSourceActive && (
+                  <Button
+                    size="sm"
+                    disabled={accountBusy}
+                    onClick={() => {
+                      setAccountBusy(true);
+                      api.useApiKeySource(selectedProvider)
+                        .then((next) => {
+                          if (!mountedRef.current) return;
+                          setState(next);
+                          setKeyFormOpen(false);
+                          dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: true });
+                          void actions.refreshIndexState();
+                        })
+                        .catch((err: unknown) => actions.toast(errorMessage(err), { level: 'error' }))
+                        .finally(() => { if (mountedRef.current) setAccountBusy(false); });
+                    }}
+                  >Use this key</Button>
+                )}
                 <Button
                   variant="outline"
                   onClick={() => setKeyEditOpen(true)}
@@ -206,7 +332,7 @@ export function EmbeddingPanel() {
                 * key already on file is a different question and keeps the
                 * plain form. */}
               {showingAuthChoice && (
-                <EmbeddingAuthChoice onUseOwnKey={() => setKeyFormOpen(true)} />
+                <EmbeddingAuthChoice onSignIn={() => setSignInFormOpen(true)} onUseOwnKey={() => setKeyFormOpen(true)} />
               )}
               {!showingAuthChoice && (
               <div className="flex min-w-0 items-center gap-2">
@@ -229,8 +355,8 @@ export function EmbeddingPanel() {
               )}
               {addError && <div className="mt-1.5 text-sm text-destructive">{addError}</div>}
             </>
-          )}
-          {!showingAuthChoice && (
+          ))}
+          {!showingHostedSummary && !signInFormOpen && !showingAuthChoice && (
             <div className="mt-3.5 text-sm leading-normal text-muted-foreground [&_code]:font-mono [&_code]:text-xs [&_code]:whitespace-nowrap [&_code]:text-accent">
               Stored locally in <code>~/.stashbase/config.json</code>. Used only for embeddings, never chat.
             </div>

--- a/web-src/src/electronBridge.ts
+++ b/web-src/src/electronBridge.ts
@@ -16,7 +16,6 @@ export interface ElectronBridge {
   openExternal?: (url: string) => Promise<boolean>;
   /** Opens the main-process bug-report review for the sender's window. */
   reportBug?: () => Promise<boolean>;
-  focusWindow?: () => Promise<boolean>;
   openFolderWindow?: (folder: string) => Promise<boolean>;
   setWindowFolder?: (folder: string | null) => Promise<boolean>;
   onPrepareContextRelease?: (handler: (reason: string) => Promise<boolean>) => (() => void);

--- a/web-src/src/electronBridge.ts
+++ b/web-src/src/electronBridge.ts
@@ -16,6 +16,7 @@ export interface ElectronBridge {
   openExternal?: (url: string) => Promise<boolean>;
   /** Opens the main-process bug-report review for the sender's window. */
   reportBug?: () => Promise<boolean>;
+  focusWindow?: () => Promise<boolean>;
   openFolderWindow?: (folder: string) => Promise<boolean>;
   setWindowFolder?: (folder: string | null) => Promise<boolean>;
   onPrepareContextRelease?: (handler: (reason: string) => Promise<boolean>) => (() => void);

--- a/web-src/src/lib/hostedQuota.ts
+++ b/web-src/src/lib/hostedQuota.ts
@@ -1,0 +1,12 @@
+import type { HostedQuota } from '../apiTypes';
+
+export function hostedQuotaRemainingPercent(quota: HostedQuota): number {
+  const percent = (quota.remainingTokens / Math.max(1, quota.grantedTokens)) * 100;
+  return Math.max(0, Math.min(100, Math.round(percent)));
+}
+
+export function hostedQuotaResetLabel(quota: HostedQuota): string {
+  return quota.periodEndsAt
+    ? `Resets ${new Date(quota.periodEndsAt).toLocaleDateString()}`
+    : '';
+}

--- a/web-src/src/store/useSearchActions.ts
+++ b/web-src/src/store/useSearchActions.ts
@@ -243,12 +243,13 @@ export function useSearchActions(
       const s = outcome.status;
       const indexReady = s.indexReady !== false;
       const semanticEnabled = s.semanticEnabled !== false;
+      const semanticAvailable = s.semanticAvailable !== false;
       if (stateRef.current.embedderHasKey !== semanticEnabled) {
         dispatch({ type: 'EMBEDDER_KEY_STATE', hasKey: semanticEnabled });
       }
-      const newPending = semanticEnabled && indexReady ? new Set(s.pending ?? []) : new Set<string>();
+      const newPending = semanticEnabled && semanticAvailable && indexReady ? new Set(s.pending ?? []) : new Set<string>();
       const visibleIndexingSettled =
-        !semanticEnabled
+        !semanticAvailable
         || (indexReady && (s.visibleIndexingSettled ?? newPending.size === 0));
       let newConv = s.pendingConversions ?? [];
       const newBlocked = s.blockedConversions ?? [];
@@ -272,26 +273,26 @@ export function useSearchActions(
       // so a fresh drop's files flicker in and out of `pending`
       // unreliably. Hold every graced import in `newPending` until the
       // UI-visible pending set settles (batch done) or the grace expires.
-      if (semanticEnabled && importIndexGrace.current.size > 0) {
+      if (semanticAvailable && importIndexGrace.current.size > 0) {
         const stillGracing = foldGraceMap(
           importIndexGrace.current,
           () => visibleIndexingSettled, // batch fully indexed
           Date.now(),
         );
         for (const name of stillGracing) newPending.add(name);
-      } else if (!semanticEnabled && importIndexGrace.current.size > 0) {
+      } else if (!semanticAvailable && importIndexGrace.current.size > 0) {
         importIndexGrace.current.clear();
       }
       // And for key-backfill marks: the daemon owns a name once it shows
       // up in its own pending set.
-      if (semanticEnabled && keyBackfillGrace.current.size > 0) {
+      if (semanticAvailable && keyBackfillGrace.current.size > 0) {
         const stillGracing = foldGraceMap(
           keyBackfillGrace.current,
           (name) => newPending.has(name),
           Date.now(),
         );
         for (const name of stillGracing) newPending.add(name);
-      } else if (!semanticEnabled && keyBackfillGrace.current.size > 0) {
+      } else if (!semanticAvailable && keyBackfillGrace.current.size > 0) {
         keyBackfillGrace.current.clear();
       }
       const prev = stateRef.current;
@@ -375,7 +376,7 @@ export function useSearchActions(
       // Keep polling fast while a conversion is in flight, even if
       // the index itself is settled — the user is waiting on a file
       // to appear.
-      const busy = (semanticEnabled && (!indexReady || !visibleIndexingSettled)) || newConv.length > 0;
+      const busy = (semanticAvailable && (!indexReady || !visibleIndexingSettled)) || newConv.length > 0;
       if (folderPathAtStart) {
         dispatch({
           type: 'LIBRARY_FOLDER_STATUS',


### PR DESCRIPTION
## What changed

- add Supabase Google PKCE sign-in and a hosted StashBase allowance alongside OpenAI/OpenRouter BYOK
- enforce the shared allowance for indexing and semantic queries while preserving Exact search at zero quota
- recover indexing after quota reset or switching to an available BYOK source
- show quota percentage and reset date in the account UI
- return browser OAuth to the initiating desktop window with a fixed data-free deep link and process-authenticated acknowledgement
- preserve malformed/unrelated configuration and add the account/retrieval gates to the cross-platform source matrix

## Why

StashBase needs an open-source desktop client that can use either user-owned API credentials or a signed-in hosted allowance. The initial implementation did not make quota exhaustion authoritative across every semantic path and had callback/configuration edge cases that could retry exhausted work, focus the wrong window, or overwrite malformed configuration.

## User impact

Signed-in users can use the included allowance without entering an API key. When it is exhausted, vector indexing and semantic search pause clearly, Exact search continues, and work resumes after reset. BYOK remains independently configurable. Browser sign-in returns to the window that initiated it and closes the callback only after native confirmation.

## Validation

- `pnpm typecheck`
- `pnpm test:config` (13 passed)
- `pnpm test:renderer` (254 passed)
- `npm run test:electron` (81 passed)
- `pnpm test:conversion-scheduler` (128 passed)
- `pnpm test:python` (27 passed)
- `pnpm test:agent` (104 passed)
- `pnpm test:retrieval`, `pnpm test:library-files`, `pnpm test:mcp`
- `pnpm test:docs`
- `pnpm build`
- `pnpm test:electron:smoke`
- `pnpm test:e2e:smoke` (5 passed)
- `pnpm test:e2e:functional` (28 passed)
- standards and spec reviews: no findings
