### PR TITLE
fix(workspace): truncate the titlebar folder name at the sidebar edge

### DIFF
--- a/code-review/journey-coverage.md
+++ b/code-review/journey-coverage.md
@@ -88,7 +88,9 @@ aliases, and Journey E2E owns representative composition.
   availability. [Navigation layout](../e2e/journeys/navigation-layout.spec.ts)
   verifies that Appearance Settings remains usable with the operating system's
   reduced-motion preference while transform movement is removed and quiet
-  state feedback remains. These checks do not yet prove the full orientation,
+  state feedback remains, and that a folder name too long for a narrowed
+  sidebar truncates inside the column instead of crossing onto the tab strip.
+  These checks do not yet prove the full orientation,
   first-value, and return sequence as one onboarding outcome.
 - **AI Eval:** onboarding mechanics are deterministic. If first value uses
   semantic retrieval or a real Agent, its quality evidence comes from J05 or

--- a/code-review/renderer-styling.md
+++ b/code-review/renderer-styling.md
@@ -221,6 +221,21 @@ this file records the mechanics a change must respect.
    intermittently stale on windowed macOS and killed clicks across the
    whole band; do not reintroduce carving, and do not let the two rects
    start overlapping on the assumption that the ordinal will save it.
+
+   Geometry owns the band's right edge the same way. `.titlebar-controls`
+   caps itself at the sidebar column, so the cluster's box never reaches
+   the tab strip beside it — but a cap only contains the cluster if one
+   child can absorb the squeeze. The sidebar toggle, the search button and
+   the hairline are fixed by design, which leaves the folder switcher as
+   the single elastic item; it carries `min-w-0 shrink` against the button
+   recipe's default `shrink-0`, and its label truncates to an ellipsis.
+   Drop that override and the trigger overflows its capped parent at its
+   full intrinsic width, painting the folder name across the document tab
+   strip (or, with Chat as the workspace, the chat tab row). The narrow
+   window this leaves is real: at the 200px minimum sidebar width the
+   macOS traffic-light inset spends most of the budget, so the label can
+   truncate to nothing. Widening the band's usable space means reserving
+   the cluster's overhang in the neighbouring row, not relaxing the cap.
 4. **Colocated feature CSS** — exemption rules (below) that a component needs
    but Tailwind utilities can't express, living in a CSS file next to the
    feature it styles and imported directly from the component(s) that render

--- a/design-docs/design/workspace.md
+++ b/design-docs/design/workspace.md
@@ -55,8 +55,10 @@ manager, or a primary graph-navigation tool.
   A created folder is an ordinary directory. Removing membership clears only
   StashBase-owned state.
 - The titlebar folder switcher keeps the window's current folder identity
-  visible and offers the full library membership. Folder-level actions remain
-  attributable to the active folder.
+  visible and offers the full library membership. A name wider than the
+  sidebar column truncates within that column instead of crossing onto the
+  document tab strip. Folder-level actions remain attributable to the active
+  folder.
 - Multiple windows share one library and runtime services while retaining
   independent active folders, tabs, search presentation, and Chat tabs.
 - Folder switches reset folder-scoped documents but preserve library search

--- a/e2e/journeys/navigation-layout.spec.ts
+++ b/e2e/journeys/navigation-layout.spec.ts
@@ -1,9 +1,11 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import type { LaunchedApp } from '../support/app.ts';
 import { launchApp } from '../support/app.ts';
 import { createAppFixture } from '../support/fixtures.ts';
 import { activeDocument, activeDocumentTab, dismissEmbeddingKeyPrompt, fileTreeRow, openLibraryFolder } from '../support/locators.ts';
