### PR TITLE
fix(account): show hosted Google identity

### DIFF
--- a/code-review/journey-coverage.md
+++ b/code-review/journey-coverage.md
@@ -69,6 +69,8 @@ aliases, and Journey E2E owns representative composition.
 - **Contract Test:** renderer initialization, Settings state, workspace
   navigation, and Electron lifecycle are exercised by `pnpm test:renderer`,
   `pnpm test:config`, `pnpm test:updates`, and `pnpm test:electron:smoke`.
+  Account identity fixtures cover profile normalization, migration, privacy,
+  and UI fallbacks.
   Renderer state evidence keeps bootstrap settlement distinct from confirmed
   library membership, so a failed or pending membership load cannot claim the
   library is empty.
@@ -166,7 +168,7 @@ aliases, and Journey E2E owns representative composition.
 
 - **Contract Test:** `pnpm test:retrieval` and the data, scope, credential,
   and renderer suites cover exact filtering, semantic mechanics, source
-  remapping, access boundaries, and failure presentation.
+  remapping, access boundaries, account identity, and failure presentation.
 - **Journey E2E:** [semantic search UI](../e2e/journeys/semantic-search-ui.spec.ts)
   covers mode, scope, readiness, result presentation, and source navigation.
 - **AI Eval:** Gap. Current deterministic tests do not prove that representative

--- a/code-review/settings-config.md
+++ b/code-review/settings-config.md
@@ -46,6 +46,15 @@ access surface external clients copy from.
 - Account access and refresh tokens are Node-only configuration. They never
   cross renderer HTTP responses or the Node/Python boundary; Python receives a
   random per-process loopback bearer credential instead.
+- Google display name and avatar URL are optional display-only session fields.
+  Refreshes and legacy-session hydration preserve known valid values when
+  provider metadata is absent or unavailable; sign-out clears them with the
+  session. They never affect authorization, quota ownership, or embedding
+  source selection, and raw provider metadata never crosses the account API.
+- Renderer avatar URLs are same-origin. Node accepts only HTTPS Google profile
+  images from the exact allowed host and bounds redirects, time, bytes, and
+  raster content type; failure remains an ordinary initials/icon fallback and
+  never becomes a general URL proxy or account failure.
 - Refresh demand for one account session is single-flight. A refresh may
   update or clear only the exact session it started from; a stale completion
   cannot overwrite or sign out a newer session.
@@ -99,13 +108,13 @@ access surface external clients copy from.
 | Persistent Interface | strict/fallback read and write plus domain getters/setters in `server/app-config.ts` |
 | Domain owners | `server/mcp-http-settings.ts`, `server/hosted-account.ts`, `server/hosted-embedding-broker.ts`, embedding and transcription configuration Modules |
 | HTTP Adapters | `server/routes/appearance.ts`, `capture.ts`, `updates.ts`, `onboarding.ts`, `account.ts`, `embedder.ts`, `transcription.ts`, `mcp.ts` |
-| Renderer Adapters | `web-src/src/features/settings/hooks/` — one controller per panel (`useGeneralSettings.ts`, `useEmbedderSettings.ts`, `useTranscriptionSettings.ts`, `useMcpAccess.ts`, `useAgentRuntimes.ts`, `useAppearanceSettings.ts`, `useApiKeyEntry.ts`), each owning its reads, its optimistic writes, and their ordering guards. The panels under `components/` render what a controller returns and hold only which dialog is open |
+| Renderer Adapters | `web-src/src/features/account/components/SidebarAccountRow.tsx`, `web-src/src/common/components/AccountIdentity.tsx`, and `web-src/src/features/settings/hooks/` — one controller per panel (`useGeneralSettings.ts`, `useEmbedderSettings.ts`, `useTranscriptionSettings.ts`, `useMcpAccess.ts`, `useAgentRuntimes.ts`, `useAppearanceSettings.ts`, `useApiKeyEntry.ts`), each owning its reads, its optimistic writes, and their ordering guards. The panels under `components/` render what a controller returns and hold only which dialog is open |
 | Authorization read | `web-src/src/common/hooks/useEmbedderState.ts` — shared with the Files-panel callout, which may not import this feature |
 | Appearance Adapter | `web-src/src/features/settings/lib/appearance.ts`, applied to a window by `hooks/useAppliedAppearance.ts` |
 | Capture runtime Adapter | `web-src/src/app/hooks/useClipboardImageOffer.ts`, `electron/preload.cjs`, and the clipboard boundary in `electron/main.cjs` |
 | Update runtime Adapter | `electron/update-manager.cjs`, `electron/main.cjs`, `electron/preload.cjs`, `web-src/src/common/hooks/useDesktopUpdate.ts`, and `web-src/src/common/components/DesktopUpdateBanner.tsx` — the hook and banner sit in `common/` because Settings and the sidebar account row both render update state, and a feature may not import a sibling |
 | Open-request Interfaces | `web-src/src/common/lib/settingsTrigger.ts` (Settings), `web-src/src/common/lib/embeddingSetupTrigger.ts` (AI Index setup), `web-src/src/common/lib/embeddingAuth.ts` (authorization and basic-mode facts) — shared so no surface reaches into the Settings feature to ask it to open |
-| Focused evidence | `server/app-config.test.ts`, `server/hosted-account.test.ts`, `server/__tests__/mcp-http-settings.test.ts`, `electron/clipboard-watch-policy.test.cjs`, `electron/update-manager.test.cjs`, `web-src/src/common/__tests__/desktop-update-hook.test.ts`, `web-src/src/features/settings/__tests__/appearance.test.ts`, `web-src/src/common/__tests__/embedding-auth.test.ts`, `e2e/smoke/settings.spec.ts`, and J04 in `e2e/journeys/preparation-capture.spec.ts` |
+| Focused evidence | `server/app-config.test.ts`, `server/hosted-account.test.ts`, `server/__tests__/mcp-http-settings.test.ts`, `electron/clipboard-watch-policy.test.cjs`, `electron/update-manager.test.cjs`, renderer account/appearance/embedding tests, `web-src/src/common/__tests__/desktop-update-hook.test.ts`, `web-src/src/features/settings/__tests__/appearance.test.ts`, `web-src/src/common/__tests__/embedding-auth.test.ts`, `e2e/smoke/settings.spec.ts`, and J04 in `e2e/journeys/preparation-capture.spec.ts` |
 
 ## Validation
 

