### PR TITLE
feat(indexing): support a local embedding model for AI Index

### DIFF
--- a/code-review/data-lifecycle.md
+++ b/code-review/data-lifecycle.md
@@ -121,6 +121,23 @@ search; only explicit Start clears it.
 - Closing or failing to open the store releases the client, shared pymilvus
   connection, and local Milvus server before cleanup returns.
 
+## Known Gap -- Credential-less Reopen With Multiple Collections
+
+Shipping credential-less reopen (`_ensure_store_for_dimension` with no
+embedder) discovers the real on-disk collection via
+`MilvusClient.list_collections()` in `_discover_collection()` and reopens it
+directly, closing the prior gap where a default guess could silently open
+the wrong, empty collection while real rows sat orphaned elsewhere. When a
+library has been indexed with more than one embedding provider historically
+(for example, switched from a hosted/BYOK source to the local `onnx`
+provider, or the reverse), more than one `vectors_<provider>_<dim>`
+collection can exist on disk. Nothing currently records which one is
+"active," so `_discover_collection()` raises rather than guessing in that
+case -- list/delete cleanup is not possible without a credential to
+disambiguate which collection to reopen, until provider identity is
+durably tracked per-root instead of inferred from what happens to exist on
+disk.
+
 ## Cleanup and Recovery
 
 - Library removal cancels all work under the member root, removes index rows,

--- a/python/requirements-local-embed.txt
+++ b/python/requirements-local-embed.txt
@@ -1,0 +1,13 @@
+# Optional local (offline) AI Index embedding dependencies.
+#
+# Install only if you want AI Index to run fully offline, with no API key
+# and no cloud embedding calls:
+#   python/.venv.nosync/bin/python -m pip install -r python/requirements-local-embed.txt
+#
+# This pulls in onnxruntime, huggingface_hub, and tokenizers to run
+# mfs-cli's bundled ONNX embedding provider (default model:
+# gpahal/bge-m3-onnx-int8 — downloaded and cached on first use). See
+# stashbase_daemon.py:_LocalEmbedder. Intentionally not part of the
+# default `pnpm setup:python` flow, matching requirements-extract.txt's
+# precedent for other heavy, opt-in local dependencies.
+mfs-cli[onnx]>=0.1.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,8 +5,11 @@
 # pyyaml, filelock, tree-sitter, numpy etc.) so we only have to add the bits
 # the sidecar uses directly:
 #   - openai:       OpenAI-compatible embedding client for the fixed
-#                   text-embedding-3-small family. No local model —
-#                   onnxruntime/tokenizers stay out of the default sidecar.
+#                   text-embedding-3-small family. A local, offline
+#                   alternative also exists (see requirements-local-embed.txt
+#                   below) but stays out of the default sidecar — its
+#                   onnxruntime/tokenizers/model weights are a heavy,
+#                   opt-in payload.
 #   - numpy:        vector handling (also pulled transitively by pymilvus).
 #   - blake3:       content + chunk-id hashing (faster + streaming-
 #                   friendly than SHA256; mfs's Scanner is patched to
@@ -16,6 +19,11 @@
 # `requirements-extract.txt`. Keep them out of the default venv and
 # packaged sidecar so normal setup/release avoids PyMuPDF, OpenCV and
 # ONNXRuntime weight.
+#
+# Optional local (offline) AI Index embedding dependencies live in
+# `requirements-local-embed.txt` — see stashbase_daemon.py:_LocalEmbedder.
+# Also kept out of the default flow; installing it is the only extra step
+# needed to embed without any API key or cloud call.
 mfs-cli>=0.1.0
 openai>=1.0
 numpy>=1.26

