### PR TITLE
fix(server): add async path resolution for preparation requests

### DIFF
--- a/code-review/file-transactions.md
+++ b/code-review/file-transactions.md
@@ -35,6 +35,19 @@
 - App-maintained derived paths are never writable source targets. Dot-directory
   Agent configuration remains writable even though dot-directories stay out of
   the knowledge index.
+- Request-handling Adapters perform potentially slow realpath,
+  canonicalization, existence, and type checks asynchronously. A sync path
+  resolver is allowed only where its caller is already outside the shared Node
+  request-handling event loop or the work is otherwise bounded.
+
+### Known gap — request-path filesystem liveness
+
+`FilesystemPathModule.resolveUnderAsync` is available and the Preparation
+prepare, reprocess, and cancellation paths use it, but other request Adapters
+still call the sync resolver. On macOS, its containment checks also reach the
+sync mounted-volume identity implementation. Path safety remains enforced, but
+slow or network-mounted folders can still block unrelated requests, and no
+focused concurrency evidence currently establishes the required liveness.
 
 ## Save and Version Contract
 

--- a/server/filesystem-path.test.ts
+++ b/server/filesystem-path.test.ts
@@ -175,3 +175,51 @@ test('resolveUnder blocks existing and creatable symlink or junction escapes', (
     filesystemPath.absolute(fs.realpathSync.native(outside)),
   );
 });
+
+test('resolveUnderAsync matches resolveUnder for symlink or junction escapes', async (t) => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'stashbase-path-async-'));
+  const root = path.join(temp, 'root');
+  const outside = path.join(temp, 'outside');
+  fs.mkdirSync(root);
+  fs.mkdirSync(outside);
+  fs.writeFileSync(path.join(root, 'inside.md'), 'inside');
+  fs.writeFileSync(path.join(outside, 'outside.md'), 'outside');
+  fs.symlinkSync(outside, path.join(root, 'link'), process.platform === 'win32' ? 'junction' : 'dir');
+  if (process.platform !== 'win32') {
+    fs.symlinkSync(path.join(outside, 'outside.md'), path.join(root, 'linked-file.md'));
+  }
+  t.after(() => fs.rmSync(temp, { recursive: true, force: true }));
+
+  assert.equal(
+    await filesystemPath.resolveUnderAsync(root, 'inside.md', { access: 'existing' }),
+    filesystemPath.absolute(path.join(root, 'inside.md')),
+  );
+  await assert.rejects(
+    () => filesystemPath.resolveUnderAsync(root, 'link/outside.md', { access: 'existing' }),
+    /escapes folder through symlink/,
+  );
+  await assert.rejects(
+    () => filesystemPath.resolveUnderAsync(root, 'link/new.md', { access: 'creatable' }),
+    /escapes folder through symlink/,
+  );
+  if (process.platform !== 'win32') {
+    await assert.rejects(
+      () => filesystemPath.resolveUnderAsync(root, 'linked-file.md', { access: 'creatable' }),
+      /escapes folder through symlink/,
+    );
+  }
+  assert.equal(
+    await filesystemPath.resolveUnderAsync(root, 'new/child.md', { access: 'creatable' }),
+    filesystemPath.absolute(path.join(root, 'new', 'child.md')),
+  );
+
+  // resolveUnder and resolveUnderAsync must agree on every access mode, not
+  // just the escape cases, since routes migrate to the async path one at a
+  // time and both are expected to behave identically in the meantime.
+  for (const access of ['lexical', 'existing', 'creatable'] as const) {
+    assert.equal(
+      await filesystemPath.resolveUnderAsync(root, 'inside.md', { access }),
+      filesystemPath.resolveUnder(root, 'inside.md', { access }),
+    );
+  }
+});

--- a/server/filesystem-path.ts
+++ b/server/filesystem-path.ts
@@ -42,10 +42,10 @@ export interface FilesystemPathModule {
   canonicalRelative(root: string, relative: string): string;
   /** Resolve a folder-relative path and optionally enforce realpath safety. */
   resolveUnder(root: string, relative: string, options?: ResolveUnderOptions): string;
-  /** Async equivalent of `resolveUnder()`. Prefer this on the request-handling
-   *  path: `resolveUnder()` performs its symlink/realpath checks with sync
-   *  syscalls, which block the single Node event loop shared by every
-   *  window's file, search, and MCP requests. */
+  /** Promise-based equivalent of `resolveUnder()` for staged migration of
+   *  request-handling callers. Canonicalization and realpath checks use async
+   *  filesystem APIs; platform identity/containment still shares the sync
+   *  implementation where noted by the File Transactions known gap. */
   resolveUnderAsync(root: string, relative: string, options?: ResolveUnderOptions): Promise<string>;
 }
 
