### PR TITLE
test(frontend): add renderer quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,47 @@ on:
     branches: [main, 'release/**']
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
+  renderer-quality:
+    name: Renderer quality gates (Ubuntu)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.5.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Test renderer quality gate contract
+        run: pnpm test:renderer-quality-gates
+
+      - name: Audit renderer fundamentals
+        id: shadscan
+        uses: TheOrcDev/shadscan@1d4415ac799f453fe5ef192cf7f165433aa4e82b # v0.17.0
+        with:
+          path: .
+          version: '0.17.0'
+          fail-under: '45'
+          create-issue: 'false'
+
+      - name: Upload ShadScan report
+        if: ${{ always() && steps.shadscan.outputs.report-path != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: shadscan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.shadscan.outputs.report-path }}
+          if-no-files-found: error
+          retention-days: 14
+
   source-build:
     name: Source build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/code-review/document-viewers.md
+++ b/code-review/document-viewers.md
@@ -56,7 +56,10 @@ forwarding, and script confinement.
   and holds one scroll owner and no preparation state.
 - DOCX fetches source bytes, parses in a renderer Worker, sanitizes output, and
   falls back to durable prepared HTML after a `20 s` direct-preview deadline.
-  Server preparation has its own `60 s` worker deadline.
+  A parse, fetch, or timeout failure keeps an explicit direct-preview warning
+  above the fallback; it does not depend on or fabricate a preparation failure.
+  Reprocess remains available only for a real preparation failure. Server
+  preparation has its own `60 s` worker deadline.
 - Local HTML is served with the viewer bootstrap the frame needs — heading
   ids, anchor scroll, the in-frame Find half, external-link forwarding, and a
   neutral scrollbar rule. Injected chrome is a default, not an override: it

--- a/code-review/journey-coverage.md
+++ b/code-review/journey-coverage.md
@@ -82,8 +82,11 @@ aliases, and Journey E2E owns representative composition.
 - **Journey E2E:** [launch smoke](../e2e/smoke/launch.spec.ts) and
   [library navigation](../e2e/journeys/library-navigation.spec.ts) exercise
   blank-workspace entry, AI Index skip behavior, folder selection, and local
-  availability. They do not yet prove the full orientation, first-value, and
-  return sequence as one onboarding outcome.
+  availability. [Navigation layout](../e2e/journeys/navigation-layout.spec.ts)
+  verifies that Appearance Settings remains usable with the operating system's
+  reduced-motion preference while transform movement is removed and quiet
+  state feedback remains. These checks do not yet prove the full orientation,
+  first-value, and return sequence as one onboarding outcome.
 - **AI Eval:** onboarding mechanics are deterministic. If first value uses
   semantic retrieval or a real Agent, its quality evidence comes from J05 or
   J10 rather than being duplicated here.

--- a/code-review/journey-coverage.md
+++ b/code-review/journey-coverage.md
@@ -133,8 +133,8 @@ aliases, and Journey E2E owns representative composition.
   [library mutations](../e2e/journeys/library-mutations.spec.ts), and
   [format and media](../e2e/journeys/formats-media.spec.ts) cover representative
   format classes and document work, including preview-only affordances,
-  external-write conflict recovery, and a live edit flushed through recovery
-  reload.
+  explicit PDF/DOCX preview-failure identity, external-write conflict recovery,
+  and a live edit flushed through recovery reload.
 - **AI Eval:** not required.
 - **Release Check:** complex packaged PDF, DOCX, and media behavior remains
   release evidence.

--- a/code-review/release-pipeline.md
+++ b/code-review/release-pipeline.md
@@ -31,6 +31,10 @@ before its metadata and payloads coexist.
   release/update/signing contracts, config/account, scheduler, cancellation,
   retrieval, renderer, server, MCP, Python, and real Electron lifecycle
   behavior.
+- A read-only Ubuntu renderer-quality job pins both the ShadScan Action
+  revision and CLI version, publishes the complete JSON report, and fails an
+  unassessed audit or a score below the reviewed baseline. It never launches an
+  Agent, creates an issue, or mutates repository state.
 - Ubuntu Playwright adds smoke, deterministic functional journeys, and reviewed
   visual baselines without replacing the three-platform source matrix.
 - Linux source Electron may use `--no-sandbox` under hosted Xvfb. Packaged apps
