### PR TITLE
fix(preparation): hide Windows PDF OCR consoles

### DIFF
--- a/code-review/data-lifecycle.md
+++ b/code-review/data-lifecycle.md
@@ -54,6 +54,10 @@
   interruptions unless their owner explicitly records a failure.
 - Cancelling native work owns the descendant process tree and waits for
   process/output-handle retirement before reporting the task released.
+- PDF/OCR preparation never owns a visible console window. POSIX extractors use
+  a detached process group for tree signals; Windows PDF/OCR extractors stay
+  attached, hide their console, and use `taskkill /T` for descendant
+  cancellation.
 
 ## Reconcile
 
@@ -169,7 +173,7 @@ of the resource tradeoff.
 | Daemon Adapter | `server/mfs-daemon.ts` ↔ `python/stashbase_daemon.py` |
 | Retrieval Interface | `server/retrieval/index.ts`, with keyword, semantic, and evidence Modules beside it |
 | Format owners | PDF, OCR, DOCX, and audio Modules under `server/` plus their native/Python Adapters |
-| Focused evidence | `server/conversion-scheduler.test.ts`, `server/conversion.test.ts`, `server/conversion-status.test.ts`, `server/semantic-workload.test.ts`, `server/index-status.test.ts`, `server/indexer-mfs-path.test.ts`, `server/audio-transcription.test.ts`, `server/retrieval/index.test.ts`, and `python/stashbase_daemon_test.py` |
+| Focused evidence | `server/conversion-scheduler.test.ts`, `server/conversion.test.ts`, `server/conversion-status.test.ts`, `server/extractor-process.test.ts`, `server/semantic-workload.test.ts`, `server/index-status.test.ts`, `server/indexer-mfs-path.test.ts`, `server/audio-transcription.test.ts`, `server/retrieval/index.test.ts`, and `python/stashbase_daemon_test.py` |
 
 ## Review Checklist
 

--- a/code-review/journey-coverage.md
+++ b/code-review/journey-coverage.md
@@ -143,7 +143,9 @@ aliases, and Journey E2E owns representative composition.
 
 - **Contract Test:** `pnpm test:config`, `pnpm test:conversion-scheduler`, and
   `pnpm test:python` cover the default-off capture preference, scheduling,
-  format completion, cancellation, freshness, checkpoints, and recovery.
+  format completion, cancellation, PDF/OCR spawn configuration, freshness,
+  checkpoints, and recovery. `pnpm test:package-inputs` locks the static
+  Windows extractor bootloader argument wiring without discarding stderr.
   `pnpm test:electron` locks the focused-window and unclaimed-composer offer
   policy.
 - **Journey E2E:** [preparation capture](../e2e/journeys/preparation-capture.spec.ts)
@@ -154,8 +156,8 @@ aliases, and Journey E2E owns representative composition.
 - **AI Eval:** extraction correctness is format-specific deterministic or
   dataset evidence; no shared product-level quality Eval is currently claimed.
 - **Release Check:** operating-system screenshot capture and representative
-  PDF/OCR/DOCX/media preparation with packaged native helpers remain release
-  evidence.
+  PDF/OCR/DOCX/media preparation with packaged native helpers, including no
+  visible console or focus theft on Windows, remain release evidence.
 - **Gap:** none in the deterministic screenshot-to-current-evidence path.
 
 ## J05: Search

--- a/code-review/release-pipeline.md
+++ b/code-review/release-pipeline.md
@@ -41,6 +41,9 @@ before its metadata and payloads coexist.
 - Each platform builds the pinned transcription sidecar for its target. Native
   archives may use declared mirrors only when the accepted bytes match the
   pinned digest.
+- The packaged PDF/OCR extractor keeps its console-enabled stderr channel for
+  progress and failure reporting, while its Windows bootloader hides consoles
+  owned by both the entry process and frozen multiprocessing workers.
 - Packaging rejects missing/empty binaries, licenses, or notices; wrong binary
   formats; version/build-option drift; unacceptable FFmpeg licensing/features;
   and target ABI or minimum-OS drift.

