### PR TITLE
feat(mcp): read_file returns a line window on request

### DIFF
--- a/code-review/mcp-access.md
+++ b/code-review/mcp-access.md
@@ -46,6 +46,16 @@ clients and are not a general host-filesystem API.
   not read file bodies. `read_file` has an `8 MiB` response ceiling for source
   and current derived text; oversized content fails explicitly rather than
   consuming unbounded server memory.
+- `read_file` accepts an optional 1-based `offset`/`limit` line window over
+  every readable family, direct and derived alike. The window is applied after
+  the bounded read, so it narrows what a caller receives and never widens what
+  the server admits: a source above the read ceiling stays unreadable in every
+  window. A malformed bound is a `400`, never a silent whole-file read.
+- A windowed response is self-describing — `partial`, `totalLines`, and a
+  `nextOffset` that is absent once the window ends the file — and omits
+  `version`. Dropping the version token keeps a window outside the optimistic
+  write path, so a partial read cannot be laundered into a version-checked
+  full-file overwrite.
 - The Workbench tree is intentionally wider than the Agent file surface.
   Generic files, user dotfiles admitted only by the Workbench, excluded-folder
   placeholders, symlinks, and special entries do not appear in

--- a/design-docs/design/documents.md
+++ b/design-docs/design/documents.md
@@ -93,6 +93,11 @@ the active Workbench, including generic regular files; they do not make a
 preview-only format content-editable or widen Agent access. Restricted
 filesystem entries are reveal-only. Generic bytes are never decoded lossily.
 
+`read_file` returns the whole readable text by default and, on request, one
+declared line window of it, so a long source can be consumed a piece at a time
+instead of spending an Agent's entire context in one call. A window is opt-in
+and never silently substituted for a whole read.
+
 ## Experience Contract
 
 - A visible source file is always the identity for tabs, links, search results,
@@ -114,6 +119,9 @@ filesystem entries are reveal-only. Generic bytes are never decoded lossily.
   lossy replacement-character decode.
 - A structured JSON view is a controller over source text, never a second
   document model or persistence path.
+- A partial read announces itself, reports the source's full length, and offers
+  the offset that continues it. It never carries a version token, so a window
+  cannot be mistaken for the whole file by a later version-checked write.
 - Rendering untrusted document content never grants application privileges or
   loads arbitrary remote resources.
 - Product copy, Agent tool descriptions, and tests qualify format access by

--- a/mcp/library-operations-http.ts
+++ b/mcp/library-operations-http.ts
@@ -68,7 +68,12 @@ export function createHttpLibraryOperations(
       body: JSON.stringify({ name, ...(location != null ? { location } : {}) }),
     }),
     listDirectory: (path) => json(`${webBase}/api/library/directory?${pathQuery(path)}`, { headers: headers() }),
-    read: (path) => json(`${webBase}/api/library/file?${pathQuery(path)}`, { headers: headers() }),
+    read: (path, range) => json(
+      `${webBase}/api/library/file?${pathQuery(path)}`
+        + (range?.offset != null ? `&offset=${range.offset}` : '')
+        + (range?.limit != null ? `&limit=${range.limit}` : ''),
+      { headers: headers() },
+    ),
     write: ({ path, content, baseVersion }) => json(`${webBase}/api/library/file`, {
       method: 'PUT', headers: headers({ 'content-type': 'application/json' }), body: JSON.stringify({ path, content, ...(typeof baseVersion === 'string' ? { baseVersion } : {}) }),
     }),