@@ -129,7 +133,7 @@ journeys.
 | Platform Adapters | `.github/workflows/release-macos.yml`, `release-linux.yml`, `release-windows.yml` |
 | Packaging Module | `scripts/package-desktop.mjs`, signing contracts, `scripts/update-artifact-contract.mjs`, `scripts/build-python-sidecar.mjs`, `scripts/build-transcription-sidecar.sh`, `scripts/after-pack-macos.cjs` |
 | Packaged verification | `scripts/smoke-packaged-server.mjs` and platform release verifiers |
-| Focused evidence | `scripts/package-inputs.test.mjs`, `scripts/require-green-ci.test.mjs`, signing contract tests, `scripts/update-release-contract.test.mjs`, `electron/update-install-strategy.test.cjs`, the platform workflows, and the N→N+1 release check |
+| Focused evidence | `scripts/renderer-quality-gates.test.mjs`, `scripts/package-inputs.test.mjs`, `scripts/require-green-ci.test.mjs`, signing contract tests, `scripts/update-release-contract.test.mjs`, `electron/update-install-strategy.test.cjs`, the platform workflows, and the N→N+1 release check |
 
 ## Release Runbook
 

--- a/code-review/renderer-styling.md
+++ b/code-review/renderer-styling.md
@@ -1097,6 +1097,17 @@ the tag.
 
 Extend them when the contract grows; never weaken one to land a change.
 
+The external ShadScan audit is a complementary regression signal for the
+shadcn/Base UI layer, not a substitute for these repository-owned invariants or
+browser evidence. CI pins the Action revision and CLI `0.17.0`, uploads the
+machine-readable report, and enforces the reviewed `45` floor. The baseline is
+intentionally not treated as a product-quality percentage: Electron/Vite
+implementations such as theme management, the Error Boundary, Toasts, and the
+command surface are observable in renderer and Playwright evidence even when
+that static ruleset does not recognize their custom wiring. Raise the floor
+only after reviewing a complete report; never add product behavior solely to
+silence an inapplicable rule.
+
 ## CSS exemptions — rules Tailwind utilities can't own
 
 These categories are still exempt from the utility-only rule; what changed
@@ -1178,7 +1189,7 @@ deletes its CSS import in the same change.
 | Overlay + measure geometry | `--overlay-w-*` / `--overlay-h-*` / `--measure-*` in `globals.css`; `--container-overlay-*` / `--container-measure-*` and `@utility max-h-overlay-*` / `max-w-overlay-fit` in `styles.css` |
 | Pane chrome offsets | `--chrome-top` / `--chrome-banner-h` / `--chrome-top-banner` in `globals.css`; `@utility top-chrome` / `top-chrome-banner` in `styles.css` |
 | Generated icon Adapter | source map in `scripts/gen-icons.mjs` → `web-src/src/common/components/icons.tsx` |
-| Focused evidence | `web-src/src/common/__tests__/renderer-foundation.test.ts`, `electron/tab-strip-layout-smoke.cjs`, and `e2e/visual/` |
+| Focused evidence | `web-src/src/common/__tests__/renderer-foundation.test.ts`, `scripts/renderer-quality-gates.test.mjs`, `electron/tab-strip-layout-smoke.cjs`, and `e2e/visual/` |
 
 ## Review checklist for styling changes
 

--- a/code-review/ui-regression-testing.md
+++ b/code-review/ui-regression-testing.md
@@ -151,6 +151,8 @@ MCP write inside the new project.
 ## Validation Commands
 
 ```bash
+pnpm test:renderer-quality-gates
+pnpm audit:renderer
 pnpm test:e2e:check-focus
 pnpm test:e2e:harness
 pnpm test:e2e:smoke
@@ -160,6 +162,14 @@ pnpm test:e2e:visual
 pnpm typecheck
 pnpm build:web
 ```