--- a/design-docs/design/preparation.md
+++ b/design-docs/design/preparation.md
@@ -57,6 +57,8 @@ artifacts.
   interruption is rediscoverable.
 - Optional native tools and state stores degrade to actionable status rather
   than blocking folder entry.
+- PDF and image OCR helpers must not surface console windows or take focus from
+  the user's current work.
 - Ambient capture remains opt-in and reversible. Failure to read the setting or
   clipboard fails closed rather than enabling monitoring or creating a source.
 

--- a/scripts/build-python-sidecar.mjs
+++ b/scripts/build-python-sidecar.mjs
@@ -22,6 +22,12 @@ const extractReqs = path.join(root, 'python', 'requirements-extract.txt');
 const setupPython = path.join(root, 'scripts', 'setup-python.mjs');
 const args = process.argv.slice(2);
 const buildExtractor = args.includes('--with-extract') || process.env.STASHBASE_BUILD_EXTRACT === '1';
+// Keep the console-enabled bootloader so Node can capture stderr progress and
+// failures, but hide consoles owned by the Windows extractor and its frozen
+// multiprocessing workers before they can flash or steal focus.
+const extractorConsoleArgs = process.platform === 'win32'
+  ? ['--hide-console', 'hide-early']
+  : [];
 const pyinstallerEnv = {
   ...process.env,
   PYINSTALLER_CONFIG_DIR: cachePath,
@@ -252,6 +258,7 @@ if (!buildExtractor) {
       '--noconfirm',
       '--name',
       'stashbase-extract',
+      ...extractorConsoleArgs,
       // pdf_extract.py / ocr_extract.py are sibling modules imported lazily
       // by extract_main; put `python/` on the analysis path and pin them as
       // hidden imports so PyInstaller bundles both branches.

--- a/scripts/package-inputs.test.mjs
+++ b/scripts/package-inputs.test.mjs
@@ -46,3 +46,14 @@ test('electron-builder includes local CommonJS dependencies outside electron/', 
     `package.json build.files omits Electron runtime dependencies:\n${missing.join('\n')}`,
   );
 });
+
+test('Windows extractor build wires PyInstaller hide-console without switching off stderr', () => {
+  const source = fs.readFileSync(path.join(root, 'scripts', 'build-python-sidecar.mjs'), 'utf8');
+
+  assert.match(
+    source,
+    /const extractorConsoleArgs = process\.platform === 'win32'[\s\S]*?'--hide-console',[\s\S]*?'hide-early'/,
+  );
+  assert.match(source, /'stashbase-extract',\s*\.\.\.extractorConsoleArgs,/);
+  assert.doesNotMatch(source, /'--(?:no)?console'/);
+});

--- a/server/extractor-process.test.ts
+++ b/server/extractor-process.test.ts
@@ -4,7 +4,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { spawnOptionsForExtractor, terminateExtractorTree } from './extractor-process.ts';
+import {
+  spawnOptionsForExtractor,
+  spawnOptionsForPdfOcr,
+  terminateExtractorTree,
+} from './extractor-process.ts';
 
 const CHILD_SOURCE = 'setInterval(() => undefined, 1000)';
 const PARENT_SOURCE = [
@@ -23,6 +27,15 @@ function processExists(pid: number): boolean {
     return false;
   }
 }
+
+test('PDF/OCR subprocess configuration stays hidden on Windows', () => {
+  const windowsOptions = spawnOptionsForPdfOcr('win32');
+  assert.equal(windowsOptions.detached, false);
+  assert.equal(windowsOptions.windowsHide, true);
+
+  assert.equal(spawnOptionsForPdfOcr('linux').detached, true);
+  assert.equal(spawnOptionsForExtractor().detached, true);
+});
 
 async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;

--- a/server/extractor-process.ts
+++ b/server/extractor-process.ts
@@ -4,11 +4,13 @@ import os from 'node:os';
 const KILL_GRACE_MS = 1500;
 const EXTRACTOR_NICE_PRIORITY = 15;
 