--- a/design-docs/design/search.md
+++ b/design-docs/design/search.md
@@ -51,11 +51,13 @@ user-managed results.
   observable setup sequence lives in
   [J01](../user-journeys.md#j01-complete-onboarding-and-reach-first-value).
 - Hosted indexing and meaning-based queries draw from one token allowance.
-  The account menu shows identity, remaining percentage, and reset date. When
-  the allowance is exhausted, hosted semantic work stops while Exact search
-  and every local-file workflow remain available. Pending semantic work
-  resumes after the allowance refreshes or an available BYOK source is
-  selected.
+  The account menu and AI Index Settings show the provider display name and
+  avatar when available, retain the full email for account identification, and
+  share deterministic fallbacks. They also show remaining percentage and reset
+  date. When the allowance is exhausted, hosted semantic work stops while
+  Exact search and every local-file workflow remain available. Pending
+  semantic work resumes after the allowance refreshes or an available BYOK
+  source is selected.
 - In-app and MCP retrieval share source identity and access rules. MCP also
   supports validated source-type categories.
 

--- a/design-docs/design/workspace.md
+++ b/design-docs/design/workspace.md
@@ -41,6 +41,10 @@ manager, or a primary graph-navigation tool.
   hides that announcement only — a newer release, or a download becoming ready
   to install, announces again, and Settings remains the standing update and
   preference surface.
+- A signed-in account is recognizable by its Google display name and avatar in
+  Files, with the full email retained in the account menu. Missing or failed
+  profile display data falls back without changing account controls; signed
+  out remains the complete Anonymous local-workspace state.
 - Users can open or create a local folder, switch folders in place, favorite a
   member, open it in another window, sync it, or remove it from the library.
   A created folder is an ordinary directory. Removing membership clears only

--- a/design-docs/user-journeys.md
+++ b/design-docs/user-journeys.md
@@ -80,6 +80,10 @@ folder. No account, AI Index source, active folder, or Agent runtime is assumed.
 - Returning users recognize their library and completed durable setup without
   replaying first-use explanation or losing access when an optional online
   capability is unavailable.
+- When a user chooses Google sign-in for hosted AI Index, the sidebar, account
+  menu, and Settings consistently identify the connected person by optional
+  provider profile data plus the full email, without making profile loading a
+  prerequisite for local or hosted work.
 
 ### Degradation and Recovery
 

--- a/design-docs/visual-style.md
+++ b/design-docs/visual-style.md
@@ -66,6 +66,10 @@ type is carried primarily by shape and label rather than a rainbow of colors.
 - Circles and capsules are reserved for semantics that need them, such as
   identity, status, or a terminal action. A box never becomes a capsule by
   being short — if the shape appears, it was chosen.
+- A person avatar keeps one stable circular footprint while remote content
+  loads or fails. Its fallback order is provider image, display-name initials,
+  email initials, then the generic person icon; decorative avatar content does
+  not repeat adjacent identity text to assistive technology.
 - List hover and selection are quiet inset surfaces. Accent feedback is
   reserved for states that must be unmistakable, such as an active drop target.
 - Sibling controls align to shared grid lines. Empty states use one deliberate

--- a/e2e/smoke/settings.spec.ts
+++ b/e2e/smoke/settings.spec.ts
@@ -71,6 +71,62 @@ test('J01: user can navigate Settings and persist appearance across relaunch', a
   }
 });
 