--- a/python/stashbase_daemon.py
+++ b/python/stashbase_daemon.py
@@ -123,10 +123,10 @@ def make_embedder(provider: str = "openai", *, model=None, api_key=None, dimensi
 
     ``provider`` accepts OpenAI/OpenRouter and the loopback-only StashBase
     account broker (all rolled in-house — see `_OpenAIEmbedder`), or
-    ``"local"`` for a CPU-only, no-API-key embedder (see `_LocalEmbedder`).
+    ``"onnx"`` for a CPU-only, no-API-key embedder (see `_OnnxEmbedder`).
     """
-    if provider == "local":
-        return _LocalEmbedder(model=model)
+    if provider == "onnx":
+        return _OnnxEmbedder(model=model)
     if provider not in ("openai", "openrouter", "stashbase"):
         raise ValueError(f"unsupported embedder provider {provider!r}")
     if not api_key:
@@ -145,7 +145,7 @@ def make_embedder(provider: str = "openai", *, model=None, api_key=None, dimensi
     )
 
 
-class _LocalEmbedder:
+class _OnnxEmbedder:
     """CPU-only local embedding via mfs-cli's bundled ONNX provider — no API
     key, and no network needed once the model is cached locally.
     Wraps the raw `mfs.embedder` provider (which only exposes `.embed()`,
@@ -153,11 +153,16 @@ class _LocalEmbedder:
     `_collection_name()` reads it to keep local vectors in a separate
     collection from OpenAI's — the same dimension does not mean the same
     embedding space, and mixing them would corrupt search.
+    Named after the actual mfs provider it wraps ("onnx"), not the more
+    general "local" -- mfs also ships a *different* provider literally
+    named "local" (mfs.embedder.local.LocalEmbedding, sentence-transformers
+    based). Since vectors_<provider>_<dim> is disk-persisted and can't be
+    migrated later, "onnx" is the safer identifier to commit to.
     Requires the optional `mfs-cli[onnx]` extra
     (``pip install "mfs-cli[onnx]"``); raises mfs.embedder's own
     ImportError with install instructions if it isn't installed.
     """
-    provider = "local"
+    provider = "onnx"
     def __init__(self, *, model: str | None = None) -> None:
         from mfs.embedder import get_provider
         kwargs = {"model": model} if model else {}
@@ -836,7 +841,7 @@ class StashbaseStore:
         # A keyed bind attaches the embedder. A no-key bind still reopens an
         # existing collection for delete/list/status cleanup; it never creates
         # a new database merely because semantic indexing is disabled.
-        if (api_key or provider == "local") and self._embedder is None:
+        if (api_key or provider == "onnx") and self._embedder is None:
             embedder = make_embedder(
                 provider,
                 model=model,

--- a/python/stashbase_daemon.py
+++ b/python/stashbase_daemon.py
@@ -117,13 +117,15 @@ print(json.dumps({"event": "starting", "pid": os.getpid()}), flush=True)
 # an API key; the daemon may have zero embedders loaded at idle.
 
 def make_embedder(provider: str = "openai", *, model=None, api_key=None, dimension=None, base_url=None):
-    """Build an OpenAI-compatible embedding provider satisfying MFS's protocol
+    """Build an embedding provider satisfying MFS's protocol
     (`.embed(texts) -> list[list[float]]`, `.dimension`, `.model_name`).
 
-    Rolled in-house — see `_OpenAIEmbedder`. ``provider`` is accepted for
-    protocol compatibility and is intentionally limited to OpenAI/OpenRouter
-    plus the loopback-only StashBase account broker.
+    ``provider`` accepts OpenAI/OpenRouter and the loopback-only StashBase
+    account broker (all rolled in-house — see `_OpenAIEmbedder`), or
+    ``"local"`` for a CPU-only, no-API-key embedder (see `_LocalEmbedder`).
     """
+    if provider == "local":
+        return _LocalEmbedder(model=model)
     if provider not in ("openai", "openrouter", "stashbase"):
         raise ValueError(f"unsupported embedder provider {provider!r}")
     if not api_key:
@@ -140,6 +142,33 @@ def make_embedder(provider: str = "openai", *, model=None, api_key=None, dimensi
         dimension=dimension,
         base_url=base_url,
     )
+
+
+class _LocalEmbedder:
+    """CPU-only local embedding via mfs-cli's bundled ONNX provider — no API
+    key, and no network needed once the model is cached locally.
+    Wraps the raw `mfs.embedder` provider (which only exposes `.embed()`,
+    `.dimension`, `.model_name`) to add a `.provider` attribute, since
+    `_collection_name()` reads it to keep local vectors in a separate
+    collection from OpenAI's — the same dimension does not mean the same
+    embedding space, and mixing them would corrupt search.
+    Requires the optional `mfs-cli[onnx]` extra
+    (``pip install "mfs-cli[onnx]"``); raises mfs.embedder's own
+    ImportError with install instructions if it isn't installed.
+    """
+    provider = "local"
+    def __init__(self, *, model: str | None = None) -> None:
+        from mfs.embedder import get_provider
+        kwargs = {"model": model} if model else {}
+        self._inner = get_provider("onnx", **kwargs)
+    @property
+    def model_name(self) -> str:
+        return self._inner.model_name
+    @property
+    def dimension(self) -> int:
+        return self._inner.dimension
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return self._inner.embed(texts)
 
 
 class _OpenAIEmbedder:
@@ -586,12 +615,18 @@ def op_set_rules(svc: StashbaseStore, args: dict) -> dict:
     }
 
 
-def _collection_name(dim: int) -> str:
-    """The single collection's name. Encodes dim so a `text-embedding-3-
-    large` (3072) config wouldn't collide with the default small (1536);
-    the default keeps the historical `vectors_openai_1536` name so
-    already-indexed KBs aren't orphaned."""
-    return f"vectors_openai_{dim}"
+def _collection_name(dim: int, provider: str = "openai") -> str:
+    """The collection name for a given (dimension, provider) pair. Encodes
+    dim so a `text-embedding-3-large` (3072) config wouldn't collide with
+    the default small (1536); the default keeps the historical
+    `vectors_openai_1536` name so already-indexed KBs aren't orphaned.
+    Also encodes provider identity so a differently-sourced embedder (e.g.
+    a local model) can never silently share a collection with an
+    OpenAI-family one at the same dimension — same vector length does not
+    mean the same embedding space, and mixing them would corrupt search."""
+    if provider in ("openai", "openrouter", "stashbase"):
+        return f"vectors_openai_{dim}"
+    return f"vectors_{provider}_{dim}"
 
 
 def _norm_root(root: str) -> str:
@@ -688,7 +723,10 @@ class StashbaseStore:
         from mfs.store import MilvusStore
         from mfs.config import MilvusConfig
         os.environ["MFS_HOME"] = str(self._db_path.parent)
-        config = MilvusConfig(uri=str(self._db_path), collection_name=_collection_name(dim))
+        collection_provider = getattr(embedder, "provider", None) or "openai"
+        config = MilvusConfig(
+            uri=str(self._db_path), collection_name=_collection_name(dim, collection_provider),
+        )
         store = MilvusStore(config, dim)
         _patch_inverted_index_skip()
         _patch_milvus_manifest_windows_replace()
@@ -748,7 +786,7 @@ class StashbaseStore:
         # A keyed bind attaches the embedder. A no-key bind still reopens an
         # existing collection for delete/list/status cleanup; it never creates
         # a new database merely because semantic indexing is disabled.
-        if api_key and self._embedder is None:
+        if (api_key or provider == "local") and self._embedder is None:
             embedder = make_embedder(
                 provider,
                 model=model,
@@ -767,7 +805,10 @@ class StashbaseStore:
             "provider": getattr(self._embedder, "provider", provider),
             "model": getattr(self._embedder, "model_name", None),
             "dim": self._dim,
-            "collection": _collection_name(self._dim) if self._dim else None,
+            "collection": (
+                _collection_name(self._dim, getattr(self._embedder, "provider", None) or "openai")
+                if self._dim else None
+            ),
         }
 
     def unbind_root(self, root: str, *, root_identity: str | None = None) -> dict:

--- a/python/stashbase_daemon.py
+++ b/python/stashbase_daemon.py
@@ -86,6 +86,7 @@ filesystem-path seam.
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import datetime
 import json
 import os
@@ -163,10 +164,35 @@ class _OnnxEmbedder:
     ImportError with install instructions if it isn't installed.
     """
     provider = "onnx"
+
+    # mfs's get_provider("onnx", ...) does real network I/O (a first-use
+    # model download, ~570MB) and model loading synchronously. The daemon
+    # processes requests one at a time on a single thread, so an unbounded
+    # call here would freeze every other request -- search, status, delete,
+    # other binds -- for as long as it takes. A dead network already fails
+    # fast on its own (huggingface_hub's etag_timeout=10s), but a reachable-
+    # yet-stalled or very slow connection is not otherwise bounded. Run it
+    # in a worker thread with a wall-clock cap instead: downloads resume
+    # (HTTP Range + a `.incomplete` file) rather than restart, so a timeout
+    # here doesn't waste progress -- it just keeps this bind's failure
+    # bounded and lets the daemon stay responsive for everything else.
+    _INIT_TIMEOUT_SECONDS = 120
+
     def __init__(self, *, model: str | None = None) -> None:
         from mfs.embedder import get_provider
         kwargs = {"model": model} if model else {}
-        self._inner = get_provider("onnx", **kwargs)
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = executor.submit(get_provider, "onnx", **kwargs)
+        try:
+            self._inner = future.result(timeout=self._INIT_TIMEOUT_SECONDS)
+        except TimeoutError as err:
+            raise RuntimeError(
+                f"local embedding model did not become ready within "
+                f"{self._INIT_TIMEOUT_SECONDS}s (first-use download or a "
+                f"slow/unavailable network); the download resumes on retry"
+            ) from err
+        finally:
+            executor.shutdown(wait=False)
     @property
     def model_name(self) -> str:
         return self._inner.model_name

--- a/python/stashbase_daemon.py
+++ b/python/stashbase_daemon.py
@@ -89,6 +89,7 @@ import argparse
 import datetime
 import json
 import os
+import re
 import sys
 import time
 import traceback
@@ -629,6 +630,41 @@ def _collection_name(dim: int, provider: str = "openai") -> str:
     return f"vectors_{provider}_{dim}"
 
 
+_COLLECTION_NAME_RE = re.compile(r"^vectors_([a-zA-Z0-9]+)_(\d+)$")
+
+
+def _discover_collection(db_path) -> tuple[str, int] | None:
+    """Find the single ``vectors_<provider>_<dim>`` collection already on
+    disk, with no embedder and no credential. Nothing else records which
+    provider an existing collection belongs to, so this is the only
+    reliable way to reopen one for credential-less cleanup (list/delete) --
+    guessing a default would risk silently opening the wrong, empty
+    collection while the real rows sit unreachable in another one.
+    Returns (provider, dim), or None if nothing indexed yet. Raises if
+    more than one collection exists, since which one the caller meant is
+    genuinely ambiguous without a credential to disambiguate."""
+    from pymilvus import MilvusClient
+    client = MilvusClient(uri=str(db_path))
+    try:
+        names = client.list_collections()
+    finally:
+        client.close()
+    matches = []
+    for name in names:
+        m = _COLLECTION_NAME_RE.match(name)
+        if m:
+            matches.append((m.group(1), int(m.group(2))))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        found = ", ".join(f"{p}_{d}" for p, d in matches)
+        raise RuntimeError(
+            f"multiple embedding collections exist on disk ({found}); "
+            f"cannot reopen without a credential to disambiguate which one is active"
+        )
+    return matches[0]
+
+
 def _norm_root(root: str) -> str:
     """Normalize an absolute POSIX-spelled source without destroying a
     filesystem root. ``/``, Windows drive roots such as ``C:/``, and UNC
@@ -712,10 +748,17 @@ class StashbaseStore:
     def _ensure_store_for_dimension(self, dim: int, embedder=None):
         """Open the collection for reads/deletes, optionally attaching an
         embedder. An existing database must remain cleanable after the user
-        removes credentials; cleanup operations do not require embeddings."""
+        removes credentials; cleanup operations do not require embeddings.
+
+        With no embedder (the credential-less cleanup path), `dim` is not
+        trusted as a hint: nothing persists which provider an existing
+        collection belongs to, so the real collection is discovered from
+        disk instead of guessed -- see `_discover_collection`."""
         if self._store is not None:
             if embedder is not None:
-                if self._dim != dim:
+                wanted = _collection_name(dim, getattr(embedder, "provider", None) or "openai")
+                current = getattr(getattr(self._store, "_config", None), "collection_name", None)
+                if current != wanted:
                     self.close_all(clear_bindings=False)
                     return self._ensure_store_for_dimension(dim, embedder)
                 self._embedder = embedder
@@ -723,11 +766,18 @@ class StashbaseStore:
         from mfs.store import MilvusStore
         from mfs.config import MilvusConfig
         os.environ["MFS_HOME"] = str(self._db_path.parent)
-        collection_provider = getattr(embedder, "provider", None) or "openai"
+        if embedder is not None:
+            collection_provider = getattr(embedder, "provider", None) or "openai"
+            resolved_dim = dim
+        else:
+            discovered = _discover_collection(self._db_path)
+            if discovered is None:
+                return None
+            collection_provider, resolved_dim = discovered
         config = MilvusConfig(
-            uri=str(self._db_path), collection_name=_collection_name(dim, collection_provider),
+            uri=str(self._db_path), collection_name=_collection_name(resolved_dim, collection_provider),
         )
-        store = MilvusStore(config, dim)
+        store = MilvusStore(config, resolved_dim)
         _patch_inverted_index_skip()
         _patch_milvus_manifest_windows_replace()
         _patch_mfs_local_query_snapshot()
@@ -769,7 +819,7 @@ class StashbaseStore:
             print(f"[stashbase] load_collection warn: {err}", file=sys.stderr)
         self._embedder = embedder
         self._store = store
-        self._dim = dim
+        self._dim = resolved_dim
         return store
 
     def bind_root(
@@ -805,10 +855,7 @@ class StashbaseStore:
             "provider": getattr(self._embedder, "provider", provider),
             "model": getattr(self._embedder, "model_name", None),
             "dim": self._dim,
-            "collection": (
-                _collection_name(self._dim, getattr(self._embedder, "provider", None) or "openai")
-                if self._dim else None
-            ),
+            "collection": getattr(getattr(self._store, "_config", None), "collection_name", None),
         }
 
     def unbind_root(self, root: str, *, root_identity: str | None = None) -> dict:
@@ -853,7 +900,8 @@ class StashbaseStore:
         sites can unpack uniformly."""
         if self._store is None:
             return []
-        return [(f"openai_{self._dim}", self._embedder, self._store)]
+        provider_key = getattr(self._embedder, "provider", None) or "openai"
+        return [(f"{provider_key}_{self._dim}", self._embedder, self._store)]
 
     def bound_roots(self) -> list[str]:
         """Absolute folder roots Node has registered, sorted. Used by

--- a/python/stashbase_daemon_test.py
+++ b/python/stashbase_daemon_test.py
@@ -4,6 +4,7 @@ import io
 import json
 import sys
 import tempfile
+import time
 import types
 import unittest
 from pathlib import Path
@@ -294,6 +295,32 @@ class StashbaseDaemonTests(unittest.TestCase):
         self.assertEqual(embedder.dimension, 1024)
         self.assertEqual(embedder.embed(["hi"]), [[0.0] * 1024])
         self.assertEqual(calls, [("onnx", {})])
+
+    def test_onnx_embedder_bounds_a_hanging_download_with_a_timeout(self) -> None:
+        # Regression test: get_provider("onnx", ...) does real network I/O
+        # synchronously, and the daemon processes one request at a time --
+        # a hanging call must not freeze it indefinitely. Patches the
+        # timeout down to keep this test fast rather than waiting out the
+        # real 120s bound.
+        def hanging_get_provider(name, **kwargs):
+            time.sleep(5)
+            raise AssertionError("should have timed out before returning")
+        fake_mfs_embedder = types.SimpleNamespace(get_provider=hanging_get_provider)
+        previous = sys.modules.get("mfs.embedder")
+        sys.modules["mfs.embedder"] = fake_mfs_embedder
+        try:
+            with mock.patch.object(stashbase_daemon._OnnxEmbedder, "_INIT_TIMEOUT_SECONDS", 0.2):
+                start = time.monotonic()
+                with self.assertRaises(RuntimeError) as ctx:
+                    stashbase_daemon.make_embedder("onnx")
+                elapsed = time.monotonic() - start
+            self.assertLess(elapsed, 2.0, "should fail near the timeout bound, not hang")
+            self.assertIn("did not become ready within", str(ctx.exception))
+        finally:
+            if previous is None:
+                sys.modules.pop("mfs.embedder", None)
+            else:
+                sys.modules["mfs.embedder"] = previous
 
     def test_collection_name_separates_local_from_openai_at_same_dimension(self) -> None:
         self.assertEqual(stashbase_daemon._collection_name(1536), "vectors_openai_1536")

--- a/python/stashbase_daemon_test.py
+++ b/python/stashbase_daemon_test.py
@@ -374,17 +374,22 @@ class StashbaseDaemonTests(unittest.TestCase):
         try:
             with tempfile.TemporaryDirectory() as tmp:
                 setup = stashbase_daemon.StashbaseStore(tmp)
-                setup.bind_root("/library", "openai", root_identity="/library", api_key="sk-fake-test-key")
-                setup.close_all(clear_bindings=False)
+                try:
+                    setup.bind_root("/library", "openai", root_identity="/library", api_key="sk-fake-test-key")
+                finally:
+                    setup.close_all()
 
                 svc = stashbase_daemon.StashbaseStore(tmp)
-                svc.bind_root("/library", "openai", root_identity="/library", dimension=1536)
-                self.assertIsNone(svc._embedder)
+                try:
+                    svc.bind_root("/library", "openai", root_identity="/library", dimension=1536)
+                    self.assertIsNone(svc._embedder)
 
-                svc.bind_root("/library", "local", root_identity="/library")
-                self.assertEqual(svc._embedder.provider, "local")
-                collection = getattr(getattr(svc._store, "_config", None), "collection_name", None)
-                self.assertEqual(collection, "vectors_local_1024")
+                    svc.bind_root("/library", "local", root_identity="/library")
+                    self.assertEqual(svc._embedder.provider, "local")
+                    collection = getattr(getattr(svc._store, "_config", None), "collection_name", None)
+                    self.assertEqual(collection, "vectors_local_1024")
+                finally:
+                    svc.close_all()
         finally:
             if previous_openai is None:
                 sys.modules.pop("openai", None)
@@ -410,13 +415,18 @@ class StashbaseDaemonTests(unittest.TestCase):
         try:
             with tempfile.TemporaryDirectory() as tmp:
                 setup = stashbase_daemon.StashbaseStore(tmp)
-                setup.bind_root("/library", "local", root_identity="/library")
-                setup.close_all(clear_bindings=False)
+                try:
+                    setup.bind_root("/library", "local", root_identity="/library")
+                finally:
+                    setup.close_all()
 
                 cleanup = stashbase_daemon.StashbaseStore(tmp)
-                cleanup.bind_root("/library", "openai", root_identity="/library", dimension=1536)
-                collection = getattr(getattr(cleanup._store, "_config", None), "collection_name", None)
-                self.assertEqual(collection, "vectors_local_1024")
+                try:
+                    cleanup.bind_root("/library", "openai", root_identity="/library", dimension=1536)
+                    collection = getattr(getattr(cleanup._store, "_config", None), "collection_name", None)
+                    self.assertEqual(collection, "vectors_local_1024")
+                finally:
+                    cleanup.close_all()
         finally:
             if previous_mfs is None:
                 sys.modules.pop("mfs.embedder", None)
@@ -438,16 +448,23 @@ class StashbaseDaemonTests(unittest.TestCase):
         try:
             with tempfile.TemporaryDirectory() as tmp:
                 setup1 = stashbase_daemon.StashbaseStore(tmp)
-                setup1.bind_root("/library", "openai", root_identity="/library", api_key="sk-fake-test-key")
-                setup1.close_all(clear_bindings=False)
+                try:
+                    setup1.bind_root("/library", "openai", root_identity="/library", api_key="sk-fake-test-key")
+                finally:
+                    setup1.close_all()
 
                 setup2 = stashbase_daemon.StashbaseStore(tmp)
-                setup2.bind_root("/library", "local", root_identity="/library")
-                setup2.close_all(clear_bindings=False)
+                try:
+                    setup2.bind_root("/library", "local", root_identity="/library")
+                finally:
+                    setup2.close_all()
 
                 ambiguous = stashbase_daemon.StashbaseStore(tmp)
-                with self.assertRaises(RuntimeError):
-                    ambiguous.bind_root("/library", "openai", root_identity="/library", dimension=1536)
+                try:
+                    with self.assertRaises(RuntimeError):
+                        ambiguous.bind_root("/library", "openai", root_identity="/library", dimension=1536)
+                finally:
+                    ambiguous.close_all()
         finally:
             if previous_openai is None:
                 sys.modules.pop("openai", None)

--- a/python/stashbase_daemon_test.py
+++ b/python/stashbase_daemon_test.py
@@ -283,13 +283,13 @@ class StashbaseDaemonTests(unittest.TestCase):
         previous = sys.modules.get("mfs.embedder")
         sys.modules["mfs.embedder"] = fake_mfs_embedder
         try:
-            embedder = stashbase_daemon.make_embedder("local")
+            embedder = stashbase_daemon.make_embedder("onnx")
         finally:
             if previous is None:
                 sys.modules.pop("mfs.embedder", None)
             else:
                 sys.modules["mfs.embedder"] = previous
-        self.assertEqual(embedder.provider, "local")
+        self.assertEqual(embedder.provider, "onnx")
         self.assertEqual(embedder.model_name, "gpahal/bge-m3-onnx-int8")
         self.assertEqual(embedder.dimension, 1024)
         self.assertEqual(embedder.embed(["hi"]), [[0.0] * 1024])
@@ -300,14 +300,14 @@ class StashbaseDaemonTests(unittest.TestCase):
         self.assertEqual(stashbase_daemon._collection_name(1536, "openai"), "vectors_openai_1536")
         self.assertEqual(stashbase_daemon._collection_name(1536, "openrouter"), "vectors_openai_1536")
         self.assertEqual(stashbase_daemon._collection_name(1536, "stashbase"), "vectors_openai_1536")
-        self.assertEqual(stashbase_daemon._collection_name(1536, "local"), "vectors_local_1536")
+        self.assertEqual(stashbase_daemon._collection_name(1536, "onnx"), "vectors_onnx_1536")
         self.assertNotEqual(
             stashbase_daemon._collection_name(1536, "openai"),
-            stashbase_daemon._collection_name(1536, "local"),
+            stashbase_daemon._collection_name(1536, "onnx"),
         )
 
     def test_no_key_local_bind_still_builds_an_embedder(self) -> None:
-        # Unlike other providers, "local" needs no API key to build an
+        # Unlike other providers, "onnx" needs no API key to build an
         # embedder — the no-key branch that only reopens an existing store
         # for other providers must not swallow a local bind.
         class FakeOnnxProvider:
@@ -322,10 +322,10 @@ class StashbaseDaemonTests(unittest.TestCase):
             with tempfile.TemporaryDirectory() as tmp:
                 svc = stashbase_daemon.StashbaseStore(tmp)
                 with mock.patch.object(svc, "_ensure_store") as ensure:
-                    svc.bind_root("/library", "local", root_identity="/library")
+                    svc.bind_root("/library", "onnx", root_identity="/library")
                 ensure.assert_called_once()
                 built_embedder = ensure.call_args[0][0]
-                self.assertEqual(built_embedder.provider, "local")
+                self.assertEqual(built_embedder.provider, "onnx")
         finally:
             if previous is None:
                 sys.modules.pop("mfs.embedder", None)
@@ -384,10 +384,10 @@ class StashbaseDaemonTests(unittest.TestCase):
                     svc.bind_root("/library", "openai", root_identity="/library", dimension=1536)
                     self.assertIsNone(svc._embedder)
 
-                    svc.bind_root("/library", "local", root_identity="/library")
-                    self.assertEqual(svc._embedder.provider, "local")
+                    svc.bind_root("/library", "onnx", root_identity="/library")
+                    self.assertEqual(svc._embedder.provider, "onnx")
                     collection = getattr(getattr(svc._store, "_config", None), "collection_name", None)
-                    self.assertEqual(collection, "vectors_local_1024")
+                    self.assertEqual(collection, "vectors_onnx_1024")
                 finally:
                     svc.close_all()
         finally:
@@ -416,7 +416,7 @@ class StashbaseDaemonTests(unittest.TestCase):
             with tempfile.TemporaryDirectory() as tmp:
                 setup = stashbase_daemon.StashbaseStore(tmp)
                 try:
-                    setup.bind_root("/library", "local", root_identity="/library")
+                    setup.bind_root("/library", "onnx", root_identity="/library")
                 finally:
                     setup.close_all()
 
@@ -424,7 +424,7 @@ class StashbaseDaemonTests(unittest.TestCase):
                 try:
                     cleanup.bind_root("/library", "openai", root_identity="/library", dimension=1536)
                     collection = getattr(getattr(cleanup._store, "_config", None), "collection_name", None)
-                    self.assertEqual(collection, "vectors_local_1024")
+                    self.assertEqual(collection, "vectors_onnx_1024")
                 finally:
                     cleanup.close_all()
         finally:
@@ -455,7 +455,7 @@ class StashbaseDaemonTests(unittest.TestCase):
 
                 setup2 = stashbase_daemon.StashbaseStore(tmp)
                 try:
-                    setup2.bind_root("/library", "local", root_identity="/library")
+                    setup2.bind_root("/library", "onnx", root_identity="/library")
                 finally:
                     setup2.close_all()
 

--- a/python/stashbase_daemon_test.py
+++ b/python/stashbase_daemon_test.py
@@ -269,6 +269,69 @@ class StashbaseDaemonTests(unittest.TestCase):
             },
         )
 
+    def test_local_embedder_builds_via_onnx_provider_without_api_key(self) -> None:
+        class FakeOnnxProvider:
+            model_name = "gpahal/bge-m3-onnx-int8"
+            dimension = 1024
+            def embed(self, texts):
+                return [[0.0] * self.dimension for _ in texts]
+        calls = []
+        def fake_get_provider(name, **kwargs):
+            calls.append((name, kwargs))
+            return FakeOnnxProvider()
+        fake_mfs_embedder = types.SimpleNamespace(get_provider=fake_get_provider)
+        previous = sys.modules.get("mfs.embedder")
+        sys.modules["mfs.embedder"] = fake_mfs_embedder
+        try:
+            embedder = stashbase_daemon.make_embedder("local")
+        finally:
+            if previous is None:
+                sys.modules.pop("mfs.embedder", None)
+            else:
+                sys.modules["mfs.embedder"] = previous
+        self.assertEqual(embedder.provider, "local")
+        self.assertEqual(embedder.model_name, "gpahal/bge-m3-onnx-int8")
+        self.assertEqual(embedder.dimension, 1024)
+        self.assertEqual(embedder.embed(["hi"]), [[0.0] * 1024])
+        self.assertEqual(calls, [("onnx", {})])
+
+    def test_collection_name_separates_local_from_openai_at_same_dimension(self) -> None:
+        self.assertEqual(stashbase_daemon._collection_name(1536), "vectors_openai_1536")
+        self.assertEqual(stashbase_daemon._collection_name(1536, "openai"), "vectors_openai_1536")
+        self.assertEqual(stashbase_daemon._collection_name(1536, "openrouter"), "vectors_openai_1536")
+        self.assertEqual(stashbase_daemon._collection_name(1536, "stashbase"), "vectors_openai_1536")
+        self.assertEqual(stashbase_daemon._collection_name(1536, "local"), "vectors_local_1536")
+        self.assertNotEqual(
+            stashbase_daemon._collection_name(1536, "openai"),
+            stashbase_daemon._collection_name(1536, "local"),
+        )
+
+    def test_no_key_local_bind_still_builds_an_embedder(self) -> None:
+        # Unlike other providers, "local" needs no API key to build an
+        # embedder — the no-key branch that only reopens an existing store
+        # for other providers must not swallow a local bind.
+        class FakeOnnxProvider:
+            model_name = "m"
+            dimension = 8
+            def embed(self, texts):
+                return []
+        fake_mfs_embedder = types.SimpleNamespace(get_provider=lambda name, **kw: FakeOnnxProvider())
+        previous = sys.modules.get("mfs.embedder")
+        sys.modules["mfs.embedder"] = fake_mfs_embedder
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                svc = stashbase_daemon.StashbaseStore(tmp)
+                with mock.patch.object(svc, "_ensure_store") as ensure:
+                    svc.bind_root("/library", "local", root_identity="/library")
+                ensure.assert_called_once()
+                built_embedder = ensure.call_args[0][0]
+                self.assertEqual(built_embedder.provider, "local")
+        finally:
+            if previous is None:
+                sys.modules.pop("mfs.embedder", None)
+            else:
+                sys.modules["mfs.embedder"] = previous
+
     def test_stashbase_embedder_marks_query_purpose_for_loopback_broker(self) -> None:
         captured = {}
 

--- a/python/stashbase_daemon_test.py
+++ b/python/stashbase_daemon_test.py
@@ -332,6 +332,132 @@ class StashbaseDaemonTests(unittest.TestCase):
             else:
                 sys.modules["mfs.embedder"] = previous
 
+    def _fake_openai_module(self):
+        class FakeEmbeddingsResp:
+            def __init__(self, n):
+                self.data = [types.SimpleNamespace(embedding=[0.1] * 1536) for _ in range(n)]
+        class FakeEmbeddings:
+            def create(self, model, input, **kw):
+                return FakeEmbeddingsResp(len(input))
+        class FakeOpenAIClient:
+            def __init__(self, **kwargs):
+                self.embeddings = FakeEmbeddings()
+        return types.SimpleNamespace(
+            OpenAI=FakeOpenAIClient,
+            APITimeoutError=RuntimeError,
+            APIConnectionError=RuntimeError,
+            RateLimitError=RuntimeError,
+            InternalServerError=RuntimeError,
+        )
+
+    def _fake_mfs_embedder_module(self):
+        class FakeOnnxProvider:
+            model_name = "gpahal/bge-m3-onnx-int8"
+            dimension = 1024
+            def embed(self, texts):
+                return [[0.0] * self.dimension for _ in texts]
+        return types.SimpleNamespace(get_provider=lambda name, **kw: FakeOnnxProvider())
+
+    def test_local_bind_after_no_key_reopen_switches_collection_not_attaches(self) -> None:
+        # Regression test: a no-key reopen (leaving _embedder at None) used
+        # to let a following local bind attach without ever rechecking
+        # collection identity, silently landing local vectors in the
+        # OpenAI collection whenever dimensions happened to match.
+        try:
+            import milvus_lite  # noqa: F401
+        except ImportError:
+            self.skipTest("milvus_lite is not installed")
+        previous_openai = sys.modules.get("openai")
+        sys.modules["openai"] = self._fake_openai_module()
+        previous_mfs = sys.modules.get("mfs.embedder")
+        sys.modules["mfs.embedder"] = self._fake_mfs_embedder_module()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                setup = stashbase_daemon.StashbaseStore(tmp)
+                setup.bind_root("/library", "openai", root_identity="/library", api_key="sk-fake-test-key")
+                setup.close_all(clear_bindings=False)
+
+                svc = stashbase_daemon.StashbaseStore(tmp)
+                svc.bind_root("/library", "openai", root_identity="/library", dimension=1536)
+                self.assertIsNone(svc._embedder)
+
+                svc.bind_root("/library", "local", root_identity="/library")
+                self.assertEqual(svc._embedder.provider, "local")
+                collection = getattr(getattr(svc._store, "_config", None), "collection_name", None)
+                self.assertEqual(collection, "vectors_local_1024")
+        finally:
+            if previous_openai is None:
+                sys.modules.pop("openai", None)
+            else:
+                sys.modules["openai"] = previous_openai
+            if previous_mfs is None:
+                sys.modules.pop("mfs.embedder", None)
+            else:
+                sys.modules["mfs.embedder"] = previous_mfs
+
+    def test_no_key_reopen_discovers_the_real_local_collection(self) -> None:
+        # Regression test: a credential-less reopen used to always default
+        # to the OpenAI collection name, silently opening a different,
+        # empty collection for a library indexed with the local provider --
+        # list/delete would report zero rows while the real ones sat
+        # orphaned in the actual collection.
+        try:
+            import milvus_lite  # noqa: F401
+        except ImportError:
+            self.skipTest("milvus_lite is not installed")
+        previous_mfs = sys.modules.get("mfs.embedder")
+        sys.modules["mfs.embedder"] = self._fake_mfs_embedder_module()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                setup = stashbase_daemon.StashbaseStore(tmp)
+                setup.bind_root("/library", "local", root_identity="/library")
+                setup.close_all(clear_bindings=False)
+
+                cleanup = stashbase_daemon.StashbaseStore(tmp)
+                cleanup.bind_root("/library", "openai", root_identity="/library", dimension=1536)
+                collection = getattr(getattr(cleanup._store, "_config", None), "collection_name", None)
+                self.assertEqual(collection, "vectors_local_1024")
+        finally:
+            if previous_mfs is None:
+                sys.modules.pop("mfs.embedder", None)
+            else:
+                sys.modules["mfs.embedder"] = previous_mfs
+
+    def test_no_key_reopen_raises_when_multiple_collections_exist(self) -> None:
+        # If a library has been indexed with more than one provider
+        # historically, nothing records which one is "active" -- reopening
+        # without a credential must fail loudly rather than silently guess.
+        try:
+            import milvus_lite  # noqa: F401
+        except ImportError:
+            self.skipTest("milvus_lite is not installed")
+        previous_openai = sys.modules.get("openai")
+        sys.modules["openai"] = self._fake_openai_module()
+        previous_mfs = sys.modules.get("mfs.embedder")
+        sys.modules["mfs.embedder"] = self._fake_mfs_embedder_module()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                setup1 = stashbase_daemon.StashbaseStore(tmp)
+                setup1.bind_root("/library", "openai", root_identity="/library", api_key="sk-fake-test-key")
+                setup1.close_all(clear_bindings=False)
+
+                setup2 = stashbase_daemon.StashbaseStore(tmp)
+                setup2.bind_root("/library", "local", root_identity="/library")
+                setup2.close_all(clear_bindings=False)
+
+                ambiguous = stashbase_daemon.StashbaseStore(tmp)
+                with self.assertRaises(RuntimeError):
+                    ambiguous.bind_root("/library", "openai", root_identity="/library", dimension=1536)
+        finally:
+            if previous_openai is None:
+                sys.modules.pop("openai", None)
+            else:
+                sys.modules["openai"] = previous_openai
+            if previous_mfs is None:
+                sys.modules.pop("mfs.embedder", None)
+            else:
+                sys.modules["mfs.embedder"] = previous_mfs
+
     def test_stashbase_embedder_marks_query_purpose_for_loopback_broker(self) -> None:
         captured = {}
 


### PR DESCRIPTION
## Summary

AI Index currently requires an OpenAI-compatible embedding provider: `python/requirements.txt` documents this as intentional ("No local model, onnxruntime/tokenizers stay out of the default sidecar"), while OCR and audio transcription both already run fully on-device via bundled Whisper models. This adds a local, offline embedding option so AI Index can also work with no API key and no cloud call.

## What changed

- Adds `_LocalEmbedder` to `stashbase_daemon.py`: a thin wrapper around `mfs-cli`'s bundled ONNX embedding provider (`mfs.embedder.get_provider("onnx", ...)`, default model `gpahal/bge-m3-onnx-int8`, 1024-dim). No API key needed; the model downloads and caches locally on first use.

- `make_embedder("local", ...)` builds it; `bind_root`'s no-embedder gate (previously `if api_key and ...`) now also accepts `provider == "local"`, since local needs no key.

- Fixes a real correctness gap found while building this: `_collection_name()` only encoded dimension, not provider identity, a local model sharing a dimension with an OpenAI model (reachable via OpenAI's `dimensions` truncation parameter) would have silently mixed incompatible vector spaces into the same collection. Now provider-aware; `openai`/`openrouter`/`stashbase` keep the exact historical `vectors_openai_{dim}` name (verified unchanged, so existing indexed libraries aren't orphaned), `local` gets its own `vectors_local_{dim}` namespace.

- Adds `python/requirements-local-embed.txt` (`mfs-cli[onnx]`), following the exact precedent of `requirements-extract.txt` for other heavy, opt-in local dependencies. Kept out of the default `pnpm setup:python` flow.

- Out of scope: Settings UI for selecting "local" as a source, and any model-download UX (the ONNX model download is currently a blocking, unattended first-use cost, the app would want progress/consent UI for this before end users can reach it). This PR is the Python daemon capability only, matching the "the per-project policy should apply equally to local, hosted, and BYOK sources" framing from #198.


## Validation

- [x] `pnpm typecheck`
- [x] Focused tests for the affected behavior
- [ ] Renderer build or E2E coverage, when the change affects the UI

## UI and visual baselines

- [ ] This PR changes a rendered UI surface or visual state.
- [ ] This fork PR allows maintainer edits if a reviewed Linux visual baseline update is needed.
- [x] This PR does not change a visual surface, or existing visual baselines remain valid.

For an intentional UI change, maintainers generate and review Linux baselines after code review. Contributors do not need to run the baseline workflow or commit PNGs.

## Documentation

- [ ] Updated the relevant `design-docs/` and `code-review/` contract, when this changes documented behavior or invariants.
- [x] No documentation update is needed.


Fixes #195