--- a/mcp/library-server.ts
+++ b/mcp/library-server.ts
@@ -46,6 +46,12 @@ export function createLibraryMcpServer(opts: LibraryMcpServerOptions): Server {
   const { webBase, windowId, agentSessionId } = opts;
   const operations = withMcpErrors(opts.operations ?? createHttpLibraryOperations(webBase, windowId, agentSessionId));
 
+  function positiveIntArg(raw: unknown): number | undefined {
+    if (raw == null) return undefined;
+    const value = Number(raw);
+    return Number.isInteger(value) && value >= 1 ? value : undefined;
+  }
+
   function filePathArg(args: Record<string, unknown>): unknown {
     return typeof args.path === 'string' && args.path.trim()
       ? args.path
@@ -128,7 +134,10 @@ export function createLibraryMcpServer(opts: LibraryMcpServerOptions): Server {
     }
 
     if (req.params.name === 'read_file') {
-      const result = await operations.read(filePathArg(args));
+      const result = await operations.read(filePathArg(args), {
+        offset: positiveIntArg(args.offset),
+        limit: positiveIntArg(args.limit),
+      });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };
@@ -253,12 +262,18 @@ const BUILTIN_TOOLS = [
         'PDFs, DOCX, and media return current prepared text. Images are visible in ' +
         '`list_directory` and searchable through OCR evidence, but are not returned as bytes. ' +
         'Generic Workbench-only files are not listed or readable through MCP. ' +
-        'One response is limited to 8 MiB; split oversized text before reading it through this tool.',
+        'Use `offset` and `limit` to read a long file one window at a time instead of ' +
+        'spending your context on the whole file. A windowed response sets `partial: true`, ' +
+        'reports `totalLines`, and returns `nextOffset` until the window reaches the end. ' +
+        'It also omits `version`, so read the whole file before any `baseVersion` write. ' +
+        'A source above the 8 MiB read ceiling is not served by this tool in any window.',
       inputSchema: {
         type: 'object',
         properties: {
           path: { type: 'string', description: 'Absolute file path under one of your folders.' },
           file_path: { type: 'string', description: 'Alias for path; accepted for Claude Read-style calls.' },
+          offset: { type: 'integer', minimum: 1, description: 'Optional 1-based line to start at. Defaults to the first line.' },
+          limit: { type: 'integer', minimum: 1, description: 'Optional maximum number of lines to return. Defaults to the rest of the file.' },
         },
       },
     },

--- a/mcp/library-server.ts
+++ b/mcp/library-server.ts
@@ -17,6 +17,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { LibraryOperations } from '../server/library-operations/index.ts';
+import { parseLibraryFileLineBound } from '../server/library-file-reader.ts';
 import { createHttpLibraryOperations } from './library-operations-http.ts';
 import {
   parseSearchMode,
@@ -45,12 +46,6 @@ const MAX_TOP_K = 25;
 export function createLibraryMcpServer(opts: LibraryMcpServerOptions): Server {
   const { webBase, windowId, agentSessionId } = opts;
   const operations = withMcpErrors(opts.operations ?? createHttpLibraryOperations(webBase, windowId, agentSessionId));
-
-  function positiveIntArg(raw: unknown): number | undefined {
-    if (raw == null) return undefined;
-    const value = Number(raw);
-    return Number.isInteger(value) && value >= 1 ? value : undefined;
-  }
 
   function filePathArg(args: Record<string, unknown>): unknown {
     return typeof args.path === 'string' && args.path.trim()
@@ -134,10 +129,12 @@ export function createLibraryMcpServer(opts: LibraryMcpServerOptions): Server {
     }
 
     if (req.params.name === 'read_file') {
-      const result = await operations.read(filePathArg(args), {
-        offset: positiveIntArg(args.offset),
-        limit: positiveIntArg(args.limit),
-      });
+      const offset = parseLibraryFileLineBound(args.offset, 'offset');
+      const limit = parseLibraryFileLineBound(args.limit, 'limit');
+      const result = await operations.read(
+        filePathArg(args),
+        offset == null && limit == null ? undefined : { offset, limit },
+      );
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };

--- a/server/__tests__/mcp-http-transport.test.ts
+++ b/server/__tests__/mcp-http-transport.test.ts
@@ -6,6 +6,7 @@ import { mount } from '../routes/mcp-http.ts';
 import { createDockerMcpApp, createMcpHttpService } from '../mcp-http-service.ts';
 import type { McpHttpSettingsStore } from '../mcp-http-settings.ts';
 import { createLibraryOperations } from '../library-operations/index.ts';
+import { applyLineRange } from '../library-file-reader.ts';
 
 const initRequest = {
   jsonrpc: '2.0',
@@ -31,6 +32,8 @@ test('HTTP transport enforces the live Settings token and preserves the shared t
   let token = 'a'.repeat(64);
   let searchInput: Record<string, unknown> | undefined;
   let stdioSearchBody: Record<string, unknown> | undefined;
+  let readInput: { path: unknown; range: unknown } | undefined;
+  let stdioReadQuery: Record<string, unknown> | undefined;
   let createProjectInput: Record<string, unknown> | undefined;
   let stdioCreateProjectBody: Record<string, unknown> | undefined;
   let stdioCreateProjectAttribution: string | undefined;
@@ -38,6 +41,18 @@ test('HTTP transport enforces the live Settings token and preserves the shared t
   app.use(express.json());
   app.get('/api/library/info', (_req, res) => {
     res.json({ folder_home: '/tmp', folders: [] });
+  });
+  app.get('/api/library/file', (req, res) => {
+    stdioReadQuery = req.query as Record<string, unknown>;
+    res.json(applyLineRange({
+      path: String(req.query.path),
+      format: 'md',
+      content: 'one\ntwo\nthree\n',
+      version: 'v1',
+    }, {
+      offset: req.query.offset == null ? undefined : Number(req.query.offset),
+      limit: req.query.limit == null ? undefined : Number(req.query.limit),
+    }));
   });
   app.post('/api/library/search', (req, res) => {
     stdioSearchBody = req.body as Record<string, unknown>;
@@ -78,6 +93,15 @@ test('HTTP transport enforces the live Settings token and preserves the shared t
         createProjectInput = input as unknown as Record<string, unknown>;
         return { path: '/tmp/Project', name: 'Project', registered: true, rebound: false, note: 'ok' };
       },
+      read: async (path, range) => {
+        readInput = { path, range };
+        return applyLineRange({
+          path: String(path),
+          format: 'md',
+          content: 'one\ntwo\nthree\n',
+          version: 'v1',
+        }, range);
+      },
     }),
   });
 
@@ -112,9 +136,41 @@ test('HTTP transport enforces the live Settings token and preserves the shared t
       listed.body.result.tools.find((tool: any) => tool.name === 'read_file').description,
       /Generic Workbench-only files are not listed or readable through MCP/,
     );
+    const readTool = listed.body.result.tools.find((tool: any) => tool.name === 'read_file');
+    assert.equal(readTool.inputSchema.properties.offset.minimum, 1);
+    assert.equal(readTool.inputSchema.properties.limit.minimum, 1);
 
     const called = await post(base, callRequest, token);
     assert.equal(called.status, 200);
+
+    const read = await post(base, {
+      jsonrpc: '2.0',
+      id: 8,
+      method: 'tools/call',
+      params: {
+        name: 'read_file',
+        arguments: { path: '/tmp/notes.md', offset: 1 },
+      },
+    }, token);
+    assert.equal(read.status, 200);
+    assert.deepEqual(readInput, { path: '/tmp/notes.md', range: { offset: 1, limit: undefined } });
+    const readPayload = JSON.parse(read.body.result.content[0].text);
+    assert.equal(readPayload.partial, true);
+    assert.equal('version' in readPayload, false);
+
+    readInput = undefined;
+    const invalidRead = await post(base, {
+      jsonrpc: '2.0',
+      id: 9,
+      method: 'tools/call',
+      params: {
+        name: 'read_file',
+        arguments: { path: '/tmp/notes.md', limit: 0 },
+      },
+    }, token);
+    assert.equal(invalidRead.status, 200);
+    assert.match(invalidRead.body.error.message, /limit must be a positive integer/);
+    assert.equal(readInput, undefined);
 
     const searched = await post(base, {
       jsonrpc: '2.0',
@@ -209,6 +265,16 @@ test('HTTP transport enforces the live Settings token and preserves the shared t
     assert.equal(stdioPayload.mode, 'keyword');
     assert.equal(stdioPayload.top_k, 4);
     assert.deepEqual(stdioPayload.types, ['image']);
+    assert.deepEqual(stdioReadQuery, { path: '/tmp/notes.md', offset: '2', limit: '1' });
+    const stdioReadPayload = JSON.parse(stdio.read.result.content[0].text);
+    assert.deepEqual(stdioReadPayload, {
+      path: '/tmp/notes.md',
+      format: 'md',
+      content: 'two\n',
+      partial: true,
+      totalLines: 3,
+      nextOffset: 3,
+    });
     // The stdio host forwards its spawn-time session identity as the
     // attribution header — this is how a built-in panel session's
     // create_project call finds the live session to rebind.
@@ -298,6 +364,7 @@ async function runStdio(port: number): Promise<{
   listed: any;
   called: any;
   searched: any;
+  read: any;
   createdProject: any;
 }> {
   const { spawn } = await import('node:child_process');
@@ -338,19 +405,30 @@ async function runStdio(port: number): Promise<{
     id: 5,
     method: 'tools/call',
     params: {
+      name: 'read_file',
+      arguments: { path: '/tmp/notes.md', offset: 2, limit: 1 },
+    },
+  })}\n`);
+  child.stdin.write(`${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 6,
+    method: 'tools/call',
+    params: {
       name: 'create_project',
       arguments: { name: 'StdioProject' },
     },
   })}\n`);
 
   try {
-    const lines = await waitForJsonLines(() => stdout, 5);
+    const lines = await waitForJsonLines(() => stdout, 6);
+    const byId = new Map(lines.map((line) => [line.id, line]));
     return {
-      initialized: lines[0],
-      listed: lines[1],
-      called: lines[2],
-      searched: lines[3],
-      createdProject: lines[4],
+      initialized: byId.get(1),
+      listed: byId.get(2),
+      called: byId.get(3),
+      searched: byId.get(4),
+      read: byId.get(5),
+      createdProject: byId.get(6),
     };
   } catch (err) {
     throw new Error(`${err instanceof Error ? err.message : String(err)}\nstderr: ${stderr}`);

--- a/server/library-file-reader.ts
+++ b/server/library-file-reader.ts
@@ -42,6 +42,22 @@ export interface LibraryFileLineRange {
   limit?: number;
 }
 
+/** Parse one optional public read-window bound. HTTP query parameters arrive
+ * as strings while MCP arguments arrive as numbers; both transports must
+ * reject malformed supplied values instead of silently widening to a whole
+ * file read. */
+export function parseLibraryFileLineBound(raw: unknown, name: 'offset' | 'limit'): number | undefined {
+  if (raw === undefined) return undefined;
+  if ((typeof raw !== 'string' && typeof raw !== 'number') || (typeof raw === 'string' && !raw.trim())) {
+    throw routeError(`${name} must be a positive integer`, 400);
+  }
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw routeError(`${name} must be a positive integer`, 400);
+  }
+  return value;
+}
+
 export function isAgentReadableDerivedTextReady(
   sourceAbs: string,
   sourceFormat: 'pdf' | 'docx' | 'audio',
@@ -145,9 +161,9 @@ export function applyLineRange(
   read: LibraryFileRead,
   range?: LibraryFileLineRange,
 ): LibraryFileRead {
+  if (range == null) return read;
   const offset = Math.max(1, Math.trunc(range?.offset ?? 1));
   const limit = range?.limit == null ? null : Math.max(0, Math.trunc(range.limit));
-  if (offset === 1 && limit == null) return read;
 
   const lines = read.content.split('\n');
   const endsWithNewline = lines.length > 1 && lines[lines.length - 1] === '';

--- a/server/library-file-reader.ts
+++ b/server/library-file-reader.ts
@@ -29,6 +29,17 @@ export interface LibraryFileRead {
   sourceFormat?: string;
   readPath?: string;
   derived?: boolean;
+  /** Present only when `content` is a line window rather than the whole file. */
+  partial?: true;
+  totalLines?: number;
+  /** Offset to pass back for the next window; absent once the window ends the file. */
+  nextOffset?: number;
+}
+
+/** A 1-based line window over an already-read file. */
+export interface LibraryFileLineRange {
+  offset?: number;
+  limit?: number;
 }
 
 export function isAgentReadableDerivedTextReady(
@@ -118,7 +129,51 @@ export async function agentContextFile(rawPath: unknown): Promise<AgentContextFi
   });
 }
 
-export async function readLibraryFile(rawPath: unknown): Promise<LibraryFileRead> {
+export async function readLibraryFile(
+  rawPath: unknown,
+  range?: LibraryFileLineRange,
+): Promise<LibraryFileRead> {
+  return applyLineRange(await readWholeLibraryFile(rawPath), range);
+}
+
+/** Narrow an already-read file to a 1-based line window. Reading stays whole-file
+ * and bounded by MAX_TEXT_READ_BYTES; this only bounds what the caller receives.
+ * Because the slice happens after that bounded read, a source above the ceiling
+ * stays unreadable in every window. Serving those would mean streaming the window
+ * off disk, which costs TXT its whole-file UTF-8 validation. */
+export function applyLineRange(
+  read: LibraryFileRead,
+  range?: LibraryFileLineRange,
+): LibraryFileRead {
+  const offset = Math.max(1, Math.trunc(range?.offset ?? 1));
+  const limit = range?.limit == null ? null : Math.max(0, Math.trunc(range.limit));
+  if (offset === 1 && limit == null) return read;
+
+  const lines = read.content.split('\n');
+  const endsWithNewline = lines.length > 1 && lines[lines.length - 1] === '';
+  if (endsWithNewline) lines.pop();
+  const totalLines = lines.length;
+
+  const start = Math.min(offset - 1, totalLines);
+  const end = limit == null ? totalLines : Math.min(start + limit, totalLines);
+  const window = lines.slice(start, end);
+  const content = window.length === 0
+    ? ''
+    : window.join('\n') + (end < totalLines || endsWithNewline ? '\n' : '');
+
+  // A window must never be mistaken for the whole file: without the version
+  // token it cannot be laundered into an optimistic full-file overwrite.
+  const { version: _version, ...rest } = read;
+  return {
+    ...rest,
+    content,
+    partial: true,
+    totalLines,
+    ...(end < totalLines ? { nextOffset: end + 1 } : {}),
+  };
+}
+
+async function readWholeLibraryFile(rawPath: unknown): Promise<LibraryFileRead> {
   const derived = await normalizeDerivedReadPath(rawPath);
   if (derived) return derived;
   const target = await normalizeLibraryFilePath(rawPath);

--- a/server/library-operations/index.ts
+++ b/server/library-operations/index.ts
@@ -13,7 +13,7 @@ import {
   routeError,
 } from '../library-file-access.ts';
 import { listLibraryDirectory } from '../library-directory.ts';
-import { readLibraryFile } from '../library-file-reader.ts';
+import { readLibraryFile, type LibraryFileLineRange } from '../library-file-reader.ts';
 import {
   deleteLibraryFile,
   editLibraryFile,
@@ -80,7 +80,7 @@ export interface LibraryOperations {
    * project; folder-bound and unattributed callers only create + register. */
   createProject(input: { name: unknown; location?: unknown; agentSessionId?: string; windowId?: string }): Promise<unknown>;
   listDirectory(path?: unknown): Promise<unknown>;
-  read(path: unknown): Promise<unknown>;
+  read(path: unknown, range?: LibraryFileLineRange): Promise<unknown>;
   write(input: { path: unknown; content: unknown; baseVersion?: string }): Promise<unknown>;
   edit(input: { path: unknown; oldText: unknown; newText: unknown; replaceAll?: boolean; baseVersion?: string }): Promise<unknown>;
   move(input: { path: unknown; newPath: unknown; cascade?: boolean }): Promise<unknown>;
@@ -272,7 +272,7 @@ export function createLibraryOperations(
     createProject: (input) => asLibraryOperation(() => deps.createProject(input)),
 
     listDirectory: (path) => asLibraryOperation(() => deps.listDirectory(path)),
-    read: (path) => asLibraryOperation(() => deps.read(path)),
+    read: (path, range) => asLibraryOperation(() => deps.read(path, range)),
     write: ({ path, content, baseVersion }) => asLibraryOperation(() => {
       if (typeof content !== 'string') throw routeError('content (string) required', 400);
       return deps.write(path, content, { baseVersion });

--- a/server/routes/library-files.test.ts
+++ b/server/routes/library-files.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import express from 'express';
+import { applyLineRange } from '../library-file-reader.ts';
 import { createLibraryOperations } from '../library-operations/index.ts';
 import { mount } from './library-files.ts';
 
@@ -106,6 +107,84 @@ test('library search validates and forwards file-type filters', async () => {
       error: 'unknown search mode; mode must be one of: semantic, keyword',
       code: 'INVALID_SEARCH_MODE',
     });
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test('read windows return only the requested lines and drop the version token', () => {
+  const whole = {
+    path: '/library/notes/long.md',
+    format: 'md',
+    content: 'one\ntwo\nthree\nfour\n',
+    version: 'v1',
+  };
+
+  assert.deepEqual(applyLineRange(whole, undefined), whole);
+  assert.deepEqual(applyLineRange(whole, { offset: 1 }), whole);
+
+  assert.deepEqual(applyLineRange(whole, { offset: 2, limit: 2 }), {
+    path: whole.path,
+    format: 'md',
+    content: 'two\nthree\n',
+    partial: true,
+    totalLines: 4,
+    nextOffset: 4,
+  });
+
+  // A window that ends the file reports no next offset and keeps the source's
+  // trailing-newline convention.
+  assert.deepEqual(applyLineRange(whole, { offset: 4, limit: 10 }), {
+    path: whole.path,
+    format: 'md',
+    content: 'four\n',
+    partial: true,
+    totalLines: 4,
+  });
+  assert.equal(
+    applyLineRange({ ...whole, content: 'one\ntwo' }, { offset: 2, limit: 5 }).content,
+    'two',
+  );
+
+  // Past the end is an empty window, not an error and not a whole-file read.
+  assert.equal(applyLineRange(whole, { offset: 99, limit: 5 }).content, '');
+});
+
+test('read route forwards a line window and rejects a malformed one', async () => {
+  let readArgs: unknown[] = [];
+  const operations = createLibraryOperations({
+    read: (async (...args: unknown[]) => {
+      readArgs = args;
+      return { path: '/library/notes/long.md', format: 'md', content: 'two\n' };
+    }) as never,
+  });
+  const app = express();
+  app.use(express.json());
+  mount(app, operations);
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', reject);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const url = `http://127.0.0.1:${address.port}/api/library/file`;
+
+  try {
+    const windowed = await fetch(`${url}?path=%2Flibrary%2Fnotes%2Flong.md&offset=2&limit=1`);
+    assert.equal(windowed.status, 200);
+    assert.deepEqual(readArgs[1], { offset: 2, limit: 1 });
+
+    readArgs = [];
+    const whole = await fetch(`${url}?path=%2Flibrary%2Fnotes%2Flong.md`);
+    assert.equal(whole.status, 200);
+    assert.deepEqual(readArgs[1], { offset: undefined, limit: undefined });
+
+    readArgs = [];
+    const bad = await fetch(`${url}?path=%2Flibrary%2Fnotes%2Flong.md&offset=0`);
+    assert.equal(bad.status, 400);
+    assert.match((await bad.json() as { error: string }).error, /offset must be a positive integer/);
+    assert.deepEqual(readArgs, []);
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }

--- a/server/routes/library-files.test.ts
+++ b/server/routes/library-files.test.ts
@@ -121,7 +121,13 @@ test('read windows return only the requested lines and drop the version token', 
   };
 
   assert.deepEqual(applyLineRange(whole, undefined), whole);
-  assert.deepEqual(applyLineRange(whole, { offset: 1 }), whole);
+  assert.deepEqual(applyLineRange(whole, { offset: 1 }), {
+    path: whole.path,
+    format: 'md',
+    content: whole.content,
+    partial: true,
+    totalLines: 4,
+  });
 
   assert.deepEqual(applyLineRange(whole, { offset: 2, limit: 2 }), {
     path: whole.path,
@@ -178,12 +184,17 @@ test('read route forwards a line window and rejects a malformed one', async () =
     readArgs = [];
     const whole = await fetch(`${url}?path=%2Flibrary%2Fnotes%2Flong.md`);
     assert.equal(whole.status, 200);
-    assert.deepEqual(readArgs[1], { offset: undefined, limit: undefined });
+    assert.equal(readArgs[1], undefined);
 
     readArgs = [];
     const bad = await fetch(`${url}?path=%2Flibrary%2Fnotes%2Flong.md&offset=0`);
     assert.equal(bad.status, 400);
     assert.match((await bad.json() as { error: string }).error, /offset must be a positive integer/);
+    assert.deepEqual(readArgs, []);
+
+    const empty = await fetch(`${url}?path=%2Flibrary%2Fnotes%2Flong.md&limit=`);
+    assert.equal(empty.status, 400);
+    assert.match((await empty.json() as { error: string }).error, /limit must be a positive integer/);
     assert.deepEqual(readArgs, []);
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/server/routes/library-files.ts
+++ b/server/routes/library-files.ts
@@ -11,6 +11,7 @@ import { indexer } from '../state.ts';
 import { sendError } from '../http.ts';
 import {
   requireLibraryStatusFolder,
+  routeError,
 } from '../library-file-access.ts';
 import { agentContextFile } from '../library-file-reader.ts';
 import { currentWindowId } from '../folder.ts';
@@ -205,7 +206,9 @@ export function mount(app: express.Express, operations: LibraryOperations = crea
 
   app.get('/api/library/file', async (req, res) => {
     try {
-      res.json(await operations.read(req.query.path));
+      const offset = positiveIntQuery(req.query.offset, 'offset');
+      const limit = positiveIntQuery(req.query.limit, 'limit');
+      res.json(await operations.read(req.query.path, { offset, limit }));
     } catch (err: unknown) {
       sendError(res, err);
     }
@@ -249,4 +252,15 @@ export function mount(app: express.Express, operations: LibraryOperations = crea
       sendError(res, err);
     }
   });
+}
+
+/** Read-window query params are optional, but a malformed one is an error rather
+ * than a silent whole-file read that would flood the caller's context. */
+function positiveIntQuery(raw: unknown, name: string): number | undefined {
+  if (raw == null || raw === '') return undefined;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw routeError(`${name} must be a positive integer`, 400);
+  }
+  return value;
 }

--- a/server/routes/library-files.ts
+++ b/server/routes/library-files.ts
@@ -11,9 +11,8 @@ import { indexer } from '../state.ts';
 import { sendError } from '../http.ts';
 import {
   requireLibraryStatusFolder,
-  routeError,
 } from '../library-file-access.ts';
-import { agentContextFile } from '../library-file-reader.ts';
+import { agentContextFile, parseLibraryFileLineBound } from '../library-file-reader.ts';
 import { currentWindowId } from '../folder.ts';
 import { AGENT_SESSION_ID_HEADER } from '../agent-session-registry.ts';
 import { createLibraryOperations, type LibraryOperations } from '../library-operations/index.ts';
@@ -206,9 +205,12 @@ export function mount(app: express.Express, operations: LibraryOperations = crea
 
   app.get('/api/library/file', async (req, res) => {
     try {
-      const offset = positiveIntQuery(req.query.offset, 'offset');
-      const limit = positiveIntQuery(req.query.limit, 'limit');
-      res.json(await operations.read(req.query.path, { offset, limit }));
+      const offset = parseLibraryFileLineBound(req.query.offset, 'offset');
+      const limit = parseLibraryFileLineBound(req.query.limit, 'limit');
+      res.json(await operations.read(
+        req.query.path,
+        offset == null && limit == null ? undefined : { offset, limit },
+      ));
     } catch (err: unknown) {
       sendError(res, err);
     }
@@ -252,15 +254,4 @@ export function mount(app: express.Express, operations: LibraryOperations = crea
       sendError(res, err);
     }
   });
-}
-
-/** Read-window query params are optional, but a malformed one is an error rather
- * than a silent whole-file read that would flood the caller's context. */
-function positiveIntQuery(raw: unknown, name: string): number | undefined {
-  if (raw == null || raw === '') return undefined;
-  const value = Number(raw);
-  if (!Number.isInteger(value) || value < 1) {
-    throw routeError(`${name} must be a positive integer`, 400);
-  }
-  return value;
 }


### PR DESCRIPTION
## Summary

Closes #209.

`read_file` was all-or-nothing, and its own description asked the caller to do something the tool did not allow: *"One response is limited to 8 MiB; split oversized text before reading it through this tool."* There was no way to split. The only bound was the `8 MiB` admission ceiling shared with indexing, which fails a read outright rather than narrowing it.

The practical cost is context, not memory. A 3 MB prepared transcript is well under the ceiling and still lands in an agent's context as one ~750k-token response, so an agent that wanted twenty lines around a search hit had to take the whole file or nothing.

`read_file` now accepts an optional 1-based `offset`/`limit` line window over every readable family, direct and derived alike. Omitting both is the previous whole-file read byte for byte, with no added response fields.

## What changed

- `applyLineRange` in `server/library-file-reader.ts` is the single slice point. `readLibraryFile` became a thin wrapper over the renamed `readWholeLibraryFile`, so direct source, PDF/DOCX/audio derived text, and derived-path normalization all window through the same code rather than three parallel implementations.
- The window is applied **after** the existing bounded read, so it narrows what a caller receives and never widens what the server admits. The `8 MiB` ceiling, TXT UTF-8 validation, and derived-readiness behavior are untouched, and a source above the ceiling stays unreadable in every window.
- **A window carries no `version`.** `write_file` and `edit_file` accept a `baseVersion` taken from `read_file`. A versioned window would let an agent read lines 200–300, write those hundred lines back as the whole file, and pass a token asserting it had checked — silently destroying the rest. Dropping the token keeps windows outside the optimistic write path entirely.
- A windowed response is self-describing: `partial: true`, `totalLines`, and a `nextOffset` that is absent once the window ends the file.
- `GET /api/library/file` takes `offset`/`limit` and rejects a malformed bound with a `400`, never degrading into a silent whole-file read — the exact failure the window exists to prevent. An offset past the end is an empty window, not an error.
- The `read_file` tool description no longer instructs the caller to split oversized text; it describes the window, the fields it returns, and the ceiling no window can cross.

Line endings and the source's trailing-newline convention round-trip unchanged through a window.

Streaming a window off disk so files above the `8 MiB` ceiling become readable is deliberately out of scope: whole-file UTF-8 validation for TXT is a documented contract that per-window validation would weaken, and files above the ceiling are not indexed, so they never appear in `search_library` results.

## Validation

- [x] `pnpm typecheck`
- [x] Focused tests for the affected behavior — `pnpm test:library-files`, 19/19
- [ ] Renderer build or E2E coverage, when the change affects the UI

Two tests added to `server/routes/library-files.test.ts`: a pure unit test over `applyLineRange` (offsets, limits, a window that ends the file, a file with no trailing newline, an offset past the end, the dropped `version`), and a route test that the bound reaches the read operation, that omitting it still reads whole, and that a malformed bound is a `400` that never calls through.

## UI and visual baselines

- [ ] This PR changes a rendered UI surface or visual state.
- [x] This fork PR allows maintainer edits if a reviewed Linux visual baseline update is needed.
- [x] This PR does not change a visual surface, or existing visual baselines remain valid.

No renderer files are touched.

## Documentation

- [x] Updated the relevant `design-docs/` and `code-review/` contract, when this changes documented behavior or invariants.
- [ ] No documentation update is needed.

`code-review/mcp-access.md` records the window invariant and the reason `version` is omitted. `design-docs/design/documents.md` states at the product level that a read may be a declared window and that a partial read announces itself.