@@ -286,10 +286,10 @@ export function createFilesystemPath(
   }
 
   // --- Async mirrors for the request-handling path -------------------------
-  // These duplicate the sync functions above one-for-one using fs.promises
-  // instead of the *Sync variants, so the single Node event loop shared by
-  // every window's file/search/MCP requests isn't blocked by a slow syscall
-  // (e.g. realpath or readdir against a network-mounted or slow folder).
+  // These duplicate the sync functions above one-for-one using async
+  // filesystem APIs for canonicalization and realpath work. They establish a
+  // migration path for request handlers; platform identity/containment still
+  // shares sync helpers until the File Transactions known gap is closed.
   // Kept as separate functions, rather than a sync/async flag on the
   // existing ones, so neither implementation has to guard against `await`
   // inside a hot, already-audited sync path.

--- a/server/filesystem-path.ts
+++ b/server/filesystem-path.ts
@@ -8,6 +8,11 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { promisify } from 'node:util';
+
+// fs.promises.realpath() has no `.native` counterpart (unlike the sync and
+// callback APIs), so promisify the callback-style native binding directly.
+const realpathNativeAsync = promisify(fs.realpath.native);
 
 export type FilesystemPlatform = 'win32' | 'darwin' | 'posix';
 export type PathAccess = 'lexical' | 'existing' | 'creatable';