-import { primaryKey } from './journey-helpers.ts';
+import { openFolderPickerMenu, primaryKey, stubOpenFolderDialog } from './journey-helpers.ts';
 
 test('Find transfers its query and active-folder scope to exact all-files search', async ({}, testInfo) => {
   const fixture = await createAppFixture({ membership: 'two-folders' });
@@ -106,6 +108,53 @@ test('J01 reduced motion keeps overlay feedback while removing transform movemen
     expect(motion.animationDurationMs).toBeLessThanOrEqual(0.01);
     expect(motion.transitionProperty).not.toMatch(/transform|translate|scale|rotate/);
     expect(motion.transitionProperty).toContain('opacity');
+    app.errors.assertNone();
+  } finally {
+    await app?.close();
+    await fixture.cleanup();
+  }
+});
+
+/** The titlebar's left cluster floats over the sidebar column; the folder
+ *  name is its only elastic item. A name too long for the column must
+ *  ellipsize at the column edge — bleeding it right paints it over the
+ *  document tab strip (or, with Chat as the workspace, the chat tab row). */
+test('a narrowed sidebar truncates the titlebar folder name instead of bleeding it onto the tab strip', async ({}, testInfo) => {
+  const fixture = await createAppFixture({ membership: 'one-folder' });
+  const longNamedFolder = path.join(fixture.root, 'workspaces', 'quarterly-planning-archive');
+  fs.mkdirSync(longNamedFolder, { recursive: true });
+  fs.writeFileSync(path.join(longNamedFolder, 'Plan.md'), '# Plan\n\nLong-name fixture.\n', 'utf8');
+  let app: LaunchedApp | undefined;
+  try {
+    app = await launchApp(fixture, testInfo);
+    await stubOpenFolderDialog(app.electron, { kind: 'success', path: longNamedFolder });
+    await openFolderPickerMenu(app.page);
+    await expect(app.page).toHaveTitle('quarterly-planning-archive — StashBase');
+    await dismissEmbeddingKeyPrompt(app.page);
+
+    // ArrowLeft steps 16px down from the 280px default and floors at the
+    // 200px minimum open width, so five presses park the panel there.
+    const sidebar = app.page.getByRole('separator', { name: 'Resize sidebar' });
+    await sidebar.focus();
+    for (let index = 0; index < 5; index += 1) await sidebar.press('ArrowLeft');
+    await expect(sidebar).toHaveAttribute('aria-valuenow', '200');
+
+    const switcher = await app.page.evaluate(() => {
+      const shell = document.querySelector('.app')!;
+      const trigger = document.querySelector('button[aria-label="Switch folder"]')!;
+      const label = trigger.querySelector('span')!;
+      const columnRight = Number.parseFloat(
+        getComputedStyle(shell).getPropertyValue('--sidebar-width'),
+      );
+      return {
+        bleedPastColumn: Math.round(trigger.getBoundingClientRect().right - columnRight),
+        labelWidth: label.clientWidth,
+        fullLabelWidth: label.scrollWidth,
+      };
+    });
+    expect(switcher.bleedPastColumn).toBeLessThanOrEqual(0);
+    expect(switcher.labelWidth).toBeGreaterThan(0);
+    expect(switcher.fullLabelWidth).toBeGreaterThan(switcher.labelWidth);
     app.errors.assertNone();
   } finally {
     await app?.close();

--- a/web-src/src/app/app-shell.css
+++ b/web-src/src/app/app-shell.css
@@ -111,8 +111,12 @@ body.is-electron.platform-darwin.is-fullscreen {
   left: var(--titlebar-controls-left);
   /* Cap the cluster to the sidebar column: a long folder name in the
    * switcher must ellipsize at the column edge, never bleed across
-   * the pane boundary onto the tab strip. The switcher's own spans
-   * carry min-width:0 + truncate, so the flex squeeze lands there.
+   * the pane boundary onto the tab strip. The cap alone does not do
+   * that — a flex child that refuses to shrink just overflows it — so
+   * the switcher trigger opts back in to `shrink` (FolderSwitcher.tsx,
+   * against the button recipe's `shrink-0`) and its label carries
+   * min-width:0 + truncate. Every other child here is fixed-width, so
+   * the squeeze lands on the name.
    * (Collapse keeps the stored --sidebar-width, so the cap holds.) */
   max-width: calc(var(--sidebar-width) - var(--titlebar-controls-left) - 8px);
 }

--- a/web-src/src/features/workspace/components/FolderSwitcher.tsx
+++ b/web-src/src/features/workspace/components/FolderSwitcher.tsx
@@ -96,8 +96,13 @@ export function FolderSwitcher() {
          * `size="sm"` is the 28px row this always was. The overrides are
          * the titlebar deltas: regular weight, the selected surface a
          * menu anchor takes while its menu is up, and a disabled state
-         * that stays hoverable so the "Opening …" title still appears. */
-        className="min-w-0 gap-1 px-1.5 text-base font-normal text-foreground aria-expanded:bg-active aria-expanded:text-foreground disabled:pointer-events-auto disabled:cursor-default disabled:opacity-60 [-webkit-app-region:no-drag]"
+         * that stays hoverable so the "Opening …" title still appears.
+         * `shrink` overrides the button recipe's `shrink-0`: this is the
+         * one elastic item in the titlebar cluster, so the cluster's
+         * max-width cap (app-shell.css) squeezes the label to an ellipsis
+         * here instead of bleeding the name past the sidebar edge onto
+         * the tab strip. `min-w-0` is what lets the squeeze reach zero. */
+        className="min-w-0 shrink gap-1 px-1.5 text-base font-normal text-foreground aria-expanded:bg-active aria-expanded:text-foreground disabled:pointer-events-auto disabled:cursor-default disabled:opacity-60 [-webkit-app-region:no-drag]"
         aria-label="Switch folder"
         aria-haspopup="menu"
         aria-expanded={anchor !== null}


### PR DESCRIPTION
## Summary

A folder name in the titlebar could paint over the agent tab strip, so two
pieces of text overlapped at the top of the window. The switcher now
truncates the name at the sidebar column edge instead.

`.titlebar-controls` already caps the cluster at the sidebar column, and its
comment claimed a long name would ellipsize there. It could not. The shared
button recipe sets `shrink-0`, so the switcher trigger sat at its full
intrinsic width and overflowed the cap; the trigger's `min-w-0` and the
label's `truncate` were both unreachable. Measured in Electron at the 200px
minimum sidebar width with the macOS traffic-light inset, the trigger's right
edge reached 268px against a 201px column, a 67px bleed.

Known residual: at the 200px floor on macOS, the traffic lights plus the two
icon utilities and the hairline spend most of the 104px budget, so the label
can truncate to nothing. That is contained truncation rather than an overlap,
and the name returns once the sidebar passes roughly 206px. Giving the band
more room means reserving the cluster's overhang in the neighbouring row,
which is deliberately not in this PR.

## What changed

- `FolderSwitcher` opts back in to `shrink` against the button recipe's
  `shrink-0`, making it the one elastic item in a cluster whose other
  children are fixed by design.
- The `app-shell.css` comment that already asserted this worked now records
  what actually makes it work.
- A `navigation-layout` journey opens a long-named folder, narrows the
  sidebar to its floor, and asserts the trigger stays inside the column while
  its label truncates and stays readable.
- `renderer-styling.md`, `journey-coverage.md`, and the Workspace design doc
  record the invariant, its new evidence, and the residual above.

## Validation

- [x] `pnpm typecheck`
- [x] Focused tests for the affected behavior
- [x] Renderer build or E2E coverage, when the change affects the UI

The new journey was proven red before the fix. With only the component change
stashed and the renderer rebuilt, `expect(switcher.bleedPastColumn)` failed at
`1 failed`; with the fix restored, `1 passed`. Also run: `pnpm typecheck`,
`pnpm typecheck:e2e`, `pnpm lint:web`, `pnpm build:web`, `pnpm test:docs`,
`pnpm test:e2e:check-focus`, and `pnpm test:e2e:smoke` (`14 passed`).

Three local failures are pre-existing or environmental on this machine and
unrelated to the change. `splitters expose keyboard-updated ARIA values` fails
the same way on a clean checkout. The Linux visual suite fails all 7 at launch
on `devicePixelRatio` 2 against the expected 1, so
`STASHBASE_E2E_DEVICE_SCALE_FACTOR=1` is not taking on this display and the
suite cannot judge composition here. The `failed assertion probe` harness test
shells out to `pnpm`, which is not installed locally.

## UI and visual baselines

- [x] This PR changes a rendered UI surface or visual state.
- [x] This fork PR allows maintainer edits if a reviewed Linux visual baseline update is needed.
- [ ] This PR does not change a visual surface, or existing visual baselines remain valid.

The switcher renders identically at the default sidebar width, 105px wide
before and after, so existing baselines should hold. Only the narrowed-sidebar
case changes, which no baseline covers.

## Documentation

- [x] Updated the relevant `design-docs/` and `code-review/` contract, when this changes documented behavior or invariants.
- [ ] No documentation update is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eWsENWCFAFLNFky8Gq434
