### PR TITLE
fix(packaging): add transcription source mirrors

### DIFF
--- a/scripts/build-transcription-sidecar.sh
+++ b/scripts/build-transcription-sidecar.sh
@@ -203,7 +203,10 @@ OPUS_SRC="$SRC/opus-$OPUS_VERSION"
 download_checked \
   "$OPUS_ARCHIVE" \
   "$OPUS_SHA256" \
-  "https://downloads.xiph.org/releases/opus/opus-$OPUS_VERSION.tar.gz"
+  "https://downloads.xiph.org/releases/opus/opus-$OPUS_VERSION.tar.gz" \
+  "https://archive.mozilla.org/pub/opus/opus-$OPUS_VERSION.tar.gz" \
+  "https://distfiles.macports.org/opus/opus-$OPUS_VERSION.tar.gz" \
+  "https://gentoo.osuosl.org/distfiles/opus-$OPUS_VERSION.tar.gz"
 cmake -E remove_directory "$OPUS_SRC"
 tar -xzf "$OPUS_ARCHIVE" -C "$SRC"
 OPUS_BUILD="$BUILD/opus"
@@ -230,7 +233,9 @@ download_checked \
   "$FFMPEG_ARCHIVE" \
   "$FFMPEG_SHA256" \
   "https://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.xz" \
-  "https://www.ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.xz"
+  "https://www.ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.xz" \
+  "https://distfiles.macports.org/ffmpeg/ffmpeg-$FFMPEG_VERSION.tar.xz" \
+  "https://gentoo.osuosl.org/distfiles/ffmpeg-$FFMPEG_VERSION.tar.xz"
 cmake -E remove_directory "$FFMPEG_SRC"
 tar -xJf "$FFMPEG_ARCHIVE" -C "$SRC"
 FFMPEG_BUILD="$BUILD/ffmpeg"


### PR DESCRIPTION
## Summary

Adds checksum-verified fallback mirrors for the pinned Opus and FFmpeg source archives used by the transcription sidecar build.

This change was split from #179 because it belongs to release packaging rather than editor conflict recovery. The original author remains credited on the commit.

## Validation

- `bash -n scripts/build-transcription-sidecar.sh`
- `git diff --check HEAD~1..HEAD`