+
+The pinned ShadScan source audit complements, but does not replace, rendered
+evidence. Its reviewed floor protects the current static baseline and its JSON
+report remains a CI artifact. Playwright owns the claims that static analysis
+cannot decide: one keyboard-only Quick Open path with focus return, reduced
+motion on a real overlay, compact-layout continuity, both application themes,
+and Linux screenshots spanning application chrome, workspace navigation,
+command surfaces, and a document state.
 
 Use `pnpm test:e2e:debug` for an interactive local smoke run. On headless Linux,
 prefix Playwright with `xvfb-run -a`. `pnpm test:e2e:visual:update` is
@@ -179,6 +189,7 @@ do not copy a test count or per-test catalog into this contract.
 | Deterministic fixtures | `e2e/fixtures/journey-workspaces.ts`, `fake-extractor.mjs`, and the fake Codex app-server |
 | Required suites | `e2e/smoke/`, `e2e/journeys/`, and `e2e/visual/` |
 | Harness evidence | `e2e/harness/`, `e2e/support/fixtures.test.ts`, and CI summary reporter tests |
+| Static renderer audit | `pnpm audit:renderer` and `scripts/renderer-quality-gates.test.mjs` |
 | CI Adapter | `.github/workflows/ci.yml` and `.github/workflows/visual-baselines.yml` |
 
 ## Visual Baseline Workflow

--- a/design-docs/design/documents.md
+++ b/design-docs/design/documents.md
@@ -39,8 +39,10 @@ editor, a media editor, or a proprietary document format.
 - HTML is viewed as source content; the current compatibility preview executes
   local document scripts in a same-origin iframe. PDF uses its source document
   in the preview surface. DOCX uses a sanitized source-based preview with a
-  prepared fallback. Image and media viewers keep source identity while adding
-  format-appropriate navigation, playback, or transcript evidence.
+  prepared fallback; direct-preview failure remains explicit while that
+  independently prepared fallback is pending or available. Image and media
+  viewers keep source identity while adding format-appropriate navigation,
+  playback, or transcript evidence.
 - Safe workspace-relative links stay in StashBase. HTTP(S) links use the
   system browser. Markdown, DOCX, and Agent-rendered executable content stays
   inert.

--- a/e2e/journeys/formats-media.spec.ts
+++ b/e2e/journeys/formats-media.spec.ts
@@ -2,7 +2,12 @@ import { expect, test } from '@playwright/test';
 import type { LaunchedApp } from '../support/app.ts';
 import { launchApp } from '../support/app.ts';
 import { createAppFixture } from '../support/fixtures.ts';