+test('signed-in Google identity is consistent in the sidebar, account menu, and AI Index Settings', async ({}, testInfo) => {
+  const fixture = await createAppFixture({ membership: 'empty' });
+  let app: LaunchedApp | undefined;
+  const account = {
+    signedIn: true,
+    active: true,
+    email: 'ada@example.com',
+    displayName: 'Ada Lovelace',
+    avatarUrl: '/api/account/avatar',
+    quota: {
+      plan: 'free', grantedTokens: 1_000, usedTokens: 100, reservedTokens: 0,
+      remainingTokens: 900, periodStartedAt: null, periodEndsAt: null,
+    },
+  };
+  try {
+    app = await launchApp(fixture, testInfo);
+    await app.page.route('**/api/account*', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(account) });
+    });
+    await app.page.route('**/api/account/avatar', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'image/png',
+        body: Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=', 'base64'),
+      });
+    });
+    await app.page.route('**/api/embedder', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
+        provider: 'openai', hasKey: false, authorized: true, source: 'stashbase-account',
+        model: 'fixture-model', account,
+      }) });
+    });
+    await app.page.evaluate(() => window.dispatchEvent(new CustomEvent('stashbase-account-changed')));
+
+    const accountButton = app.page.getByRole('button', { name: 'Account: Ada Lovelace (ada@example.com)' });
+    await expect(accountButton).toBeVisible();
+    await expect(accountButton).toContainText('Ada Lovelace');
+    await expect(accountButton.locator('img[src="/api/account/avatar"]')).toBeVisible();
+    await accountButton.click();
+    await expect(app.page.getByText('ada@example.com', { exact: true })).toBeVisible();
+    await expect(app.page.getByText('Remaining usage', { exact: true })).toBeVisible();
+    await expect(app.page.getByRole('menu').locator('img[src="/api/account/avatar"]')).toBeVisible();
+    await app.page.keyboard.press('Escape');
+
+    await settingsButton(app.page).click();
+    await settingsTab(app.page, 'AI Index').click();
+    await expect(settingsDialog(app.page)).toContainText('Ada Lovelace');
+    await expect(settingsDialog(app.page)).toContainText('ada@example.com');
+    await expect(settingsDialog(app.page).locator('img[src="/api/account/avatar"]')).toBeVisible();
+    app.errors.assertNone();
+  } finally {
+    await app?.close();
+    await fixture.cleanup();
+  }
+});
+
 test('J04: clipboard screenshot offers are default-off and require an explicit General setting', async ({}, testInfo) => {
   const fixture = await createAppFixture({ membership: 'one-folder' });
   let app: LaunchedApp | undefined;

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -23,6 +23,7 @@ import type {
 } from '../shared/preferences.ts';
 import type { EmbedderProvider, EmbeddingSource } from '../shared/embedding.ts';
 import type { LocalTranscriptionModelId } from '../shared/transcription.ts';
+import { normalizeHostedDisplayName, parseGoogleAvatarUrl } from './hosted-account-profile.ts';
 
 export type {
   AppearancePreferences,
@@ -75,6 +76,10 @@ export interface HostedAccountSession {
   expiresAt: number;
   userId: string;
   email: string;
+  /** Optional display-only Google profile fields. They never participate in
+   * authentication, authorization, quota ownership, or source selection. */
+  displayName?: string;
+  avatarUrl?: string;
 }
 
 const EMBEDDER_DEFAULTS: Record<EmbedderProvider, Omit<EmbedderConfig, 'provider' | 'apiKey'>> = {
@@ -272,7 +277,19 @@ export function getHostedAccountSession(): HostedAccountSession | undefined {
     typeof raw.userId !== 'string' || !raw.userId ||
     typeof raw.email !== 'string' || !raw.email
   ) return undefined;
-  return { ...raw };
+  const displayName = normalizeHostedDisplayName(raw.displayName);
+  const avatarUrl = parseGoogleAvatarUrl(raw.avatarUrl)?.toString();
+  // Select fields explicitly: malformed/legacy provider metadata and any
+  // future credentials must never hitchhike into the normalized session.
+  return {
+    accessToken: raw.accessToken,
+    refreshToken: raw.refreshToken,
+    expiresAt: raw.expiresAt,
+    userId: raw.userId,
+    email: raw.email,
+    ...(displayName ? { displayName } : {}),
+    ...(avatarUrl ? { avatarUrl } : {}),
+  };
 }
 
 export function setHostedAccountSession(session: HostedAccountSession | undefined): void {

--- a/server/hosted-account-profile.ts
+++ b/server/hosted-account-profile.ts
@@ -1,0 +1,18 @@
+const GOOGLE_AVATAR_HOST = 'lh3.googleusercontent.com';
+
+export function normalizeHostedDisplayName(value: unknown): string | undefined {
+  const normalized = typeof value === 'string'
+    ? value.replace(/[\p{Cc}\p{Cf}]/gu, '').trim().replace(/\s+/gu, ' ')
+    : '';
+  return normalized ? Array.from(normalized).slice(0, 200).join('') : undefined;
+}
+
+export function parseGoogleAvatarUrl(value: unknown): URL | undefined {
+  if (typeof value !== 'string') return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol === 'https:' && url.hostname === GOOGLE_AVATAR_HOST
+      && !url.username && !url.password) return url;
+  } catch { /* invalid and disallowed URLs share the same absent-profile fallback */ }
+  return undefined;
+}

--- a/server/hosted-account.test.ts
+++ b/server/hosted-account.test.ts
@@ -111,7 +111,9 @@ test('OAuth PKCE session persists locally and authenticates quota requests', () 
       calls.push({ url: String(url), body: init.body ? JSON.parse(String(init.body)) : null, authorization: new Headers(init.headers).get('authorization') });
       if (String(url).endsWith('/auth/v1/token?grant_type=pkce')) return Response.json({
         access_token: 'access-1', refresh_token: 'refresh-1', expires_at: 4102444800,
-        user: { id: 'user-1', email: 'person@example.com' },
+        user: { id: 'user-1', email: 'person@example.com', user_metadata: {
+          full_name: 'Ada Lovelace', avatar_url: 'https://lh3.googleusercontent.com/a/profile-photo',
+        } },
       });
       if (String(url).endsWith('/v1/account/usage')) return Response.json({
         plan: 'free', grantedTokens: 1000000, usedTokens: 12, reservedTokens: 0,
@@ -148,7 +150,187 @@ test('OAuth PKCE session persists locally and authenticates quota requests', () 
   assert.equal(output.session.refreshToken, 'refresh-1');
   assert.equal(output.source, 'stashbase-account');
   assert.equal(output.state.email, 'person@example.com');
+  assert.equal(output.state.displayName, 'Ada Lovelace');
+  assert.equal(output.state.avatarUrl, '/api/account/avatar');
   assert.equal('userId' in output.state, false);
+  assert.equal('accessToken' in output.state, false);
+  assert.equal('refreshToken' in output.state, false);
+  assert.equal('user_metadata' in output.state, false);
+});
+
+test('Google profile normalization accepts display-safe metadata and rejects unsafe avatars', () => {
+  const result = runIsolated(`
+    const account = await import('./server/hosted-account.ts');
+    process.stdout.write(JSON.stringify({
+      safe: account.normalizedGoogleProfile({ user_metadata: {
+        name: '  Grace   Hopper  ', picture: 'https://lh3.googleusercontent.com/a/photo',
+      } }),
+      identity: account.normalizedGoogleProfile({ identities: [{ provider: 'google', identity_data: {
+        full_name: 'Katherine Johnson', avatar_url: 'https://lh3.googleusercontent.com/a/identity-photo',
+      } }] }),
+      invalidPrimary: account.normalizedGoogleProfile({
+        user_metadata: { full_name: ' \\u0000 ', avatar_url: 'http://not-allowed.example/avatar' },
+        identities: [{ provider: 'google', identity_data: {
+          full_name: 'Dorothy Vaughan', picture: 'https://lh3.googleusercontent.com/a/valid-fallback',
+        } }],
+      }),
+      unsafe: account.normalizedGoogleProfile({ user_metadata: {
+        full_name: 'Person', avatar_url: 'http://lh3.googleusercontent.com/a/photo', raw_provider_token: 'secret',
+      } }),
+    }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    safe: { displayName: 'Grace Hopper', avatarUrl: 'https://lh3.googleusercontent.com/a/photo' },
+    identity: { displayName: 'Katherine Johnson', avatarUrl: 'https://lh3.googleusercontent.com/a/identity-photo' },
+    invalidPrimary: { displayName: 'Dorothy Vaughan', avatarUrl: 'https://lh3.googleusercontent.com/a/valid-fallback' },
+    unsafe: { displayName: 'Person' },
+  });
+});
+
+test('persisted account sessions normalize and allowlist optional profile fields', () => {
+  const result = runIsolated(`
+    const config = await import('./server/app-config.ts');
+    config.setHostedAccountSession({
+      accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800,
+      userId: 'user', email: 'person@example.com', displayName: '  Ada  \\u0000 Lovelace  ',
+      avatarUrl: 'http://lh3.googleusercontent.com/a/unsafe', rawProviderToken: 'secret',
+    });
+    process.stdout.write(JSON.stringify(config.getHostedAccountSession()));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    expiresAt: 4_102_444_800,
+    userId: 'user',
+    email: 'person@example.com',
+    displayName: 'Ada Lovelace',
+  });
+});
+
+test('a legacy session stays signed in when optional profile hydration fails', () => {
+  const result = runIsolated(`
+    globalThis.fetch = async () => { throw new Error('profile offline'); };
+    const config = await import('./server/app-config.ts');
+    const account = await import('./server/hosted-account.ts');
+    config.setHostedAccountSession({ accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800, userId: 'user', email: 'legacy@example.com' });
+    const state = await account.hostedAccountState(false);
+    process.stdout.write(JSON.stringify({ state, session: config.getHostedAccountSession() }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.state.signedIn, true);
+  assert.equal(output.state.email, 'legacy@example.com');
+  assert.equal(output.session.displayName, undefined);
+});
+
+test('a hanging optional profile lookup does not delay usable account state', () => {
+  const result = runIsolated(`
+    globalThis.fetch = async (url) => {
+      if (String(url).endsWith('/auth/v1/user')) return new Promise(() => {});
+      throw new Error('unexpected URL ' + url);
+    };
+    const config = await import('./server/app-config.ts');
+    const account = await import('./server/hosted-account.ts');
+    config.setHostedAccountSession({ accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800, userId: 'user', email: 'legacy@example.com' });
+    account.rememberHostedQuota({
+      plan: 'free', grantedTokens: 1000000, usedTokens: 12, reservedTokens: 0,
+      remainingTokens: 999988, periodStartedAt: '2026-08-01T00:00:00.000Z', periodEndsAt: '2026-09-01T00:00:00.000Z',
+    });
+    const outcome = await Promise.race([
+      account.hostedAccountState(false).then((state) => ({ kind: 'state', state })),
+      new Promise((resolve) => setTimeout(() => resolve({ kind: 'timeout' }), 100)),
+    ]);
+    process.stdout.write(JSON.stringify(outcome));
+    process.exit(0);
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.kind, 'state');
+  assert.equal(output.state.signedIn, true);
+  assert.equal(output.state.email, 'legacy@example.com');
+});
+
+test('a legacy session hydrates optional profile data without signing in again', () => {
+  const result = runIsolated(`
+    globalThis.fetch = async (url) => {
+      if (String(url).endsWith('/auth/v1/user')) return Response.json({
+        id: 'user', email: 'legacy@example.com',
+        user_metadata: { full_name: 'Legacy Person', picture: 'https://lh3.googleusercontent.com/a/legacy' },
+      });
+      return Response.json({ error: 'quota offline' }, { status: 503 });
+    };
+    const config = await import('./server/app-config.ts');
+    const account = await import('./server/hosted-account.ts');
+    config.setHostedAccountSession({ accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800, userId: 'user', email: 'legacy@example.com' });
+    const state = await account.hostedAccountState(false);
+    process.stdout.write(JSON.stringify({ state, session: config.getHostedAccountSession() }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.state.displayName, 'Legacy Person');
+  assert.equal(output.state.avatarUrl, '/api/account/avatar');
+  assert.equal(output.session.avatarUrl, 'https://lh3.googleusercontent.com/a/legacy');
+});
+
+test('avatar fetch is same-host, typed, bounded, and cached', () => {
+  const result = runIsolated(`
+    let calls = 0;
+    globalThis.fetch = async (url) => {
+      calls += 1;
+      if (!String(url).startsWith('https://lh3.googleusercontent.com/')) throw new Error('unexpected host');
+      return new Response(new Uint8Array([1, 2, 3]), { headers: { 'content-type': 'image/png', 'content-length': '3' } });
+    };
+    const config = await import('./server/app-config.ts');
+    const account = await import('./server/hosted-account.ts');
+    config.setHostedAccountSession({
+      accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800,
+      userId: 'user', email: 'person@example.com', avatarUrl: 'https://lh3.googleusercontent.com/a/photo',
+    });
+    const first = await account.hostedAccountAvatar();
+    const second = await account.hostedAccountAvatar();
+    process.stdout.write(JSON.stringify({ calls, contentType: first.contentType, bytes: [...first.bytes], same: first.bytes === second.bytes }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), { calls: 1, contentType: 'image/png', bytes: [1, 2, 3], same: true });
+});
+
+test('avatar fetch rejects oversized or incorrectly typed provider responses', () => {
+  const result = runIsolated(`
+    const config = await import('./server/app-config.ts');
+    const account = await import('./server/hosted-account.ts');
+    config.setHostedAccountSession({
+      accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800,
+      userId: 'user', email: 'person@example.com', avatarUrl: 'https://lh3.googleusercontent.com/a/photo',
+    });
+    globalThis.fetch = async () => new Response('not an image', { headers: { 'content-type': 'text/html' } });
+    const wrongType = await account.hostedAccountAvatar().then(() => null, (error) => error.message);
+    globalThis.fetch = async () => new Response(new Uint8Array([1]), { headers: { 'content-type': 'image/png', 'content-length': String(2 * 1024 * 1024 + 1) } });
+    const oversized = await account.hostedAccountAvatar().then(() => null, (error) => error.message);
+    process.stdout.write(JSON.stringify({ wrongType, oversized }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.match(output.wrongType, /unsupported content type/u);
+  assert.match(output.oversized, /too large/u);
+});
+
+test('sign out clears display profile data with the local session', () => {
+  const result = runIsolated(`
+    globalThis.fetch = async () => Response.json({});
+    const config = await import('./server/app-config.ts');
+    const account = await import('./server/hosted-account.ts');
+    config.setHostedAccountSession({
+      accessToken: 'access', refreshToken: 'refresh', expiresAt: 4102444800,
+      userId: 'user', email: 'person@example.com', displayName: 'Person',
+      avatarUrl: 'https://lh3.googleusercontent.com/a/photo',
+    });
+    await account.signOutHostedAccount();
+    process.stdout.write(JSON.stringify({ session: config.getHostedAccountSession() ?? null, state: await account.hostedAccountState() }));
+  `);
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), { session: null, state: { signedIn: false, active: false } });
 });
 
 test('loopback broker translates OpenAI requests and preserves query purpose', () => {
@@ -264,7 +446,11 @@ test('concurrent hosted token refreshes share one request', () => {
     };
     const config = await import('./server/app-config.ts');
     const account = await import('./server/hosted-account.ts');
-    config.setHostedAccountSession({ accessToken: 'access-old', refreshToken: 'refresh-old', expiresAt: 1, userId: 'user', email: 'person@example.com' });
+    config.setHostedAccountSession({
+      accessToken: 'access-old', refreshToken: 'refresh-old', expiresAt: 1,
+      userId: 'user', email: 'person@example.com', displayName: 'Existing Person',
+      avatarUrl: 'https://lh3.googleusercontent.com/a/existing',
+    });
     const tokens = await Promise.all([account.hostedAccessToken(), account.hostedAccessToken(), account.hostedAccessToken({ forceRefresh: true })]);
     process.stdout.write(JSON.stringify({ refreshCalls, tokens, session: config.getHostedAccountSession() }));
   `);
@@ -273,6 +459,8 @@ test('concurrent hosted token refreshes share one request', () => {
   assert.equal(output.refreshCalls, 1);
   assert.deepEqual(output.tokens, ['access-new', 'access-new', 'access-new']);
   assert.equal(output.session.refreshToken, 'refresh-new');
+  assert.equal(output.session.displayName, 'Existing Person');
+  assert.equal(output.session.avatarUrl, 'https://lh3.googleusercontent.com/a/existing');
 });
 
 test('a stale failed refresh cannot clear a newer hosted session', () => {

--- a/server/hosted-account.ts
+++ b/server/hosted-account.ts
@@ -16,6 +16,7 @@ import {
   setHostedAccountSession,
   type HostedAccountSession,
 } from './app-config.ts';
+import { normalizeHostedDisplayName, parseGoogleAvatarUrl } from './hosted-account-profile.ts';
 
 export const STASHBASE_API_URL = 'https://api.stashbase.ai';
 const SUPABASE_URL = 'https://vqtfigkoihpuziaimluf.supabase.co';
@@ -24,12 +25,18 @@ const SUPABASE_URL = 'https://vqtfigkoihpuziaimluf.supabase.co';
 const SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_D-S7Ry-IWC9pTdDx6DHHHw_-mmaTp3b';
 const CLIENT_VERSION = packageJson.version;
 
+interface SupabaseUser {
+  id?: string;
+  email?: string;
+  user_metadata?: Record<string, unknown>;
+  identities?: Array<{ provider?: string; identity_data?: Record<string, unknown> }>;
+}
 interface SupabaseTokenResponse {
   access_token?: string;
   refresh_token?: string;
   expires_at?: number;
   expires_in?: number;
-  user?: { id?: string; email?: string };
+  user?: SupabaseUser;
   error?: string;
   error_description?: string;
   msg?: string;
@@ -62,6 +69,14 @@ let quotaRefreshTimer: NodeJS.Timeout | null = null;
 let onQuotaAvailable: (() => void | Promise<void>) | null = null;
 let quotaAvailabilityRecovery: Promise<void> = Promise.resolve();
 let tokenRefresh: { sessionKey: string; promise: Promise<string> } | null = null;
+let profileHydration: { sessionKey: string; attemptedAt: number; promise: Promise<void> } | null = null;
+const PROFILE_HYDRATION_RETRY_MS = 5 * 60 * 1000;
+const PROFILE_TIMEOUT_MS = 3_000;
+const AVATAR_MAX_BYTES = 2 * 1024 * 1024;
+const AVATAR_TIMEOUT_MS = 5_000;
+const AVATAR_MAX_REDIRECTS = 2;
+const AVATAR_CONTENT_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/avif']);
+let avatarCache: { key: string; contentType: string; bytes: Uint8Array } | null = null;
 
 function messageOf(value: ErrorPayload | null, fallback: string): string {
   return value?.message ?? value?.error_description ?? value?.msg ?? value?.error ?? fallback;
@@ -69,6 +84,19 @@ function messageOf(value: ErrorPayload | null, fallback: string): string {
 
 async function jsonBody<T>(response: Response): Promise<T | null> {
   try { return await response.json() as T; } catch { return null; }
+}
+
+export function normalizedGoogleProfile(user: SupabaseUser | undefined): Pick<HostedAccountSession, 'displayName' | 'avatarUrl'> {
+  const metadata = user?.user_metadata;
+  const identity = user?.identities?.find((candidate) => candidate.provider === 'google')?.identity_data;
+  const displayName = [metadata?.full_name, metadata?.name, identity?.full_name, identity?.name]
+    .map(normalizeHostedDisplayName).find((value) => value !== undefined);
+  const avatarUrl = [metadata?.avatar_url, metadata?.picture, identity?.avatar_url, identity?.picture]
+    .map(parseGoogleAvatarUrl).find((value) => value !== undefined)?.toString();
+  return {
+    ...(displayName ? { displayName } : {}),
+    ...(avatarUrl ? { avatarUrl } : {}),
+  };
 }
 
 function sessionFrom(value: SupabaseTokenResponse, fallback?: HostedAccountSession): HostedAccountSession {
@@ -80,7 +108,12 @@ function sessionFrom(value: SupabaseTokenResponse, fallback?: HostedAccountSessi
   if (!accessToken || !refreshToken || !userId || !email || !expiresAt) {
     throw new Error('Supabase returned an incomplete login session.');
   }
-  return { accessToken, refreshToken, userId, email, expiresAt };
+  const profile = normalizedGoogleProfile(value.user);
+  return {
+    accessToken, refreshToken, userId, email, expiresAt,
+    ...(profile.displayName ? { displayName: profile.displayName } : fallback?.displayName ? { displayName: fallback.displayName } : {}),
+    ...(profile.avatarUrl ? { avatarUrl: profile.avatarUrl } : fallback?.avatarUrl ? { avatarUrl: fallback.avatarUrl } : {}),
+  };
 }
 
 async function supabaseAuth(path: string, body: Record<string, unknown>, accessToken?: string): Promise<SupabaseTokenResponse> {
@@ -96,6 +129,22 @@ async function supabaseAuth(path: string, body: Record<string, unknown>, accessT
   const payload = await jsonBody<SupabaseTokenResponse>(response);
   if (!response.ok) throw new Error(messageOf(payload ?? null, `Supabase authentication failed (HTTP ${response.status}).`));
   return payload ?? {};
+}
+
+async function supabaseUser(accessToken: string): Promise<SupabaseUser> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROFILE_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${SUPABASE_URL}/auth/v1/user`, {
+      headers: { apikey: SUPABASE_PUBLISHABLE_KEY, authorization: `Bearer ${accessToken}` },
+      signal: controller.signal,
+    });
+    const payload = await jsonBody<SupabaseUser & ErrorPayload>(response);
+    if (!response.ok) throw new Error(messageOf(payload, `Supabase profile lookup failed (HTTP ${response.status}).`));
+    return payload ?? {};
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function base64Url(bytes: Buffer): string {
@@ -282,8 +331,93 @@ export async function signOutHostedAccount(): Promise<void> {
   const session = getHostedAccountSession();
   clearHostedQuota();
   setHostedAccountSession(undefined);
+  avatarCache = null;
+  profileHydration = null;
   if (!session) return;
   try { await supabaseAuth('/logout?scope=local', {}, session.accessToken); } catch { /* local sign-out still succeeds */ }
+}
+
+async function hydrateHostedProfile(session: HostedAccountSession): Promise<void> {
+  if (session.displayName && session.avatarUrl) return;
+  const sessionKey = `${session.userId}\0${session.accessToken}`;
+  const now = Date.now();
+  if (profileHydration?.sessionKey === sessionKey) {
+    if (now - profileHydration.attemptedAt < PROFILE_HYDRATION_RETRY_MS) return profileHydration.promise;
+  }
+  const promise = (async () => {
+    const user = await supabaseUser(session.accessToken);
+    const profile = normalizedGoogleProfile(user);
+    if (!profile.displayName && !profile.avatarUrl) return;
+    const current = getHostedAccountSession();
+    if (!current || current.userId !== session.userId || current.accessToken !== session.accessToken) return;
+    setHostedAccountSession({
+      ...current,
+      ...(profile.displayName ? { displayName: profile.displayName } : {}),
+      ...(profile.avatarUrl ? { avatarUrl: profile.avatarUrl } : {}),
+    });
+  })();
+  profileHydration = { sessionKey, attemptedAt: now, promise };
+  return promise;
+}
+
+function assertAvatarUrl(value: string): URL {
+  const url = parseGoogleAvatarUrl(value);
+  if (!url) throw new Error('Account avatar URL is not allowed.');
+  return url;
+}
+
+/** Fetch the signed-in account's provider avatar without exposing a general
+ * URL proxy. Redirects stay on the exact allowlisted HTTPS host; bodies are
+ * type-, time-, and size-bounded before entering the renderer boundary. */
+export async function hostedAccountAvatar(): Promise<{ contentType: string; bytes: Uint8Array } | null> {
+  const session = getHostedAccountSession();
+  if (!session?.avatarUrl) return null;
+  const key = `${session.userId}\0${session.avatarUrl}`;
+  if (avatarCache?.key === key) return { contentType: avatarCache.contentType, bytes: avatarCache.bytes };
+  let url = assertAvatarUrl(session.avatarUrl);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), AVATAR_TIMEOUT_MS);
+  try {
+    let response: Response | null = null;
+    for (let redirects = 0; redirects <= AVATAR_MAX_REDIRECTS; redirects++) {
+      response = await fetch(url, {
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: { accept: 'image/avif,image/webp,image/png,image/jpeg' },
+      });
+      if (![301, 302, 303, 307, 308].includes(response.status)) break;
+      if (redirects === AVATAR_MAX_REDIRECTS) throw new Error('Account avatar redirected too many times.');
+      const location = response.headers.get('location');
+      if (!location) throw new Error('Account avatar redirect was incomplete.');
+      url = assertAvatarUrl(new URL(location, url).toString());
+    }
+    if (!response?.ok) throw new Error(`Account avatar failed (HTTP ${response?.status ?? 0}).`);
+    const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+    if (!AVATAR_CONTENT_TYPES.has(contentType)) throw new Error('Account avatar returned an unsupported content type.');
+    const declaredLength = Number(response.headers.get('content-length'));
+    if (Number.isFinite(declaredLength) && declaredLength > AVATAR_MAX_BYTES) throw new Error('Account avatar is too large.');
+    if (!response.body) throw new Error('Account avatar returned no content.');
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > AVATAR_MAX_BYTES) {
+        await reader.cancel();
+        throw new Error('Account avatar is too large.');
+      }
+      chunks.push(value);
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+    avatarCache = { key, contentType, bytes };
+    return { contentType, bytes };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function fetchHostedQuota(options: { forceRefreshToken?: boolean } = {}): Promise<HostedQuota> {
@@ -350,8 +484,9 @@ export function setHostedQuotaAvailableHandler(handler: (() => void | Promise<vo
 }
 
 export async function hostedAccountState(refreshQuota = false): Promise<HostedAccountState> {
-  const session = getHostedAccountSession();
+  let session = getHostedAccountSession();
   if (!session) return { signedIn: false, active: false };
+  void hydrateHostedProfile(session).catch(() => { /* display-only profile data never gates account or local workflows */ });
   let quota = lastQuota;
   let quotaUnavailable = false;
   if (refreshQuota || !quota) {
@@ -362,10 +497,13 @@ export async function hostedAccountState(refreshQuota = false): Promise<HostedAc
       quotaUnavailable = true;
     }
   }
+  session = getHostedAccountSession() ?? session;
   return {
     signedIn: true,
     active: getEmbeddingSource() === 'stashbase-account',
     email: session.email,
+    ...(session.displayName ? { displayName: session.displayName } : {}),
+    ...(session.avatarUrl ? { avatarUrl: '/api/account/avatar' } : {}),
     ...(quota ? { quota } : {}),
     ...(quotaUnavailable ? { quotaUnavailable: true } : {}),
   };

--- a/server/routes/account.ts
+++ b/server/routes/account.ts
@@ -10,6 +10,7 @@ import {
   failHostedOAuth,
   finishHostedOAuth,
   hostedAccountState,
+  hostedAccountAvatar,
   hostedOAuthStatus,
   noteHostedOAuthAppReturn,
   noteHostedOAuthReturnIntent,
@@ -63,6 +64,21 @@ export function mount(app: express.Express, { appReturnToken }: AccountRouteOpti
   app.get('/api/account', async (req, res) => {
     const refresh = req.query.refresh === '1';
     res.json(await hostedAccountState(refresh));
+  });
+
+  app.get('/api/account/avatar', async (_req, res) => {
+    try {
+      const avatar = await hostedAccountAvatar();
+      if (!avatar) return res.status(404).end();
+      res.setHeader('content-type', avatar.contentType);
+      res.setHeader('cache-control', 'private, no-store');
+      res.setHeader('x-content-type-options', 'nosniff');
+      res.end(Buffer.from(avatar.bytes));
+    } catch {
+      // Avatar display is optional. Fail closed to the renderer fallback
+      // without exposing provider URLs or upstream diagnostics.
+      res.status(404).end();
+    }
   });
 
   app.post('/api/account/oauth/start', (req, res) => {

--- a/shared/account.ts
+++ b/shared/account.ts
@@ -23,6 +23,9 @@ export interface HostedAccountState {
   signedIn: boolean;
   active: boolean;
   email?: string;
+  displayName?: string;
+  /** Same-origin renderer endpoint; the provider URL remains Node-only. */
+  avatarUrl?: string;
   quota?: HostedQuota;
   /** Signed in, but the hosted service could not be reached to report
    *  usage. Distinct from having no allowance left. */

--- a/web-src/src/common/__tests__/account-identity.test.ts
+++ b/web-src/src/common/__tests__/account-identity.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import React, { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import { AccountAvatar, accountDisplayLabel, accountInitials } from '@/common/components/AccountIdentity';
+
+(globalThis as { React?: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function renderAccount(email: string, displayName: string) {
+  return createElement(AccountAvatar, {
+    account: { email, displayName, avatarUrl: '/api/account/avatar' },
+  });
+}
+
+test('account identity uses provider name, then email, without synthesizing a name', () => {
+  assert.equal(accountDisplayLabel({ displayName: 'Ada Lovelace', email: 'ada@example.com' }), 'Ada Lovelace');
+  assert.equal(accountDisplayLabel({ email: 'whole.address@example.com' }), 'whole.address@example.com');
+  assert.equal(accountDisplayLabel({}), 'Anonymous');
+  assert.equal(accountInitials({ displayName: 'Ada Lovelace', email: 'wrong@example.com' }), 'AL');
+  assert.equal(accountInitials({ displayName: 'Prince' }), 'PR');
+  assert.equal(accountInitials({ email: 'grace.hopper@example.com' }), 'GH');
+  assert.equal(accountInitials({}), '');
+});
+
+test('account avatar keeps a stable decorative fallback after image failure', async () => {
+  let renderer: ReactTestRenderer | undefined;
+  await act(async () => {
+    renderer = create(createElement(AccountAvatar, {
+      account: { displayName: 'Ada Lovelace', email: 'ada@example.com', avatarUrl: '/api/account/avatar' },
+    }));
+  });
+  const image = renderer!.root.findByType('img');
+  assert.equal(image.props.alt, '');
+  assert.equal(image.props.referrerPolicy, 'no-referrer');
+  assert.match(image.props.className, /opacity-0/u, 'fallback stays visible until the image has loaded');
+  assert.match(JSON.stringify(renderer!.toJSON()), /AL/u);
+  await act(async () => image.props.onError());
+  assert.equal(renderer!.root.findAllByType('img').length, 0);
+  assert.match(JSON.stringify(renderer!.toJSON()), /AL/u);
+  await act(async () => renderer?.unmount());
+});
+
+test('account avatar resets loading and failure state when identity changes behind the same endpoint', async () => {
+  let renderer: ReactTestRenderer | undefined;
+  await act(async () => { renderer = create(renderAccount('ada@example.com', 'Ada Lovelace')); });
+  const firstImage = renderer!.root.findByType('img');
+  await act(async () => firstImage.props.onLoad());
+  assert.match(renderer!.root.findByType('img').props.className, /opacity-100/u);
+
+  await act(async () => renderer!.update(renderAccount('grace@example.com', 'Grace Hopper')));
+  const secondImage = renderer!.root.findByType('img');
+  assert.notEqual(secondImage, firstImage, 'identity change recreates the same-URL image element');
+  assert.match(secondImage.props.className, /opacity-0/u, 'the previous person’s loaded image is not retained');
+  await act(async () => secondImage.props.onError());
+  assert.equal(renderer!.root.findAllByType('img').length, 0);
+
+  await act(async () => renderer!.update(renderAccount('dorothy@example.com', 'Dorothy Vaughan')));
+  assert.equal(renderer!.root.findAllByType('img').length, 1, 'the next account retries the shared avatar endpoint');
+  await act(async () => renderer?.unmount());
+});

--- a/web-src/src/common/components/AccountIdentity.tsx
+++ b/web-src/src/common/components/AccountIdentity.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import type { HostedAccountState } from '@/common/api/apiTypes';
+import { UserIcon } from '@/common/components/icons';
+import { cn } from '@/common/lib/utils';
+
+function firstCharacter(value: string): string {
+  return Array.from(value)[0] ?? '';
+}
+
+export function accountDisplayLabel(account: Pick<HostedAccountState, 'displayName' | 'email'>): string {
+  return account.displayName?.trim() || account.email?.trim() || 'Anonymous';
+}
+
+export function accountInitials(account: Pick<HostedAccountState, 'displayName' | 'email'>): string {
+  const name = account.displayName?.trim();
+  if (name) {
+    const words = name.split(/\s+/u).filter(Boolean);
+    return (words.length > 1
+      ? firstCharacter(words[0]) + firstCharacter(words.at(-1)!)
+      : Array.from(words[0]).slice(0, 2).join('')).toUpperCase();
+  }
+  const email = account.email?.trim();
+  if (!email) return '';
+  const local = email.split('@', 1)[0];
+  const parts = local.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+  return (parts.length > 1
+    ? firstCharacter(parts[0]) + firstCharacter(parts.at(-1)!)
+    : Array.from(local).slice(0, 2).join('')).toUpperCase();
+}
+
+/** One stable-size, decorative account image with a fallback underneath it.
+ * Empty alt avoids announcing identity twice beside the visible account text. */
+export function AccountAvatar({
+  account,
+  className = 'size-8',
+  initialsClassName = 'text-xs',
+}: {
+  account: Pick<HostedAccountState, 'displayName' | 'email' | 'avatarUrl'>;
+  className?: string;
+  initialsClassName?: string;
+}) {
+  const imageKey = `${account.email?.trim().toLowerCase() ?? ''}\0${account.avatarUrl ?? ''}`;
+  const [failedKey, setFailedKey] = useState<string | null>(null);
+  const [loadedKey, setLoadedKey] = useState<string | null>(null);
+  useEffect(() => { setFailedKey(null); setLoadedKey(null); }, [imageKey]);
+  const initials = accountInitials(account);
+  const showImage = !!account.avatarUrl && failedKey !== imageKey;
+  return (
+    <span className={cn('relative inline-flex flex-none items-center justify-center overflow-hidden rounded-full bg-accent/15 text-accent', className)} aria-hidden="true">
+      {initials
+        ? <span className={cn('font-semibold', initialsClassName)}>{initials}</span>
+        : <UserIcon className="size-3/5" />}
+      {showImage && (
+        <img
+          key={imageKey}
+          src={account.avatarUrl}
+          alt=""
+          className={cn('absolute inset-0 size-full object-cover', loadedKey === imageKey ? 'opacity-100' : 'opacity-0')}
+          draggable={false}
+          referrerPolicy="no-referrer"
+          onLoad={() => setLoadedKey(imageKey)}
+          onError={() => setFailedKey(imageKey)}
+        />
+      )}
+    </span>
+  );
+}

--- a/web-src/src/features/account/components/SidebarAccountRow.tsx
+++ b/web-src/src/features/account/components/SidebarAccountRow.tsx
@@ -1,5 +1,5 @@
 import { electronBridge } from '@/common/lib/electronBridge';
-import { BugIcon, DiscordIcon, ExternalLinkIcon, SettingsIcon } from '@/common/components/icons';
+import { BugIcon, DiscordIcon, ExternalLinkIcon, SettingsIcon, UserIcon } from '@/common/components/icons';
 import { AccountAvatar, accountDisplayLabel } from '@/common/components/AccountIdentity';
 import { useHostedAccount } from '@/features/account/hooks/useHostedAccount';
 import { DISCORD_INVITE_URL, openExternalUrl } from '@/common/lib/externalLink';
@@ -46,7 +46,17 @@ export function SidebarAccountRow() {
             title="Account"
             aria-label={`Account: ${accessibleLabel}`}
           >
-            <AccountAvatar account={account?.signedIn ? account : {}} className="size-4" initialsClassName="text-2xs" />
+            {account?.signedIn
+              ? <AccountAvatar account={account} className="size-4" initialsClassName="text-2xs" />
+              : (
+                // Preserve the long-standing anonymous affordance. Hosted
+                // identity owns the new avatar/initial fallback only after
+                // sign-in, so an account feature does not restyle local mode.
+                <span className="relative inline-flex size-4 flex-none items-center justify-center">
+                  <span className="absolute inset-[-3px] rounded-full bg-muted" aria-hidden="true" />
+                  <UserIcon className="relative size-3.5" />
+                </span>
+              )}
             <span className={cn('min-w-0 truncate transition-tint', email ? 'text-muted-foreground' : 'text-placeholder group-hover/account:text-muted-foreground')}>
               {label}
             </span>

--- a/web-src/src/features/account/components/SidebarAccountRow.tsx
+++ b/web-src/src/features/account/components/SidebarAccountRow.tsx
@@ -1,5 +1,6 @@
 import { electronBridge } from '@/common/lib/electronBridge';
-import { BugIcon, DiscordIcon, ExternalLinkIcon, SettingsIcon, UserIcon } from '@/common/components/icons';
+import { BugIcon, DiscordIcon, ExternalLinkIcon, SettingsIcon } from '@/common/components/icons';
+import { AccountAvatar, accountDisplayLabel } from '@/common/components/AccountIdentity';
 import { useHostedAccount } from '@/features/account/hooks/useHostedAccount';
 import { DISCORD_INVITE_URL, openExternalUrl } from '@/common/lib/externalLink';
 import { openSettings } from '@/common/lib/settingsTrigger';
@@ -27,8 +28,8 @@ export function SidebarAccountRow() {
   const { account, signingIn, signInError, refresh, signIn, signOut } = useHostedAccount();
 
   const email = account?.signedIn ? account.email ?? '' : '';
-  const label = email || 'Anonymous';
-  const monogram = email ? email.slice(0, 2).toUpperCase() : '';
+  const label = account?.signedIn ? accountDisplayLabel(account) : 'Anonymous';
+  const accessibleLabel = account?.signedIn && email && label !== email ? `${label} (${email})` : label;
   const quota = account?.quota;
   const remainingPercent = quota ? hostedQuotaRemainingPercent(quota) : null;
 
@@ -43,14 +44,9 @@ export function SidebarAccountRow() {
           <MenuTrigger
             className="group/account flex min-h-7 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md border-0 bg-transparent px-2 text-left text-base text-muted-foreground hover:text-foreground"
             title="Account"
-            aria-label={`Account: ${label}`}
+            aria-label={`Account: ${accessibleLabel}`}
           >
-            <span className="relative inline-flex size-4 flex-none items-center justify-center">
-              <span className="absolute inset-[-3px] rounded-full bg-muted" aria-hidden="true" />
-              {monogram
-                ? <span className="relative text-2xs font-semibold text-foreground">{monogram}</span>
-                : <UserIcon className="relative size-3.5" />}
-            </span>
+            <AccountAvatar account={account?.signedIn ? account : {}} className="size-4" initialsClassName="text-2xs" />
             <span className={cn('min-w-0 truncate transition-tint', email ? 'text-muted-foreground' : 'text-placeholder group-hover/account:text-muted-foreground')}>
               {label}
             </span>
@@ -61,10 +57,10 @@ export function SidebarAccountRow() {
                 {account?.signedIn ? (
                   <>
                     <div className="flex items-center gap-2.5 px-4 py-3">
-                      <span className="flex size-8 items-center justify-center rounded-full bg-accent/15 text-xs font-semibold text-accent">{monogram}</span>
+                      <AccountAvatar account={account} />
                       <div className="min-w-0">
-                        <div className="truncate text-sm font-semibold">{email.split('@')[0]}</div>
-                        <div className="truncate text-xs text-muted-foreground">{email}</div>
+                        <div className="truncate text-sm font-semibold">{label}</div>
+                        {label !== email && <div className="truncate text-xs text-muted-foreground">{email}</div>}
                       </div>
                     </div>
                     <MenuSeparator className="m-0" />

--- a/web-src/src/features/settings/components/EmbeddingPanel.tsx
+++ b/web-src/src/features/settings/components/EmbeddingPanel.tsx
@@ -6,7 +6,7 @@
  * `EmbedderRequireKeyGate` so it fires whether or not Settings is open.
  */
 import { useState } from 'react';
-import { type EmbedderProvider } from '@/common/api/apiTypes';
+import { type EmbedderProvider, type HostedAccountState } from '@/common/api/apiTypes';
 import { useEmbedderSettings } from '@/features/settings/hooks/useEmbedderSettings';
 import { EmbeddingAuthChoice } from '@/features/settings/components/embedder/EmbeddingAuthChoice';
 import { KeyModal } from '@/features/settings/components/embedder/KeyModal';
@@ -20,6 +20,8 @@ import { AccountSignInForm } from '@/common/components/AccountSignInForm';
 import { hostedQuotaRemainingPercent, hostedQuotaResetLabel } from '@/common/lib/hostedQuota';
 import { SectionDescription, SectionHeading } from '@/common/components/ui/section';
 import { Card } from '@/common/components/ui/card';
+import { AccountAvatar, accountDisplayLabel } from '@/common/components/AccountIdentity';
+import { cn } from '@/common/lib/utils';
 
 const PROVIDERS: Record<EmbedderProvider, { label: string; model: string; placeholder: string; costHint: string }> = {
   openai: {
@@ -37,6 +39,34 @@ const PROVIDERS: Record<EmbedderProvider, { label: string; model: string; placeh
 };
 
 const PROVIDER_ORDER: EmbedderProvider[] = ['openai', 'openrouter'];
+
+function AccountSummary({
+  account,
+  labelPrefix,
+  description,
+  heading = false,
+}: {
+  account: HostedAccountState;
+  labelPrefix?: string;
+  description: string;
+  heading?: boolean;
+}) {
+  const label = `${labelPrefix ?? ''}${accountDisplayLabel(account)}`;
+  return (
+    <div className="flex min-w-0 items-center gap-2.5">
+      <AccountAvatar account={account} />
+      <div className="min-w-0">
+        {heading
+          ? <SectionHeading level={4} className="truncate">{label}</SectionHeading>
+          : <div className="truncate text-sm font-medium">{label}</div>}
+        {account.displayName && account.email && (
+          <div className="truncate text-xs text-muted-foreground">{account.email}</div>
+        )}
+        <div className={cn('text-xs text-muted-foreground', heading && 'mt-0.5')}>{description}</div>
+      </div>
+    </div>
+  );
+}
 
 export function EmbeddingPanel() {
   const {
@@ -102,13 +132,14 @@ export function EmbeddingPanel() {
           {showingHostedSummary && (
             <Card surface="raised" className="p-4">
               <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  {/* The card's own title, so a heading rather than a bold
-                    * line: level 4 sits under the panel's level 3, which in
-                    * turn sits under the Settings dialog title's h2. */}
-                  <SectionHeading level={4} className="truncate">{state.account.email}</SectionHeading>
-                  <div className="mt-0.5 text-xs text-muted-foreground">Using the StashBase account allowance</div>
-                </div>
+                {/* The card's own title, so a heading rather than a bold
+                  * line: level 4 sits under the panel's level 3, which in
+                  * turn sits under the Settings dialog title's h2. */}
+                <AccountSummary
+                  account={state.account}
+                  description="Using the StashBase account allowance"
+                  heading
+                />
                 {state.account.quota && (
                   <div className="text-right">
                     <div className="text-base font-semibold">{hostedQuotaRemainingPercent(state.account.quota)}%</div>
@@ -157,10 +188,11 @@ export function EmbeddingPanel() {
           )}
           {state.account.signedIn && !hostedActive && !signInFormOpen && (
             <Card surface="raised" className="mb-3 flex items-center justify-between gap-3 px-3 py-2.5">
-              <div className="min-w-0">
-                <div className="truncate text-sm font-medium">Signed in as {state.account.email}</div>
-                <div className="text-xs text-muted-foreground">Your own API key is currently active.</div>
-              </div>
+              <AccountSummary
+                account={state.account}
+                labelPrefix="Signed in as "
+                description="Your own API key is currently active."
+              />
               <Button
                 variant="outline"
                 size="sm"


### PR DESCRIPTION
## Summary
- persist and expose normalized Google display names and same-origin avatars
- render one consistent account identity in the sidebar, account menu, and AI Index Settings
- hydrate legacy sessions without blocking account or local workflows
- constrain provider avatar fetching by host, type, redirects, size, timeout, and cache
- update product/review contracts and regression coverage

This extracts and completes the account-identity scope proposed in #182 without its unrelated inline-rename changes.

## Validation
- typecheck (server, renderer, E2E)
- web lint and API-boundary scan
- web/server builds and renderer chunk budget
- hosted account tests (18/18)
- renderer tests (455/455)
- Electron smoke (9/9)
- docs and E2E focus checks

Fixes #172