-export function spawnOptionsForExtractor(): {
+interface ExtractorSpawnOptions {
   detached: boolean;
   stdio: ['ignore', 'pipe', 'pipe'];
   env: NodeJS.ProcessEnv;
-} {
+}
+
+export function spawnOptionsForExtractor(): ExtractorSpawnOptions {
   return {
     detached: true,
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -22,6 +24,19 @@ export function spawnOptionsForExtractor(): {
       NUMEXPR_NUM_THREADS: process.env.STASHBASE_EXTRACTOR_THREADS ?? '1',
       OMP_WAIT_POLICY: 'PASSIVE',
     },
+  };
+}
+
+/** PDF/OCR use a console-enabled Python sidecar for progress reporting.
+ * Windows cancellation already uses taskkill /T, so detaching is unnecessary
+ * there and would allocate a console window for every extractor launch. */
+export function spawnOptionsForPdfOcr(
+  platform: NodeJS.Platform = process.platform,
+): ExtractorSpawnOptions & { windowsHide: boolean } {
+  return {
+    ...spawnOptionsForExtractor(),
+    detached: platform !== 'win32',
+    windowsHide: true,
   };
 }
 

--- a/server/image.ts
+++ b/server/image.ts
@@ -20,7 +20,7 @@ import { isImageFile } from './format.ts';
 import { derivedNoteFor, derivedDir } from './derived-store.ts';
 import { extractorSpawn } from './python-host.ts';
 import { derivedIsFresh, discoverNewSources, indexFreshDerived, maybeConvert, TransientConversionError, type ConversionSpec } from './conversion.ts';
-import { lowerExtractorPriority, spawnOptionsForExtractor, terminateExtractorTree } from './extractor-process.ts';
+import { lowerExtractorPriority, spawnOptionsForPdfOcr, terminateExtractorTree } from './extractor-process.ts';
 
 const OCR_COMPLETE_MARKER = '<!-- stashbase-ocr-conversion: complete -->';
 
@@ -94,7 +94,7 @@ function convertImage(
       return;
     }
     const { cmd, args } = extractorSpawn('ocr', 'ocr_extract.py', [imageAbsPath, notePath]);
-    const proc = spawn(cmd, args, spawnOptionsForExtractor());
+    const proc = spawn(cmd, args, spawnOptionsForPdfOcr());
     lowerExtractorPriority(proc);
     let stderr = '';
     let cancelled = false;

--- a/server/pdf.ts
+++ b/server/pdf.ts
@@ -26,7 +26,7 @@ import {
   TransientConversionError,
   type ConversionSpec,
 } from './conversion.ts';
-import { lowerExtractorPriority, spawnOptionsForExtractor, terminateExtractorTree } from './extractor-process.ts';
+import { lowerExtractorPriority, spawnOptionsForPdfOcr, terminateExtractorTree } from './extractor-process.ts';
 import type { ConversionProgress } from './conversion-status.ts';
 import { logger } from './log.ts';
 import {
@@ -144,7 +144,7 @@ function probePdfTextLayer(pdfAbsPath: string, signal: AbortSignal): Promise<boo
       resolve(false);
       return;
     }
-    const proc = spawn(cmd, args, spawnOptionsForExtractor());
+    const proc = spawn(cmd, args, spawnOptionsForPdfOcr());
     lowerExtractorPriority(proc);
     let settled = false;
     let timedOut = false;
@@ -271,7 +271,7 @@ function convertPdf(
     const { cmd, args } = extractorSpawn('pdf', 'pdf_extract.py', [
       pdfAbsPath, notePath, bundleDir,
     ]);
-    const proc = spawn(cmd, args, spawnOptionsForExtractor());
+    const proc = spawn(cmd, args, spawnOptionsForPdfOcr());
     lowerExtractorPriority(proc);
     let stderr = '';
     let stderrLineBuffer = '';


### PR DESCRIPTION
## Summary
- keep Windows PDF/OCR extractor launches attached and hidden
- hide consoles owned by frozen PyInstaller multiprocessing workers while retaining stderr
- add regression coverage and update preparation/release contracts

## Validation
- TypeScript typechecks
- conversion, retrieval, and Python tests
- documentation and release contract tests
- Electron multi-window smoke

Fixes #188