-import { dismissEmbeddingKeyPrompt, fileTreeRow, openLibraryFolder } from '../support/locators.ts';
+import {
+  activeDocumentTab,
+  dismissEmbeddingKeyPrompt,
+  fileTreeRow,
+  openLibraryFolder,
+} from '../support/locators.ts';
 import {
   JOURNEY_AUDIO,
   JOURNEY_DOCX,
@@ -79,6 +84,7 @@ test('valid tiny PDF navigates pages and retains its selected page across a tab 
     await expect(app.page.getByTitle('Jump to page')).toHaveAccessibleName('Page 2 of 2 — jump to page');
 
     await fileTreeRow(app.page, 'Welcome.md').click();
+    await expect(activeDocumentTab(app.page)).toHaveAttribute('title', 'Welcome.md');
     await app.page.getByRole('tab', { name: new RegExp(JOURNEY_PDF) }).click();
     await expect(app.page.getByTitle('Jump to page')).toHaveAccessibleName('Page 2 of 2 — jump to page');
     expectOnlyKnownViewerFailures(app, [

--- a/e2e/journeys/formats-media.spec.ts
+++ b/e2e/journeys/formats-media.spec.ts
@@ -104,7 +104,10 @@ test('malformed PDF and DOCX remain visible source identities with explicit fail
     await expect(app.page.getByRole('tab', { name: new RegExp(MALFORMED_PDF) })).toHaveAttribute('aria-selected', 'true');
 
     await fileTreeRow(app.page, MALFORMED_DOCX).click();
-    await expect(app.page.getByRole('status').filter({ hasText: 'searchable text is unavailable' })).toBeVisible();
+    const docxFailure = app.page.getByRole('status').filter({ hasText: 'Direct DOCX preview failed' });
+    await expect(docxFailure).toContainText(
+      /prepared fallback when it is available|searchable fallback is unavailable/,
+    );
     await expect(app.page.locator('iframe[title="HTML preview"]')).toBeVisible();
     await expect(app.page.getByRole('tab', { name: new RegExp(MALFORMED_DOCX) })).toHaveAttribute('aria-selected', 'true');
     expectOnlyKnownViewerFailures(app, [

--- a/e2e/journeys/navigation-layout.spec.ts
+++ b/e2e/journeys/navigation-layout.spec.ts
@@ -78,3 +78,37 @@ test('splitters expose keyboard-updated ARIA values and compact resize preserves
     await fixture.cleanup();
   }
 });
+
+test('J01 reduced motion keeps overlay feedback while removing transform movement', async ({}, testInfo) => {
+  const fixture = await createAppFixture({ membership: 'one-folder' });
+  let app: LaunchedApp | undefined;
+  try {
+    app = await launchApp(fixture, testInfo);
+    await app.page.emulateMedia({ reducedMotion: 'reduce' });
+    await expect.poll(
+      () => app?.page.evaluate(() => window.matchMedia('(prefers-reduced-motion: reduce)').matches),
+    ).toBe(true);
+
+    await app.page.getByRole('button', { name: 'Settings', exact: true }).click();
+    const settings = app.page.getByRole('dialog', { name: 'Settings' });
+    await expect(settings).toBeVisible();
+
+    const motion = await settings.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        animationDurationMs: Math.max(...style.animationDuration.split(',').map((duration) => {
+          const value = Number.parseFloat(duration);
+          return duration.trim().endsWith('ms') ? value : value * 1000;
+        })),
+        transitionProperty: style.transitionProperty,
+      };
+    });
+    expect(motion.animationDurationMs).toBeLessThanOrEqual(0.01);
+    expect(motion.transitionProperty).not.toMatch(/transform|translate|scale|rotate/);
+    expect(motion.transitionProperty).toContain('opacity');
+    app.errors.assertNone();
+  } finally {
+    await app?.close();
+    await fixture.cleanup();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "test:config": "node --import tsx --test server/app-config.test.ts server/embedding-availability.test.ts server/hosted-account.test.ts server/account-route.test.ts",
     "lint:web": "oxlint --config .oxlintrc.json web-src/src && node --test scripts/check-renderer-api-access.test.mjs && node scripts/check-renderer-api-access.mjs",
     "test:renderer": "node scripts/run-renderer-tests.mjs \"web-src/src/**/*.test.ts\"",
+    "audit:renderer": "npx --yes @shadscan/cli@0.17.0 . --json --no-interactive --fail-under 45",
+    "test:renderer-quality-gates": "node --test scripts/renderer-quality-gates.test.mjs",
     "test:electron": "node --test --test-reporter=spec electron/multi-window.test.cjs electron/clipboard-watch-policy.test.cjs electron/bug-report-service.test.cjs electron/bug-report-redaction.test.cjs electron/bug-report-collection.test.cjs electron/bug-report-handoff.test.cjs electron/bug-report-review.test.cjs",
     "test:electron:smoke": "node electron/multi-window-smoke-runner.cjs",
     "test:e2e:harness": "node --import tsx --test e2e/support/fixtures.test.ts && node --test e2e/support/ci-summary-reporter.test.cjs && playwright test e2e/harness --project=electron-smoke",

--- a/scripts/renderer-quality-gates.test.mjs
+++ b/scripts/renderer-quality-gates.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function source(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function workflowJob(workflow, name) {
+  const match = workflow.match(
+    new RegExp(`^  ${name}:\\n(?<body>[\\s\\S]*?)(?=^  [a-z][a-z0-9-]+:|(?![\\s\\S]))`, 'm'),
+  );
+  assert.ok(match?.groups?.body, `CI must define the ${name} job`);
+  return match.groups.body;
+}
+
+test('renderer quality CI is pinned, read-only, and publishes its audit', () => {
+  const workflow = source('.github/workflows/ci.yml');
+  const job = workflowJob(workflow, 'renderer-quality');
+
+  assert.match(workflow, /^permissions:\n  contents: read$/m);
+  assert.match(
+    job,
+    /uses: TheOrcDev\/shadscan@1d4415ac799f453fe5ef192cf7f165433aa4e82b\s+# v0\.17\.0/,
+  );
+  assert.match(job, /version: ['"]0\.17\.0['"]/);
+  assert.match(job, /fail-under: ['"]45['"]/);
+  assert.match(job, /create-issue: ['"]false['"]/);
+  assert.doesNotMatch(job, /continue-on-error:/);
+  assert.doesNotMatch(job, /issues:\s*write|pull-requests:\s*write|contents:\s*write/);
+  assert.match(job, /uses: actions\/upload-artifact@v6/);
+  assert.match(job, /if: \$\{\{ always\(\) && steps\.shadscan\.outputs\.report-path != '' \}\}/);
+  assert.match(job, /path: \$\{\{ steps\.shadscan\.outputs\.report-path \}\}/);
+});
+
+test('local renderer audit uses the same reviewed ShadScan floor as CI', () => {
+  const pkg = JSON.parse(source('package.json'));
+
+  assert.equal(
+    pkg.scripts['audit:renderer'],
+    'npx --yes @shadscan/cli@0.17.0 . --json --no-interactive --fail-under 45',
+  );
+  assert.equal(
+    pkg.scripts['test:renderer-quality-gates'],
+    'node --test scripts/renderer-quality-gates.test.mjs',
+  );
+});

--- a/web-src/src/features/documents/components/DocxPreview.tsx
+++ b/web-src/src/features/documents/components/DocxPreview.tsx
@@ -184,22 +184,28 @@ export function DocxPreview({ name }: { name: string }) {
      * preparation continues independently and occupies only the slim
      * status row, never the document viewport. */
     <div className="relative box-border flex h-full w-full flex-col overflow-hidden bg-background">
-      {failure ? (
+      {directFailed || failure ? (
         <StatusMessage tone="warning" className="flex min-h-7 shrink-0 items-center gap-1.5 rounded-none border-x-0 border-t-0 px-3.5 py-1.5">
           <span className="min-w-0 flex-1">
-            {retryError
-              ? 'The document is visible, but search preparation could not restart.'
-              : 'The document is visible, but its searchable text is unavailable.'}
+            {directFailed
+              ? failure
+                ? 'Direct DOCX preview failed, and its searchable fallback is unavailable.'
+                : 'Direct DOCX preview failed. StashBase will show the prepared fallback when it is available.'
+              : retryError
+                ? 'The document is visible, but search preparation could not restart.'
+                : 'The document is visible, but its searchable text is unavailable.'}
           </span>
-          <Button
-            variant="outline"
-            size="xs"
-            className="shrink-0"
-            disabled={retryBusy}
-            onClick={() => { void retry(); }}
-          >
-            {retryBusy ? 'Reprocessing…' : 'Reprocess'}
-          </Button>
+          {failure ? (
+            <Button
+              variant="outline"
+              size="xs"
+              className="shrink-0"
+              disabled={retryBusy}
+              onClick={() => { void retry(); }}
+            >
+              {retryBusy ? 'Reprocessing…' : 'Reprocess'}
+            </Button>
+          ) : null}
         </StatusMessage>
       ) : preparationStatus ? (
         <div className="box-border flex min-h-7 shrink-0 items-center gap-1.5 border-b border-border bg-background px-3.5 py-1.5 text-sm text-muted-foreground" role="status">


### PR DESCRIPTION
Closes #109

## Summary
- add a read-only, revision-pinned ShadScan CI gate with a reviewed score floor and uploaded JSON report
- add Playwright reduced-motion coverage and document the existing keyboard, theme, compact-layout, and visual evidence
- surface direct DOCX preview failures independently from durable preparation failures

## Validation
- pnpm typecheck
- pnpm lint:web
- pnpm build:web
- pnpm test:docs
- pnpm test:renderer-quality-gates
- pnpm audit:renderer (45/100, floor 45)
- renderer unit tests (459 passed on Node 24)
- Electron smoke (9 passed)
- functional journeys (37 passed; one unrelated CRUD timing retry, then 21/21 focused repeats passed)
- focused reduced-motion and malformed DOCX Playwright regressions