@@ -37,6 +42,11 @@ export interface FilesystemPathModule {
   canonicalRelative(root: string, relative: string): string;
   /** Resolve a folder-relative path and optionally enforce realpath safety. */
   resolveUnder(root: string, relative: string, options?: ResolveUnderOptions): string;
+  /** Async equivalent of `resolveUnder()`. Prefer this on the request-handling
+   *  path: `resolveUnder()` performs its symlink/realpath checks with sync
+   *  syscalls, which block the single Node event loop shared by every
+   *  window's file, search, and MCP requests. */
+  resolveUnderAsync(root: string, relative: string, options?: ResolveUnderOptions): Promise<string>;
 }
 
 interface CreateFilesystemPathOptions {
@@ -275,6 +285,87 @@ export function createFilesystemPath(
     return targetSource;
   }
 
+  // --- Async mirrors for the request-handling path -------------------------
+  // These duplicate the sync functions above one-for-one using fs.promises
+  // instead of the *Sync variants, so the single Node event loop shared by
+  // every window's file/search/MCP requests isn't blocked by a slow syscall
+  // (e.g. realpath or readdir against a network-mounted or slow folder).
+  // Kept as separate functions, rather than a sync/async flag on the
+  // existing ones, so neither implementation has to guard against `await`
+  // inside a hot, already-audited sync path.
+
+  async function canonicalRelativeAsync(root: string, relativePath: string): Promise<string> {
+    const rel = normalizeRelative(relativePath, platform);
+    if (platform === 'posix' || !rel) return rel;
+    const canonical: string[] = [];
+    let cursor = toNative(absolute(root), platform);
+    for (const segment of rel.split('/')) {
+      let spelling = segment;
+      try {
+        const found = await matchingExistingEntryAsync(cursor, segment, platform === 'darwin');
+        if (found) spelling = found;
+      } catch {
+        // A create target may have a missing suffix. Preserve caller spelling.
+      }
+      canonical.push(spelling);
+      cursor = pathApi.join(cursor, spelling);
+    }
+    return canonical.join('/');
+  }
+
+  async function canonicalCreatableRelativeAsync(root: string, relativePath: string): Promise<string> {
+    const rel = normalizeRelative(relativePath, platform);
+    const lastSlash = rel.lastIndexOf('/');
+    if (lastSlash < 0) return rel;
+    const parent = await canonicalRelativeAsync(root, rel.slice(0, lastSlash));
+    return parent ? `${parent}/${rel.slice(lastSlash + 1)}` : rel.slice(lastSlash + 1);
+  }
+
+  async function resolveUnderAsync(
+    root: string,
+    relativePath: string,
+    options: ResolveUnderOptions = {},
+  ): Promise<string> {
+    const access = options.access ?? 'lexical';
+    const label = options.label ?? 'path';
+    const rootSource = absolute(root);
+    const resolvedRelative = access === 'lexical'
+      ? relativePath
+      : access === 'creatable'
+        ? await canonicalCreatableRelativeAsync(rootSource, relativePath)
+        : await canonicalRelativeAsync(rootSource, relativePath);
+    const targetSource = join(rootSource, resolvedRelative);
+    const rootNative = toNative(rootSource, platform);
+    const targetNative = toNative(targetSource, platform);
+    if (access === 'lexical') return targetSource;
+
+    const rootReal = await realpathNativeAsync(rootNative);
+    if (access === 'existing') {
+      const targetReal = await realpathNativeAsync(targetNative);
+      if (!contains(rootReal, targetReal)) {
+        throw new Error(`${label} escapes folder through symlink`);
+      }
+      return targetSource;
+    }
+
+    // Start at the target itself. If it already exists as a symlink, checking
+    // only its parent would approve a subsequent write that follows outside
+    // the folder. Missing suffixes naturally walk up to their first existing
+    // ancestor.
+    let probe = targetNative;
+    while (!(await existsAsync(probe))) {
+      const parent = pathApi.dirname(probe);
+      if (parent === probe) break;
+      probe = parent;
+    }
+    if (!contains(rootNative, probe)) throw new Error(`${label} escapes folder`);
+    const probeReal = await realpathNativeAsync(probe);
+    if (!contains(rootReal, probeReal)) {
+      throw new Error(`${label} escapes folder through symlink`);
+    }
+    return targetSource;
+  }
+
   return {
     platform,
     absolute,
@@ -288,6 +379,7 @@ export function createFilesystemPath(
     join,
     canonicalRelative,
     resolveUnder,
+    resolveUnderAsync,
   };
 }
 
@@ -398,6 +490,46 @@ function matchingExistingEntry(cursor: string, segment: string, verifyAlias: boo
   if (!alias) return undefined;
   if (!verifyAlias) return alias;
   return sameFilesystemEntry(path.posix.join(cursor, segment), path.posix.join(cursor, alias))
+    ? alias
+    : undefined;
+}
+
+async function existsAsync(target: string): Promise<boolean> {
+  try {
+    await fs.promises.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function sameFilesystemEntryAsync(a: string, b: string): Promise<boolean> {
+  try {
+    const [aStat, bStat] = await Promise.all([fs.promises.stat(a), fs.promises.stat(b)]);
+    return aStat.dev === bStat.dev && aStat.ino === bStat.ino;
+  } catch {
+    return false;
+  }
+}
+
+async function matchingExistingEntryAsync(
+  cursor: string,
+  segment: string,
+  verifyAlias: boolean,
+): Promise<string | undefined> {
+  let entries: string[];
+  try {
+    entries = await fs.promises.readdir(cursor);
+  } catch {
+    return undefined;
+  }
+  const exact = entries.find((entry) => entry === segment);
+  if (exact) return exact;
+  const folded = segment.normalize('NFC').toLowerCase();
+  const alias = entries.find((entry) => entry.normalize('NFC').toLowerCase() === folded);
+  if (!alias) return undefined;
+  if (!verifyAlias) return alias;
+  return (await sameFilesystemEntryAsync(path.posix.join(cursor, segment), path.posix.join(cursor, alias)))
     ? alias
     : undefined;
 }

--- a/server/routes/indexing.ts
+++ b/server/routes/indexing.ts
@@ -87,9 +87,8 @@ function sourcePathForAbs(absPath: string): string {
 /** Resolve an explicit-folder request without allowing a symlink inside the
  * library folder to redirect preparation/extraction outside that folder.
  *
- * Async so the containment/symlink checks (resolveUnderAsync) and the
- * existence/type checks below don't block the single Node event loop that
- * serves every window's file, search, and MCP requests. */
+ * Uses the promise-based resolver so canonicalization, realpath, existence,
+ * and type checks can move off the single Node request-handling event loop. */
 async function requireExistingFileInFolderAsync(folderRoot: string, rel: string): Promise<string> {
   let abs: string;
   try {

--- a/server/routes/indexing.ts
+++ b/server/routes/indexing.ts
@@ -85,17 +85,22 @@ function sourcePathForAbs(absPath: string): string {
 }
 
 /** Resolve an explicit-folder request without allowing a symlink inside the
- * library folder to redirect preparation/extraction outside that folder. */
-function requireExistingFileInFolder(folderRoot: string, rel: string): string {
+ * library folder to redirect preparation/extraction outside that folder.
+ *
+ * Async so the containment/symlink checks (resolveUnderAsync) and the
+ * existence/type checks below don't block the single Node event loop that
+ * serves every window's file, search, and MCP requests. */
+async function requireExistingFileInFolderAsync(folderRoot: string, rel: string): Promise<string> {
   let abs: string;
   try {
-    abs = filesystemPath.resolveUnder(folderRoot, rel);
+    abs = await filesystemPath.resolveUnderAsync(folderRoot, rel);
   } catch (cause) {
     const err = new Error('path escapes folder', { cause });
     (err as any).status = 400;
     throw err;
   }
-  if (!fs.existsSync(abs)) {
+  const exists = await fs.promises.access(abs).then(() => true, () => false);
+  if (!exists) {
     clearRecord(sourcePathForAbs(abs));
     const err = new Error('file not found');
     (err as any).status = 404;
@@ -103,13 +108,14 @@ function requireExistingFileInFolder(folderRoot: string, rel: string): string {
   }
 
   try {
-    abs = filesystemPath.resolveUnder(folderRoot, rel, { access: 'existing' });
+    abs = await filesystemPath.resolveUnderAsync(folderRoot, rel, { access: 'existing' });
   } catch (cause) {
     const err = new Error('path escapes folder through symlink', { cause });
     (err as any).status = 400;
     throw err;
   }
-  if (!fs.statSync(abs).isFile()) {
+  const stat = await fs.promises.stat(abs);
+  if (!stat.isFile()) {
     const err = new Error('file not found');
     (err as any).status = 404;
     throw err;
@@ -117,11 +123,11 @@ function requireExistingFileInFolder(folderRoot: string, rel: string): string {
   return abs;
 }
 
-export function reprocessFileInFolder(
+export async function reprocessFileInFolder(
   relPath: string,
   folderName?: string,
   options: { language?: string } = {},
-): 'conversion' | 'index' {
+): Promise<'conversion' | 'index'> {
   const rel = typeof relPath === 'string' ? relPath.trim() : '';
   if (!rel) {
     const err = new Error('path required');
@@ -131,7 +137,7 @@ export function reprocessFileInFolder(
 
   const { folderRoot } = requireRequestFolder(folderName?.trim() || undefined);
 
-  const abs = requireExistingFileInFolder(folderRoot, rel);
+  const abs = await requireExistingFileInFolderAsync(folderRoot, rel);
   const sourcePath = sourcePathForAbs(abs);
   if (isConversionPending(sourcePath)) {
     // A manual retry promotes queued work; running work is non-preemptive.
@@ -179,7 +185,7 @@ async function cancelFilePreparationInFolder(relPath: string, folderName?: strin
     throw err;
   }
   const { folderRoot } = requireRequestFolder(folderName?.trim() || undefined);
-  const abs = requireExistingFileInFolder(folderRoot, rel);
+  const abs = await requireExistingFileInFolderAsync(folderRoot, rel);
   const sourcePath = sourcePathForAbs(abs);
   if (isAudioFile(rel)) return cancelAudioPreparation(sourcePath);
   const cancelled = await cancelConversionAndWait(sourcePath, 'user-request');
@@ -187,7 +193,7 @@ async function cancelFilePreparationInFolder(relPath: string, folderName?: strin
   return cancelled;
 }
 
-function prepareConvertibleInFolder(relPath: string, folderName?: string): void {
+async function prepareConvertibleInFolder(relPath: string, folderName?: string): Promise<void> {
   const rel = typeof relPath === 'string' ? relPath.trim() : '';
   if (!rel) {
     const err = new Error('path required');
@@ -195,7 +201,7 @@ function prepareConvertibleInFolder(relPath: string, folderName?: string): void 
     throw err;
   }
   const { folderRoot } = requireRequestFolder(folderName?.trim() || undefined);
-  const abs = requireExistingFileInFolder(folderRoot, rel);
+  const abs = await requireExistingFileInFolderAsync(folderRoot, rel);
   if (!prepareConvertibleSource(abs, rel)) {
     const err = new Error('only DOCX and media files require interactive preparation');
     (err as any).status = 415;
@@ -215,9 +221,9 @@ function normalizeLanguageOverride(value: unknown): string | undefined {
 export function mount(app: express.Express): void {
   // Opening a DOCX is an explicit user gesture. Queue it in the light lane
   // at interactive priority (or promote the existing queued task).
-  app.post('/api/files/prepare', (req, res) => {
+  app.post('/api/files/prepare', async (req, res) => {
     try {
-      prepareConvertibleInFolder(req.body?.path, parseFolderParam(req.body?.folder));
+      await prepareConvertibleInFolder(req.body?.path, parseFolderParam(req.body?.folder));
       res.json({ ok: true });
     } catch (err: unknown) {
       sendError(res, err);
@@ -392,13 +398,13 @@ export function mount(app: express.Express): void {
   // failure row. PDF/image/DOCX/audio sources also clear stale final derived
   // artifacts and re-run extraction; directly readable files schedule a
   // reconcile so the index is rebuilt from source.
-  app.post('/api/files/reprocess', (req, res) => {
+  app.post('/api/files/reprocess', async (req, res) => {
     try {
       const rel = typeof req.body?.path === 'string' ? req.body.path.trim() : '';
       const targetFolder = typeof req.body?.folder === 'string' && req.body.folder.trim()
         ? req.body.folder.trim()
         : undefined;
-      const mode = reprocessFileInFolder(rel, targetFolder, { language: req.body?.language });
+      const mode = await reprocessFileInFolder(rel, targetFolder, { language: req.body?.language });
       res.json({ ok: true, mode });
     } catch (err: unknown) {
       sendError(res, err);


### PR DESCRIPTION
## Summary

Adds a staged promise-based path resolver and migrates the Preparation request paths that validate existing files before prepare, reprocess, or cancellation. This reduces synchronous filesystem work on those request paths while preserving the existing symlink-containment behavior.

This is the first step toward #196, not the complete request-path migration. Other callers still use the synchronous resolver, and macOS containment still reaches the synchronous mounted-volume identity implementation; the remaining work stays tracked in #196.

## What changed

- Adds `resolveUnderAsync()` to `filesystem-path.ts` as an additive promise-based mirror of `resolveUnder()`, using asynchronous filesystem APIs for canonicalization, realpath, existence, and type checks. The existing sync `resolveUnder()` is unchanged.

- Migrates `requireExistingFileInFolder` (now `requireExistingFileInFolderAsync`) and its three callers (`prepareConvertibleInFolder`, `reprocessFileInFolder`, `cancelFilePreparationInFolder`), plus the two route handlers `/api/files/prepare` and `/api/files/reprocess`.

- Records the remaining request-path filesystem liveness gap in the File Transactions review contract.

- Out of scope: the remaining `resolveSafe()` / `resolveUnder()` request callers, including `active-file-operations.ts`, upload/listing paths, scoped search, and the async macOS identity/containment work. These remain tracked in #196.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test:conversion-scheduler` (147 tests)
- [x] `pnpm test:library-files` (13 tests)
- [x] `pnpm test:retrieval` (22 tests)
- [x] `pnpm test:renderer` (464 tests)
- [x] `pnpm test:python` (29 tests)
- [x] `pnpm test:docs`
- [ ] Renderer build or E2E coverage, when the change affects the UI

## UI and visual baselines

- [ ] This PR changes a rendered UI surface or visual state.
- [ ] This fork PR allows maintainer edits if a reviewed Linux visual baseline update is needed.
- [x] This PR does not change a visual surface, or existing visual baselines remain valid.

For an intentional UI change, maintainers generate and review Linux baselines after code review. Contributors do not need to run the baseline workflow or commit PNGs.

## Documentation

- [x] Updated the relevant `code-review/` contract for the staged path Interface and current Known Gap.
- [ ] No documentation update is needed.

Partially addresses #196

